### PR TITLE
chore: use symlink for local dependency linking

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
     "react": "18.0.0",
     "react-native": "0.69.4",
     "react-native-gesture-handler": "^2.5.0",
-    "react-native-keyboard-controller": "../",
+    "react-native-keyboard-controller": "link:../",
     "react-native-reanimated": "2.9.1",
     "react-native-safe-area-context": "^4.3.1",
     "react-native-screens": "^3.15.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3622,8 +3622,9 @@ react-native-gradle-plugin@^0.0.7:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz#96602f909745239deab7b589443f14fce5da2056"
   integrity sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==
 
-react-native-keyboard-controller@../:
-  version "1.0.1"
+"react-native-keyboard-controller@link:..":
+  version "0.0.0"
+  uid ""
 
 react-native-reanimated@2.9.1:
   version "2.9.1"


### PR DESCRIPTION
## Description

Use `link:../` instead of `../`.

## Motivation and Context

Using `../` instead of `link:../` can cause circular dependencies and because of that `node_modules` will take a lot of space on the disk.

## Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS
- use symlink for local dependency linking

## How Has This Been Tested?

Tested manually.

## Screenshots (if appropriate):

|Before|After|
|------|-----|
|![tg_image_1095628465](https://user-images.githubusercontent.com/22820318/184607116-0e24bc47-05f2-44c6-90e2-2d3ce54c206a.jpeg)|<img width="742" alt="image" src="https://user-images.githubusercontent.com/22820318/184607301-0ce96afd-021b-4dbe-bdb8-f85a82366e09.png">|

## Checklist

- [x] CI successfully passed