### PR TITLE
chore: add stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,10 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: true


### PR DESCRIPTION
## Description

Added stale bot to automatically close abandoned issues. 

## Motivation and Context

It requires a lot of concentration to manage all the issues that will arise. To reduce time and simplify the process I add such bot (it will close stale issues automatically).

## Changelog

### CI
- added stale bot

## How Has This Been Tested?

There is no way to test it right now. We will know whether it works only after 60 days 😓 

## Screenshots (if appropriate):

Did as per guide:

<img width="790" alt="image" src="https://user-images.githubusercontent.com/22820318/183958314-6633cb1d-d6a6-4855-a5b6-ad18d4219d90.png">

## Checklist

- [x] CI successfully passed