### PR TITLE
[RNKC-056] - move implementation from View to separate file

### DIFF
--- a/ios/KeyboardController.xcodeproj/project.pbxproj
+++ b/ios/KeyboardController.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		F359D34D28133BE1000B6AFE /* KeyboardControllerModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F359D34C28133BE1000B6AFE /* KeyboardControllerModule.swift */; };
 		F359D34F28133C26000B6AFE /* KeyboardControllerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = F359D34E28133C26000B6AFE /* KeyboardControllerModule.m */; };
+		F3626A0728B3FE760021B2D9 /* KeyboardMovementObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3626A0628B3FE760021B2D9 /* KeyboardMovementObserver.swift */; };
 		F3FF0915281851CC006831B1 /* KeyboardMoveEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3FF0914281851CC006831B1 /* KeyboardMoveEvent.swift */; };
 		F4FF95D7245B92E800C19C63 /* KeyboardControllerViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /* KeyboardControllerViewManager.swift */; };
 /* End PBXBuildFile section */
@@ -31,6 +32,7 @@
 		F359D34C28133BE1000B6AFE /* KeyboardControllerModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardControllerModule.swift; sourceTree = "<group>"; };
 		F359D34E28133C26000B6AFE /* KeyboardControllerModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KeyboardControllerModule.m; sourceTree = "<group>"; };
 		F359D35028133C6F000B6AFE /* KeyboardControllerModule-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "KeyboardControllerModule-Header.h"; sourceTree = "<group>"; };
+		F3626A0628B3FE760021B2D9 /* KeyboardMovementObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMovementObserver.swift; sourceTree = "<group>"; };
 		F3FF0914281851CC006831B1 /* KeyboardMoveEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMoveEvent.swift; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* KeyboardController-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "KeyboardController-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* KeyboardControllerViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardControllerViewManager.swift; sourceTree = "<group>"; };
@@ -58,6 +60,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				F3626A0628B3FE760021B2D9 /* KeyboardMovementObserver.swift */,
 				F3FF0914281851CC006831B1 /* KeyboardMoveEvent.swift */,
 				F359D35028133C6F000B6AFE /* KeyboardControllerModule-Header.h */,
 				F359D34E28133C26000B6AFE /* KeyboardControllerModule.m */,
@@ -127,6 +130,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F3FF0915281851CC006831B1 /* KeyboardMoveEvent.swift in Sources */,
+				F3626A0728B3FE760021B2D9 /* KeyboardMovementObserver.swift in Sources */,
 				F359D34F28133C26000B6AFE /* KeyboardControllerModule.m in Sources */,
 				F359D34D28133BE1000B6AFE /* KeyboardControllerModule.swift in Sources */,
 				F4FF95D7245B92E800C19C63 /* KeyboardControllerViewManager.swift in Sources */,

--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -50,7 +50,6 @@ public class KeyboardMovementObserver: NSObject {
     NotificationCenter.default.removeObserver(self)
   }
 
-  ///
   @objc func keyboardWillAppear(_ notification: Notification) {
     if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
       let keyboardHeight = keyboardFrame.cgRectValue.size.height

--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -1,0 +1,91 @@
+//
+//  KeyboardObserver.swift
+//  KeyboardController
+//
+//  Created by Kiryl Ziusko on 2.08.22.
+//  Copyright © 2022 Facebook. All rights reserved.
+//
+
+import Foundation
+
+@objc(KeyboardMovementObserver)
+public class KeyboardMovementObserver: NSObject {
+  var onEvent: (NSNumber, NSNumber) -> Void
+  var onNotify: (String, Any) -> Void
+
+  @objc public init(handler: @escaping (NSNumber, NSNumber) -> Void, onNotify: @escaping (String, Any) -> Void) {
+    onEvent = handler
+    self.onNotify = onNotify
+  }
+
+  @objc public func mount() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(keyboardWillDisappear),
+      name: UIResponder.keyboardWillHideNotification,
+      object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(keyboardWillAppear),
+      name: UIResponder.keyboardWillShowNotification,
+      object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(keyboardDidAppear),
+      name: UIResponder.keyboardDidShowNotification,
+      object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(keyboardDidDisappear),
+      name: UIResponder.keyboardDidHideNotification,
+      object: nil
+    )
+  }
+
+  @objc public func unmount() {
+    // swiftlint:disable notification_center_detachment
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  ///
+  @objc func keyboardWillAppear(_ notification: Notification) {
+    if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+      let keyboardHeight = keyboardFrame.cgRectValue.size.height
+
+      var data = [AnyHashable: Any]()
+      data["height"] = keyboardHeight
+
+      onEvent(Float(-keyboardHeight) as NSNumber, 1)
+      onNotify("KeyboardController::keyboardWillShow", data)
+    }
+  }
+
+  @objc func keyboardWillDisappear() {
+    var data = [AnyHashable: Any]()
+    data["height"] = 0
+
+    onEvent(0, 0)
+    onNotify("KeyboardController::keyboardWillHide", data)
+  }
+
+  @objc func keyboardDidAppear(_ notification: Notification) {
+    if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+      let keyboardHeight = keyboardFrame.cgRectValue.size.height
+
+      var data = [AnyHashable: Any]()
+      data["height"] = keyboardHeight
+
+      onNotify("KeyboardController::keyboardDidShow", data)
+    }
+  }
+
+  @objc func keyboardDidDisappear() {
+    var data = [AnyHashable: Any]()
+    data["height"] = 0
+
+    onNotify("KeyboardController::keyboardDidHide", data)
+  }
+}

--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -1,5 +1,5 @@
 //
-//  KeyboardObserver.swift
+//  KeyboardMovementObserver.swift
 //  KeyboardController
 //
 //  Created by Kiryl Ziusko on 2.08.22.


### PR DESCRIPTION
## Description

Moved tracker implementation into own file.

## Motivation and Context

It will be useful when we will reuse logic (when Fabric & Paper will be supported at the same time).

## Changelog

### iOS
- added new `KeyboardMovementObserver` file;
- moved all tracking-related functionality into new file;
- simplified `KeyboardControllerViewManager` implementation;

## How Has This Been Tested?

Tested manually on iOS simulator using example app.

## Checklist

- [x] CI successfully passed