### PR TITLE
[RNKC-044] - autopublishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

Automatic publishing to `npm` registry when release on GitHub occurs.

## Motivation and Context

It's a little bit difficult to perform two actions (publishing to npm and preparing a release on GitHub). So publishing can be automated and in this PR I added this GitHub action.

## Changelog

### CI
- added `publish.yml` file;

## How Has This Been Tested?

Will be tested later in `alpha.4` release.

## Checklist

- [x] CI successfully passed