### PR TITLE
chore: update Podfile.lock file

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -282,7 +282,7 @@ PODS:
   - React-jsinspector (0.68.1)
   - React-logger (0.68.1):
     - glog
-  - react-native-keyboard-controller (1.0.0-alpha.3):
+  - react-native-keyboard-controller (1.0.0-beta.0):
     - React-Core
   - react-native-safe-area-context (4.2.4):
     - RCT-Folly
@@ -583,7 +583,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 4a4bae5671b064a2248a690cf75957669489d08c
   React-jsinspector: 218a2503198ff28a085f8e16622a8d8f507c8019
   React-logger: f79dd3cc0f9b44f5611c6c7862badd891a862cf8
-  react-native-keyboard-controller: 1a9cde94db53a6c6a84e419023cbe536a6fa858d
+  react-native-keyboard-controller: 21030d0430a71dfc22d6cafb0199d5aec6a05749
   react-native-safe-area-context: f98b0b16d1546d208fc293b4661e3f81a895afd9
   React-perflogger: 30ab8d6db10e175626069e742eead3ebe8f24fd5
   React-RCTActionSheet: 4b45da334a175b24dabe75f856b98fed3dfd6201


### PR DESCRIPTION
## Description

Synchronize `Podfile.lock` after changing library version.

## Motivation and Context

It should happen in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/34 but I forgot to update it 🤦‍♂️ 

## Changelog

### iOS
- update Podfile.lock file in example app;

## How Has This Been Tested?

Tested in example app on iOS simulator.

## Checklist

- [x] CI successfully passed