### PR TITLE
[RNKC-071] -  convert ReactPackage to a backward compatible TurboReactPackage (android)

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -980,7 +980,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 53bd208e5c27939c6e6365528393445a596a9a2b
   React-jsinspector: 26c42646ab0bb69e29e837e23754fe7121eeaf94
   React-logger: 1bfd109a0ffa4c0989bbfac0c2d8c4abe4637faa
-  react-native-keyboard-controller: 8e27150b8c2e378215ca5ddecd76055539da56a6
+  react-native-keyboard-controller: ddd6e300abf2771bcdcbfd67187ea913ed48946e
   react-native-safe-area-context: 2f75b317784a1a8e224562941e50ecbc932d2097
   React-perflogger: 6009895616a455781293950bbd63d53cfc7ffbc5
   React-RCTActionSheet: 5e90aa5712af18bfc86c2c6d97d4dbe0e5451c1d

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
@@ -1,13 +1,54 @@
 package com.reactnativekeyboardcontroller
 
-import com.facebook.react.ReactPackage
+import androidx.annotation.Nullable
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 
-class KeyboardControllerPackage : ReactPackage {
-  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-    return listOf(KeyboardControllerModule(reactContext), StatusBarManagerCompatModule(reactContext))
+class KeyboardControllerPackage : TurboReactPackage() {
+  @Nullable
+  override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
+    return when (name) {
+      KeyboardControllerModuleImpl.NAME -> {
+        KeyboardControllerModule(reactContext)
+      }
+      StatusBarManagerCompatImpl.NAME -> {
+        StatusBarManagerCompatModule(reactContext)
+      }
+      else -> {
+        null
+      }
+    }
+  }
+
+  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
+    return ReactModuleInfoProvider {
+      val moduleInfos: MutableMap<String, ReactModuleInfo> = HashMap()
+      val isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+
+      moduleInfos[KeyboardControllerModuleImpl.NAME] = ReactModuleInfo(
+        KeyboardControllerModuleImpl.NAME,
+        KeyboardControllerModuleImpl.NAME,
+        false, // canOverrideExistingModule
+        false, // needsEagerInit
+        true, // hasConstants
+        false, // isCxxModule
+        isTurboModule // isTurboModule
+      )
+      moduleInfos[StatusBarManagerCompatImpl.NAME] = ReactModuleInfo(
+        StatusBarManagerCompatImpl.NAME,
+        StatusBarManagerCompatImpl.NAME,
+        false, // canOverrideExistingModule
+        false, // needsEagerInit
+        true, // hasConstants
+        false, // isCxxModule
+        isTurboModule // isTurboModule
+      )
+      moduleInfos
+    }
   }
 
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {

--- a/react-native-keyboard-controller.podspec
+++ b/react-native-keyboard-controller.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
     s.pod_target_xcconfig    = {
       "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
       "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
 

--- a/src/architecture.ts
+++ b/src/architecture.ts
@@ -1,4 +1,0 @@
-// @ts-expect-error because `__turboModuleProxy` has any type (maybe think about own types declaration)
-export const isTurboModuleEnabled = global.__turboModuleProxy != null;
-// @ts-expect-error because `nativeFabricUIManager` has any type (maybe think about own types declaration)
-export const isFabricEnabled = global.nativeFabricUIManager != null;

--- a/src/monkey-patch.ts
+++ b/src/monkey-patch.ts
@@ -1,14 +1,11 @@
-import { NativeModules, Platform } from 'react-native';
+import { Platform } from 'react-native';
 // @ts-expect-error because there is no corresponding type definition
 import * as NativeAndroidManager from 'react-native/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid';
 
-import { isTurboModuleEnabled } from './architecture';
-
 const getConstants = NativeAndroidManager.default.getConstants;
 
-const RCTStatusBarManagerCompat = isTurboModuleEnabled
-  ? require('./specs/NativeStatusBarManagerCompat').default
-  : NativeModules.StatusBarManagerCompat;
+const RCTStatusBarManagerCompat =
+  require('./specs/NativeStatusBarManagerCompat').default;
 
 // On Android < 11 RN uses legacy API which breaks EdgeToEdge mode in RN, so
 // in order to use library on all available platforms we have to monkey patch

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,21 +1,9 @@
 import { useEffect } from 'react';
 import {
-  requireNativeComponent,
-  UIManager,
-  Platform,
-  NativeModules,
   NativeEventEmitter,
   NativeSyntheticEvent,
   ViewProps,
 } from 'react-native';
-
-import { isFabricEnabled, isTurboModuleEnabled } from './architecture';
-
-const LINKING_ERROR =
-  `The package 'react-native-keyboard-controller' doesn't seem to be linked. Make sure: \n\n` +
-  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
-  '- You rebuilt the app after installing the package\n' +
-  '- You are not using Expo managed workflow\n';
 
 export enum AndroidSoftInputModes {
   SOFT_INPUT_ADJUST_NOTHING = 48,
@@ -45,11 +33,8 @@ type KeyboardController = {
   setInputMode: (mode: AndroidSoftInputModes) => void;
 };
 
-const ComponentName = 'KeyboardControllerView';
-
-const RCTKeyboardController = isTurboModuleEnabled
-  ? require('./specs/NativeKeyboardController').default
-  : NativeModules.KeyboardController;
+const RCTKeyboardController =
+  require('./specs/NativeKeyboardController').default;
 export const KeyboardController = RCTKeyboardController as KeyboardController;
 
 const eventEmitter = new NativeEventEmitter(RCTKeyboardController);
@@ -67,13 +52,8 @@ export const KeyboardEvents = {
     cb: (e: KeyboardEvent) => void
   ) => eventEmitter.addListener('KeyboardController::' + name, cb),
 };
-export const KeyboardControllerView = isFabricEnabled
-  ? require('./specs/KeyboardControllerViewNativeComponent').default
-  : UIManager.getViewManagerConfig(ComponentName) != null
-  ? requireNativeComponent<KeyboardControllerProps>(ComponentName)
-  : () => {
-      throw new Error(LINKING_ERROR);
-    };
+export const KeyboardControllerView =
+  require('./specs/KeyboardControllerViewNativeComponent').default;
 
 export const useResizeMode = () => {
   useEffect(() => {

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,9 +1,16 @@
 import { useEffect } from 'react';
 import {
+  Platform,
   NativeEventEmitter,
   NativeSyntheticEvent,
   ViewProps,
 } from 'react-native';
+
+const LINKING_ERROR =
+  `The package 'react-native-keyboard-controller' doesn't seem to be linked. Make sure: \n\n` +
+  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo Go\n';
 
 export enum AndroidSoftInputModes {
   SOFT_INPUT_ADJUST_NOTHING = 48,
@@ -31,13 +38,27 @@ type KeyboardController = {
   // android only
   setDefaultMode: () => void;
   setInputMode: (mode: AndroidSoftInputModes) => void;
+  // native event module stuff
+  addListener: (eventName: string) => void;
+  removeListeners: (count: number) => void;
 };
 
 const RCTKeyboardController =
   require('./specs/NativeKeyboardController').default;
-export const KeyboardController = RCTKeyboardController as KeyboardController;
+export const KeyboardController = (
+  RCTKeyboardController
+    ? RCTKeyboardController
+    : new Proxy(
+        {},
+        {
+          get() {
+            throw new Error(LINKING_ERROR);
+          },
+        }
+      )
+) as KeyboardController;
 
-const eventEmitter = new NativeEventEmitter(RCTKeyboardController);
+const eventEmitter = new NativeEventEmitter(KeyboardController);
 type KeyboardControllerEvents =
   | 'keyboardWillShow'
   | 'keyboardDidShow'


### PR DESCRIPTION
## 📜 Description

Use backward compatible `TurboReactPackage` instead of `ReactPackage`.

## 💡 Motivation and Context

According to a new RN documentation it's the way how we should declare packages now.

## 📢 Changelog

### JS
- removed `architecture.ts` file since it's not used anymore;
- use `specs` as a single source of truth;

### iOS
- added `OTHER_CPLUSPLUSFLAGS` in `Podfile` for `fabric` arch;

### Android
- use `TurboReactPackage`;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 3 (API 32).

## 📝 Checklist

- [ ] CI successfully passed