### PR TITLE
issue #14: translucent status bar on android

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -5,12 +5,14 @@ import androidx.core.view.*
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
 import com.reactnativekeyboardcontroller.events.KeyboardTransitionEvent
 
 class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : ReactViewManager() {
   private var mReactContext = reactContext
+  private var isStatusBarTranslucent = false
 
   override fun getName() = "KeyboardControllerView"
 
@@ -23,7 +25,7 @@ class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : Rea
           R.id.action_bar_root
         )
       content?.setPadding(
-        0, insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0, 0,
+        0, if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0, 0,
         insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
       )
 
@@ -44,6 +46,11 @@ class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : Rea
     )
 
     return view
+  }
+
+  @ReactProp(name = "statusBarTranslucent")
+  fun setStatusBarTranslucent(view: ReactViewGroup, isStatusBarTranslucent: Boolean) {
+    this.isStatusBarTranslucent = isStatusBarTranslucent
   }
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -98,8 +98,11 @@ type KeyboardProviderProps = {
   children: React.ReactNode;
   /**
    * Set the value to `true`, if you use translucent status bar on Android.
+   * If you already control status bar translucency via `react-native-screens`
+   * or `StatusBar` component from `react-native`, you can ignore it.
    * Defaults to `false`.
    *
+   * @see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/14
    * @platform android
    */
   statusBarTranslucent?: boolean;

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -102,7 +102,7 @@ type KeyboardProviderProps = {
    *
    * @platform android
    */
-  statusBarTranslucent: boolean;
+  statusBarTranslucent?: boolean;
 };
 
 export const KeyboardProvider = ({

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -156,21 +156,23 @@ export const KeyboardProvider = ({
         statusBarTranslucent={statusBarTranslucent}
         style={styles.container}
       >
-        <Animated.View
-          style={[
-            // we are using this small hack, because if the component (where
-            // animated value has been used) is unmounted, then animation will
-            // stop receiving events (seems like it's react-native optimization).
-            // So we need to keep a reference to the animated value, to keep it's
-            // always mounted (keep a reference to an animated value).
-            //
-            // To test why it's needed, try to open screen which consumes Animated.Value
-            // then close it and open it again (for example 'Animated transition').
-            styles.hidden,
-            { transform: [{ translateX: height }, { translateY: progress }] },
-          ]}
-        />
-        {children}
+        <>
+          <Animated.View
+            style={[
+              // we are using this small hack, because if the component (where
+              // animated value has been used) is unmounted, then animation will
+              // stop receiving events (seems like it's react-native optimization).
+              // So we need to keep a reference to the animated value, to keep it's
+              // always mounted (keep a reference to an animated value).
+              //
+              // To test why it's needed, try to open screen which consumes Animated.Value
+              // then close it and open it again (for example 'Animated transition').
+              styles.hidden,
+              { transform: [{ translateX: height }, { translateY: progress }] },
+            ]}
+          />
+          {children}
+        </>
       </KeyboardControllerViewAnimated>
     </KeyboardContext.Provider>
   );

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -94,11 +94,21 @@ export const styles = StyleSheet.create<Styles>({
   },
 });
 
+type KeyboardProviderProps = {
+  children: React.ReactNode;
+  /**
+   * Set the value to `true`, if you use translucent status bar on Android.
+   * Defaults to `false`.
+   *
+   * @platform android
+   */
+  statusBarTranslucent: boolean;
+};
+
 export const KeyboardProvider = ({
   children,
-}: {
-  children: React.ReactNode;
-}) => {
+  statusBarTranslucent,
+}: KeyboardProviderProps) => {
   const progress = useMemo(() => new Animated.Value(0), []);
   const height = useMemo(() => new Animated.Value(0), []);
   const progressSV = useSharedValue(0);
@@ -143,6 +153,7 @@ export const KeyboardProvider = ({
       <KeyboardControllerViewAnimated
         onKeyboardMoveReanimated={handler}
         onKeyboardMove={onKeyboardMove}
+        statusBarTranslucent={statusBarTranslucent}
         style={styles.container}
       >
         <Animated.View

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,12 +1,12 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import {
   requireNativeComponent,
   UIManager,
   Platform,
-  ViewStyle,
   NativeModules,
   NativeEventEmitter,
   NativeSyntheticEvent,
+  ViewProps,
 } from 'react-native';
 
 const LINKING_ERROR =
@@ -30,14 +30,13 @@ export type EventWithName<T> = {
   eventName: string;
 } & T;
 export type KeyboardControllerProps = {
-  style?: ViewStyle;
-  children: React.ReactNode;
   onKeyboardMove: (e: NativeSyntheticEvent<EventWithName<NativeEvent>>) => void;
   // fake prop used to activate reanimated bindings
   onKeyboardMoveReanimated: (
     e: NativeSyntheticEvent<EventWithName<NativeEvent>>
   ) => void;
-};
+  statusBarTranslucent?: boolean;
+} & ViewProps;
 type KeyboardController = {
   // android only
   setDefaultMode: () => void;


### PR DESCRIPTION
Fixes: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/14

This PR adds new prop called `statusBarTranslucent`

The problem was in the fact that in `ApplyWindowInsetsListener` we always add constant paddings. In case of translucent status bar we should apply 0 paddings. Prop `statusBarTranslucent` now control this aspect.