### PR TITLE
[RNKC-054] - detect keyboard size changes

### DIFF
--- a/FabricExample/src/screens/Examples/Events/index.tsx
+++ b/FabricExample/src/screens/Examples/Events/index.tsx
@@ -21,11 +21,11 @@ function EventsListener() {
         text2: `📲 Height: ${e.height}`,
       });
     });
-    const shown = KeyboardEvents.addListener('keyboardDidShow', () => {
+    const shown = KeyboardEvents.addListener('keyboardDidShow', (e) => {
       Toast.show({
         type: 'success',
         text1: '⌨️ Keyboard is shown',
-        text2: '👋',
+        text2: `👋 Height: ${e.height}`,
       });
     });
     const hide = KeyboardEvents.addListener('keyboardWillHide', (e) => {
@@ -35,11 +35,11 @@ function EventsListener() {
         text2: `📲 Height: ${e.height}`,
       });
     });
-    const hid = KeyboardEvents.addListener('keyboardDidHide', () => {
+    const hid = KeyboardEvents.addListener('keyboardDidHide', (e) => {
       Toast.show({
         type: 'error',
         text1: '⌨️ Keyboard is hidden',
-        text2: '🤐',
+        text2: `🤐 Height: ${e.height}`,
       });
     });
 

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
@@ -25,14 +25,14 @@ fun toDp(px: Float, context: Context?): Int {
   return (px / context.resources.displayMetrics.density).toInt()
 }
 
-class TranslateDeferringInsetsAnimationCallback(
+class KeyboardAnimationCallback(
   val view: ReactViewGroup,
   val persistentInsetTypes: Int,
   val deferredInsetTypes: Int,
   dispatchMode: Int = DISPATCH_MODE_STOP,
   val context: ReactApplicationContext?
 ) : WindowInsetsAnimationCompat.Callback(dispatchMode), OnApplyWindowInsetsListener {
-  private val TAG = TranslateDeferringInsetsAnimationCallback::class.qualifiedName
+  private val TAG = KeyboardAnimationCallback::class.qualifiedName
   private var persistentKeyboardHeight = 0
   private var isKeyboardVisible = false
 

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
@@ -30,7 +30,8 @@ class KeyboardAnimationCallback(
   val persistentInsetTypes: Int,
   val deferredInsetTypes: Int,
   dispatchMode: Int = DISPATCH_MODE_STOP,
-  val context: ReactApplicationContext?
+  val context: ReactApplicationContext?,
+  val onApplyWindowInsetsListener: OnApplyWindowInsetsListener
 ) : WindowInsetsAnimationCompat.Callback(dispatchMode), OnApplyWindowInsetsListener {
   private val TAG = KeyboardAnimationCallback::class.qualifiedName
   private var persistentKeyboardHeight = 0
@@ -84,7 +85,7 @@ class KeyboardAnimationCallback(
       this.persistentKeyboardHeight = keyboardHeight
     }
 
-    return insets
+    return onApplyWindowInsetsListener.onApplyWindowInsets(v, insets)
   }
 
   override fun onStart(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
@@ -50,7 +50,7 @@ class TranslateDeferringInsetsAnimationCallback(
   // TODO: calculate animated progress (should it be >1?)
   // TODO: (x) remove android documentation
   // TODO: (x) rename class?
-  override fun onApplyWindowInsets(v: View?, insets: WindowInsetsCompat?): WindowInsetsCompat {
+  override fun onApplyWindowInsets(v: View?, insets: WindowInsetsCompat): WindowInsetsCompat {
     // sometimes this method is called after `onStart` (keyboard appears),
     // sometimes it's called before `onStart` (keyboard hides)
     // since `onStart` updates `isKeyboardVisible` in order to avoid
@@ -72,7 +72,7 @@ class TranslateDeferringInsetsAnimationCallback(
       this.persistentKeyboardHeight = keyboardHeight
     }
 
-    return WindowInsetsCompat.CONSUMED
+    return insets
   }
 
   override fun onStart(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -29,9 +29,6 @@ class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : Rea
       return view
     }
 
-    val window = activity.window
-    val decorView = window.decorView
-
     val callback = KeyboardAnimationCallback(
       view = view,
       persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
@@ -39,22 +36,22 @@ class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : Rea
       // We explicitly allow dispatch to continue down to binding.messageHolder's
       // child views, so that step 2.5 below receives the call
       dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
-      context = mReactContext
-    )
-    ViewCompat.setWindowInsetsAnimationCallback(decorView, callback)
-    ViewCompat.setOnApplyWindowInsetsListener(decorView, callback)
-    ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
-      val content =
-        mReactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
-          R.id.action_bar_root
+      context = mReactContext,
+      onApplyWindowInsetsListener = { v, insets ->
+        val content =
+          mReactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
+            R.id.action_bar_root
+          )
+        content?.setPadding(
+          0, if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0, 0,
+          insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
         )
-      content?.setPadding(
-        0, if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0, 0,
-        insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
-      )
 
-      insets
-    }
+        insets
+      }
+    )
+    ViewCompat.setWindowInsetsAnimationCallback(view, callback)
+    ViewCompat.setOnApplyWindowInsetsListener(view, callback)
 
     return view
   }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -32,6 +32,17 @@ class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : Rea
     val window = activity.window
     val decorView = window.decorView
 
+    val callback = TranslateDeferringInsetsAnimationCallback(
+      view = view,
+      persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
+      deferredInsetTypes = WindowInsetsCompat.Type.ime(),
+      // We explicitly allow dispatch to continue down to binding.messageHolder's
+      // child views, so that step 2.5 below receives the call
+      dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
+      context = mReactContext
+    )
+    ViewCompat.setWindowInsetsAnimationCallback(decorView, callback)
+    ViewCompat.setOnApplyWindowInsetsListener(view, callback)
     ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
       val content =
         mReactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
@@ -44,18 +55,6 @@ class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : Rea
 
       insets
     }
-
-    val callback = TranslateDeferringInsetsAnimationCallback(
-      view = view,
-      persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
-      deferredInsetTypes = WindowInsetsCompat.Type.ime(),
-      // We explicitly allow dispatch to continue down to binding.messageHolder's
-      // child views, so that step 2.5 below receives the call
-      dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
-      context = mReactContext
-    )
-    ViewCompat.setWindowInsetsAnimationCallback(decorView, callback)
-    ViewCompat.setOnApplyWindowInsetsListener(view, callback)
 
     return view
   }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -32,7 +32,7 @@ class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : Rea
     val window = activity.window
     val decorView = window.decorView
 
-    val callback = TranslateDeferringInsetsAnimationCallback(
+    val callback = KeyboardAnimationCallback(
       view = view,
       persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
       deferredInsetTypes = WindowInsetsCompat.Type.ime(),

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -42,7 +42,7 @@ class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : Rea
       context = mReactContext
     )
     ViewCompat.setWindowInsetsAnimationCallback(decorView, callback)
-    ViewCompat.setOnApplyWindowInsetsListener(view, callback)
+    ViewCompat.setOnApplyWindowInsetsListener(decorView, callback)
     ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
       val content =
         mReactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -45,18 +45,17 @@ class KeyboardControllerViewManager(reactContext: ReactApplicationContext) : Rea
       insets
     }
 
-    ViewCompat.setWindowInsetsAnimationCallback(
-      decorView,
-      TranslateDeferringInsetsAnimationCallback(
-        view = view,
-        persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
-        deferredInsetTypes = WindowInsetsCompat.Type.ime(),
-        // We explicitly allow dispatch to continue down to binding.messageHolder's
-        // child views, so that step 2.5 below receives the call
-        dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
-        context = mReactContext
-      )
+    val callback = TranslateDeferringInsetsAnimationCallback(
+      view = view,
+      persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
+      deferredInsetTypes = WindowInsetsCompat.Type.ime(),
+      // We explicitly allow dispatch to continue down to binding.messageHolder's
+      // child views, so that step 2.5 below receives the call
+      dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
+      context = mReactContext
     )
+    ViewCompat.setWindowInsetsAnimationCallback(decorView, callback)
+    ViewCompat.setOnApplyWindowInsetsListener(view, callback)
 
     return view
   }

--- a/example/src/screens/Examples/Events/index.tsx
+++ b/example/src/screens/Examples/Events/index.tsx
@@ -21,11 +21,11 @@ function EventsListener() {
         text2: `📲 Height: ${e.height}`,
       });
     });
-    const shown = KeyboardEvents.addListener('keyboardDidShow', () => {
+    const shown = KeyboardEvents.addListener('keyboardDidShow', (e) => {
       Toast.show({
         type: 'success',
         text1: '⌨️ Keyboard is shown',
-        text2: '👋',
+        text2: `👋 Height: ${e.height}`,
       });
     });
     const hide = KeyboardEvents.addListener('keyboardWillHide', (e) => {
@@ -35,11 +35,11 @@ function EventsListener() {
         text2: `📲 Height: ${e.height}`,
       });
     });
-    const hid = KeyboardEvents.addListener('keyboardDidHide', () => {
+    const hid = KeyboardEvents.addListener('keyboardDidHide', (e) => {
       Toast.show({
         type: 'error',
         text1: '⌨️ Keyboard is hidden',
-        text2: '🤐',
+        text2: `🤐 Height: ${e.height}`,
       });
     });
 


### PR DESCRIPTION
## Description

Added `onApplyWindowInsets` into `WindowInsetsAnimationCompat.Callback` to detect keyboard size changes.

## Motivation and Context

It seems like it's only one option to detect such changes. For me it's a little bit strange, that `onProgress`/`onEnd` callback is not called and we need to write additional code to track such cases.

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/54

## Changelog

### JS
- changed `Events` example - show `height` in all events;

### Android
- fixed a bug with missing `height` in all `keyboardDid*` events;
- detect keyboard size changes;
- renamed class that implements `WindowInsetsAnimationCompat.Callback` to `KeyboardAnimationCallback`;

## How Has This Been Tested?

Tested manually on:
- Xiaomi Redmi Note 5 Pro (Android 9)
- Pixel 3 (Android 12)

## Screenshots (if appropriate):

|Before|After|
|-------|----|
|<img width="343" alt="image" src="https://user-images.githubusercontent.com/22820318/185736963-4ccc243a-68c0-4709-aa08-0c4e7e7dfd23.png">|<img width="343" alt="image" src="https://user-images.githubusercontent.com/22820318/185736918-441b5371-1bed-417e-aeb9-cd697829a209.png">|

## Checklist

- [x] CI successfully passed