### PR TITLE
issue #8: no listeners registered warnings

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -282,7 +282,7 @@ PODS:
   - React-jsinspector (0.68.1)
   - React-logger (0.68.1):
     - glog
-  - react-native-keyboard-controller (0.1.0):
+  - react-native-keyboard-controller (1.0.0-alpha.0):
     - React-Core
   - react-native-safe-area-context (4.2.4):
     - RCT-Folly
@@ -583,7 +583,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 4a4bae5671b064a2248a690cf75957669489d08c
   React-jsinspector: 218a2503198ff28a085f8e16622a8d8f507c8019
   React-logger: f79dd3cc0f9b44f5611c6c7862badd891a862cf8
-  react-native-keyboard-controller: ea59466588875b147daf53910d3deb3d628d10e3
+  react-native-keyboard-controller: ec0d3c325c2d3b6fe9c704cdb7b708bbcc3fe7b5
   react-native-safe-area-context: f98b0b16d1546d208fc293b4661e3f81a895afd9
   React-perflogger: 30ab8d6db10e175626069e742eead3ebe8f24fd5
   React-RCTActionSheet: 4b45da334a175b24dabe75f856b98fed3dfd6201

--- a/example/src/screens/Examples/AwareScrollView/index.tsx
+++ b/example/src/screens/Examples/AwareScrollView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { TextInput, LogBox, View, Dimensions } from 'react-native';
+import { TextInput, View, Dimensions } from 'react-native';
 import { KeyboardEvents } from 'react-native-keyboard-controller';
 import Reanimated, {
   useAnimatedRef,
@@ -8,10 +8,8 @@ import Reanimated, {
   useSharedValue,
 } from 'react-native-reanimated';
 
-LogBox.ignoreAllLogs();
-
 function randomColor() {
-  return '#' + Math.floor(Math.random() * 16777215).toString(16);
+  return '#' + Math.random().toString(16).slice(-6);
 }
 
 const screenHeight = Dimensions.get('window').height;

--- a/example/src/screens/Examples/KeyboardAnimation/index.tsx
+++ b/example/src/screens/Examples/KeyboardAnimation/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Animated, TextInput, View } from 'react-native';
 import {
-  KeyboardEvents,
   useKeyboardAnimation,
   useKeyboardAnimationReplica,
 } from 'react-native-keyboard-controller';
@@ -10,14 +9,6 @@ import styles from './styles';
 export default function KeyboardAnimation() {
   const { height, progress } = useKeyboardAnimation();
   const { height: heightReplica } = useKeyboardAnimationReplica();
-
-  React.useEffect(() => {
-    const listener = KeyboardEvents.addListener('keyboardWillShow', (e) => {
-      console.debug(e);
-    });
-
-    return () => listener.remove();
-  }, []);
 
   return (
     <View style={styles.container}>

--- a/ios/KeyboardControllerModule.swift
+++ b/ios/KeyboardControllerModule.swift
@@ -13,6 +13,7 @@ import AVFoundation
 @objc(KeyboardController)
 class KeyboardController: RCTEventEmitter {
   public static var shared: KeyboardController?
+  private var hasListeners = false
     
   override class func requiresMainQueueSetup() -> Bool {
     return false
@@ -34,5 +35,19 @@ class KeyboardController: RCTEventEmitter {
         "KeyboardController::keyboardWillHide",
         "KeyboardController::keyboardDidHide"
     ]
+  }
+    
+  @objc open override func startObserving() {
+    hasListeners = true
+  }
+    
+  @objc open override func stopObserving() {
+    hasListeners = false
+  }
+    
+  @objc open override func sendEvent(withName name: String!, body: Any!) {
+    if (hasListeners) {
+        super.sendEvent(withName: name, body: body)
+    }
   }
 }


### PR DESCRIPTION
As per react-native [docs](https://reactnative.dev/docs/native-modules-ios#sending-events-to-javascript) we shouldn't dispatch events without registered listeners.

Also in example app I removed an unused listener in Keyboard animation and changed function `randomColor` to produce always 6 symbols color (before it could produce 5 symbols color and RN was throwing errors, though I haven't seen them because I ignored all warnings 🤦‍♂️ )

Closes: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/8