### PR TITLE
[RNKC-069] - updated chat example

### DIFF
--- a/FabricExample/src/screens/Examples/ReanimatedChat/index.tsx
+++ b/FabricExample/src/screens/Examples/ReanimatedChat/index.tsx
@@ -1,10 +1,7 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { TextInput, View } from 'react-native';
 import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
-import Reanimated, {
-  useAnimatedRef,
-  useAnimatedStyle,
-} from 'react-native-reanimated';
+import Reanimated, { useAnimatedStyle } from 'react-native-reanimated';
 import Message from '../../../components/Message';
 import { history } from '../../../components/Message/data';
 import styles from './styles';
@@ -12,16 +9,11 @@ import styles from './styles';
 const AnimatedTextInput = Reanimated.createAnimatedComponent(TextInput);
 
 function ReanimatedChat() {
-  const scrollView = useAnimatedRef<Reanimated.ScrollView>();
   const { height } = useReanimatedKeyboardAnimation();
-
-  const scrollToBottom = useCallback(() => {
-    scrollView.current?.scrollToEnd({ animated: false });
-  }, []);
 
   const scrollViewStyle = useAnimatedStyle(
     () => ({
-      transform: [{ translateY: height.value }],
+      transform: [{ translateY: height.value }, ...styles.inverted.transform],
     }),
     []
   );
@@ -29,7 +21,7 @@ function ReanimatedChat() {
     () => ({
       height: 50,
       width: '100%',
-      backgroundColor: '#ECECEC',
+      backgroundColor: '#BCBCBC',
       transform: [{ translateY: height.value }],
     }),
     []
@@ -44,15 +36,15 @@ function ReanimatedChat() {
   return (
     <View style={styles.container}>
       <Reanimated.ScrollView
-        ref={scrollView}
-        onContentSizeChange={scrollToBottom}
         showsVerticalScrollIndicator={false}
         style={scrollViewStyle}
       >
-        <Reanimated.View style={fakeView} />
-        {history.map((message, index) => (
-          <Message key={index} {...message} />
-        ))}
+        <View style={styles.inverted}>
+          <Reanimated.View style={fakeView} />
+          {history.map((message, index) => (
+            <Message key={index} {...message} />
+          ))}
+        </View>
       </Reanimated.ScrollView>
       <AnimatedTextInput style={textInputStyle} />
     </View>

--- a/FabricExample/src/screens/Examples/ReanimatedChat/styles.ts
+++ b/FabricExample/src/screens/Examples/ReanimatedChat/styles.ts
@@ -1,5 +1,15 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  container: { justifyContent: 'flex-end', flex: 1 },
+  container: {
+    justifyContent: 'flex-end',
+    flex: 1,
+  },
+  inverted: {
+    transform: [
+      {
+        scaleY: -1,
+      },
+    ],
+  },
 });

--- a/example/src/screens/Examples/ReanimatedChat/index.tsx
+++ b/example/src/screens/Examples/ReanimatedChat/index.tsx
@@ -1,10 +1,7 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { TextInput, View } from 'react-native';
 import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
-import Reanimated, {
-  useAnimatedRef,
-  useAnimatedStyle,
-} from 'react-native-reanimated';
+import Reanimated, { useAnimatedStyle } from 'react-native-reanimated';
 import Message from '../../../components/Message';
 import { history } from '../../../components/Message/data';
 import styles from './styles';
@@ -12,16 +9,11 @@ import styles from './styles';
 const AnimatedTextInput = Reanimated.createAnimatedComponent(TextInput);
 
 function ReanimatedChat() {
-  const scrollView = useAnimatedRef<Reanimated.ScrollView>();
   const { height } = useReanimatedKeyboardAnimation();
-
-  const scrollToBottom = useCallback(() => {
-    scrollView.current?.scrollToEnd({ animated: false });
-  }, []);
 
   const scrollViewStyle = useAnimatedStyle(
     () => ({
-      transform: [{ translateY: height.value }],
+      transform: [{ translateY: height.value }, ...styles.inverted.transform],
     }),
     []
   );
@@ -29,7 +21,7 @@ function ReanimatedChat() {
     () => ({
       height: 50,
       width: '100%',
-      backgroundColor: '#ECECEC',
+      backgroundColor: '#BCBCBC',
       transform: [{ translateY: height.value }],
     }),
     []
@@ -44,15 +36,15 @@ function ReanimatedChat() {
   return (
     <View style={styles.container}>
       <Reanimated.ScrollView
-        ref={scrollView}
-        onContentSizeChange={scrollToBottom}
         showsVerticalScrollIndicator={false}
         style={scrollViewStyle}
       >
-        <Reanimated.View style={fakeView} />
-        {history.map((message, index) => (
-          <Message key={index} {...message} />
-        ))}
+        <View style={styles.inverted}>
+          <Reanimated.View style={fakeView} />
+          {history.map((message, index) => (
+            <Message key={index} {...message} />
+          ))}
+        </View>
       </Reanimated.ScrollView>
       <AnimatedTextInput style={textInputStyle} />
     </View>

--- a/example/src/screens/Examples/ReanimatedChat/styles.ts
+++ b/example/src/screens/Examples/ReanimatedChat/styles.ts
@@ -1,5 +1,15 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  container: { justifyContent: 'flex-end', flex: 1 },
+  container: {
+    justifyContent: 'flex-end',
+    flex: 1,
+  },
+  inverted: {
+    transform: [
+      {
+        scaleY: -1,
+      },
+    ],
+  },
 });


### PR DESCRIPTION
## 📜 Description

Slightly better version of chat example.

## 💡 Motivation and Context

This PR brings a new (common) approach for chat-like ScrollViews. Instead of scrolling on mount we are applying double `scaleY: -1` and thus scroll view will show its content from the end.

## 📢 Changelog

### JS
- no overlapping effect on Android;
- no content position changes on iOS (fabric only);
- no scroll on mount;
- changed color of text input for better UI;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 3 (API 32, emulator) and iPhone 11 Pro (15.5, simulator) both architectures (paper + fabric).

## 📸 Screenshots (if appropriate):

|old|new|
|---|----|
|<video src="https://user-images.githubusercontent.com/22820318/193419301-c0a377ca-ba1e-49a3-9f65-c89384d49d6d.mov">|<video src="https://user-images.githubusercontent.com/22820318/193419328-fe76bd8d-3c1a-4c14-b709-972ced8f6a46.mov">|

## 📝 Checklist

- [x] CI successfully passed