### PR TITLE
[RNKC-061] - introduce low-level `useKeyboardHandler` hook

### DIFF
--- a/FabricExample/src/constants/screenNames.ts
+++ b/FabricExample/src/constants/screenNames.ts
@@ -6,4 +6,5 @@ export enum ScreenNames {
   STATUS_BAR = 'STATUS_BAR',
   EXAMPLES_STACK = 'EXAMPLES_STACK',
   EXAMPLES = 'EXAMPLES',
+  NON_UI_PROPS = 'NON_UI_PROPS',
 }

--- a/FabricExample/src/navigation/ExamplesStack/index.tsx
+++ b/FabricExample/src/navigation/ExamplesStack/index.tsx
@@ -8,6 +8,7 @@ import ReanimatedChat from '../../screens/Examples/ReanimatedChat';
 import Events from '../../screens/Examples/Events';
 import AwareScrollView from '../../screens/Examples/AwareScrollView';
 import StatusBar from '../../screens/Examples/StatusBar';
+import NonUIProps from '../../screens/Examples/NonUIProps';
 
 type ExamplesStackParamList = {
   [ScreenNames.ANIMATED_EXAMPLE]: undefined;
@@ -15,6 +16,7 @@ type ExamplesStackParamList = {
   [ScreenNames.EVENTS]: undefined;
   [ScreenNames.AWARE_SCROLL_VIEW]: undefined;
   [ScreenNames.STATUS_BAR]: undefined;
+  [ScreenNames.NON_UI_PROPS]: undefined;
 };
 
 const Stack = createStackNavigator<ExamplesStackParamList>();
@@ -35,6 +37,9 @@ const options = {
   [ScreenNames.STATUS_BAR]: {
     headerShown: false,
     title: 'Status bar manipulation',
+  },
+  [ScreenNames.NON_UI_PROPS]: {
+    title: 'Non UI Props',
   },
 };
 
@@ -64,6 +69,11 @@ const ExamplesStack = () => (
       name={ScreenNames.STATUS_BAR}
       component={StatusBar}
       options={options[ScreenNames.STATUS_BAR]}
+    />
+    <Stack.Screen
+      name={ScreenNames.NON_UI_PROPS}
+      component={NonUIProps}
+      options={options[ScreenNames.NON_UI_PROPS]}
     />
   </Stack.Navigator>
 );

--- a/FabricExample/src/screens/Examples/Main/constants.ts
+++ b/FabricExample/src/screens/Examples/Main/constants.ts
@@ -19,4 +19,9 @@ export const examples: Example[] = [
     info: ScreenNames.STATUS_BAR,
     icons: '🔋',
   },
+  {
+    title: 'Non UI Props',
+    info: ScreenNames.NON_UI_PROPS,
+    icons: '🚀',
+  },
 ];

--- a/FabricExample/src/screens/Examples/NonUIProps/index.tsx
+++ b/FabricExample/src/screens/Examples/NonUIProps/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { View } from 'react-native';
+import { TextInput } from 'react-native-gesture-handler';
+import { useKeyboardHandler } from 'react-native-keyboard-controller';
+import Reanimated, {
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+function useGradualKeyboardAnimation() {
+  const height = useSharedValue(0);
+  const progress = useSharedValue(0);
+
+  useKeyboardHandler(
+    {
+      onMove: (e) => {
+        'worklet';
+
+        height.value = e.height;
+        progress.value = e.progress;
+      },
+      onEnd: (e) => {
+        'worklet';
+
+        height.value = e.height;
+        progress.value = progress.value;
+      },
+    },
+    []
+  );
+
+  return { height, progress };
+}
+
+function NonUIProps() {
+  const { height, progress } = useGradualKeyboardAnimation();
+
+  const rStyle = useAnimatedStyle(() => {
+    return {
+      backgroundColor: 'gray',
+      height: height.value,
+      width: interpolate(progress.value, [0, 1], [100, 200]),
+    };
+  });
+
+  return (
+    <View style={{ flex: 1 }}>
+      <TextInput
+        style={{ width: '100%', height: 50, backgroundColor: 'red' }}
+      />
+      <Reanimated.View style={rStyle} />
+    </View>
+  );
+}
+
+export default NonUIProps;

--- a/TODO
+++ b/TODO
@@ -3,7 +3,7 @@
 - [x] fix TS
 - [ ] state in events? (open, close, change, interactive)
 - [x] check that values always present in all methods (onStart,onEnd,onMove) in all test cases (close, open, change size)
-- [ ] useKeyboardHandler (with and without adjustResize)
+- [x] useKeyboardHandler (with and without adjustResize)
 - [x] versioned docs
 - [ ] iOS (on hide calls start/end twice)
 - [ ] blog post

--- a/TODO
+++ b/TODO
@@ -1,6 +1,7 @@
-- [ ] check that context handlers reacts to local state changes
+- [x] check that context handlers reacts to local state changes
 - [ ] check fabric
 - [ ] state in events? (open, close, change, interactive)
-- [ ] check that values always present in all methods (onStart,onEnd,onMove) in all test cases (close, open, change size)
-- [ ] useKeyboardHandler (with and without resize)
+- [x] check that values always present in all methods (onStart,onEnd,onMove) in all test cases (close, open, change size)
+- [ ] useKeyboardHandler (with and without adjustResize)
 - [ ] versioned docs
+- [ ] iOS (on hide calls start/end twice)

--- a/TODO
+++ b/TODO
@@ -1,6 +1,6 @@
 - [x] check that context handlers reacts to local state changes
 - [x] check fabric
-- [ ] fix TS
+- [x] fix TS
 - [ ] state in events? (open, close, change, interactive)
 - [x] check that values always present in all methods (onStart,onEnd,onMove) in all test cases (close, open, change size)
 - [ ] useKeyboardHandler (with and without adjustResize)

--- a/TODO
+++ b/TODO
@@ -1,0 +1,6 @@
+- [ ] check that context handlers reacts to local state changes
+- [ ] check fabric
+- [ ] state in events? (open, close, change, interactive)
+- [ ] check that values always present in all methods (onStart,onEnd,onMove) in all test cases (close, open, change size)
+- [ ] useKeyboardHandler (with and without resize)
+- [ ] versioned docs

--- a/TODO
+++ b/TODO
@@ -1,9 +1,0 @@
-- [x] check that context handlers reacts to local state changes
-- [x] check fabric
-- [x] fix TS
-- [ ] state in events? (open, close, change, interactive)
-- [x] check that values always present in all methods (onStart,onEnd,onMove) in all test cases (close, open, change size)
-- [x] useKeyboardHandler (with and without adjustResize)
-- [x] versioned docs
-- [ ] iOS (on hide calls start/end twice)
-- [ ] blog post

--- a/TODO
+++ b/TODO
@@ -1,7 +1,9 @@
 - [x] check that context handlers reacts to local state changes
 - [ ] check fabric
+- [ ] fix TS
 - [ ] state in events? (open, close, change, interactive)
 - [x] check that values always present in all methods (onStart,onEnd,onMove) in all test cases (close, open, change size)
 - [ ] useKeyboardHandler (with and without adjustResize)
 - [ ] versioned docs
 - [ ] iOS (on hide calls start/end twice)
+- [ ] blog post

--- a/TODO
+++ b/TODO
@@ -1,9 +1,9 @@
 - [x] check that context handlers reacts to local state changes
-- [ ] check fabric
+- [x] check fabric
 - [ ] fix TS
 - [ ] state in events? (open, close, change, interactive)
 - [x] check that values always present in all methods (onStart,onEnd,onMove) in all test cases (close, open, change size)
 - [ ] useKeyboardHandler (with and without adjustResize)
-- [ ] versioned docs
+- [x] versioned docs
 - [ ] iOS (on hide calls start/end twice)
 - [ ] blog post

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
@@ -78,7 +78,7 @@ class KeyboardAnimationCallback(
       val animation = ValueAnimator.ofInt(-this.persistentKeyboardHeight, -keyboardHeight)
       animation.addUpdateListener { animator ->
         val toValue = animator.animatedValue as Int
-        this.sendEventToJS(KeyboardTransitionEvent(view.id, toValue, -toValue.toDouble() / keyboardHeight))
+        this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMove", toValue, -toValue.toDouble() / keyboardHeight))
       }
       animation.doOnEnd {
         this.emitEvent("KeyboardController::keyboardDidShow", getEventParams(keyboardHeight))
@@ -108,6 +108,7 @@ class KeyboardAnimationCallback(
     this.emitEvent("KeyboardController::" + if (!isKeyboardVisible) "keyboardWillHide" else "keyboardWillShow", getEventParams(keyboardHeight))
 
     Log.i(TAG, "HEIGHT:: $keyboardHeight")
+    this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMoveStart", keyboardHeight, if (!isKeyboardVisible) 0.0 else 1.0))
 
     return super.onStart(animation, bounds)
   }
@@ -128,7 +129,7 @@ class KeyboardAnimationCallback(
     val diff = Insets.subtract(typesInset, otherInset).let {
       Insets.max(it, Insets.NONE)
     }
-    val diffY = (diff.top - diff.bottom).toFloat()
+    val diffY = (diff.bottom - diff.top).toFloat()
     val height = toDp(diffY, context)
 
     var progress = 0.0
@@ -139,7 +140,7 @@ class KeyboardAnimationCallback(
     }
     Log.i(TAG, "DiffY: $diffY $height $progress")
 
-    this.sendEventToJS(KeyboardTransitionEvent(view.id, height, progress))
+    this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMove", height, progress))
 
     return insets
   }
@@ -150,6 +151,7 @@ class KeyboardAnimationCallback(
     isTransitioning = false
     this.persistentKeyboardHeight = getCurrentKeyboardHeight()
     this.emitEvent("KeyboardController::" + if (!isKeyboardVisible) "keyboardDidHide" else "keyboardDidShow", getEventParams(this.persistentKeyboardHeight))
+    this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMoveStart", this.persistentKeyboardHeight, if (!isKeyboardVisible) 0.0 else 1.0))
   }
 
   private fun isKeyboardVisible(): Boolean {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
@@ -74,14 +74,16 @@ class KeyboardAnimationCallback(
       val keyboardHeight = getCurrentKeyboardHeight()
 
       this.emitEvent("KeyboardController::keyboardWillShow", getEventParams(keyboardHeight))
+      this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMoveStart", keyboardHeight, 1.0))
 
-      val animation = ValueAnimator.ofInt(-this.persistentKeyboardHeight, -keyboardHeight)
+      val animation = ValueAnimator.ofInt(this.persistentKeyboardHeight, keyboardHeight)
       animation.addUpdateListener { animator ->
         val toValue = animator.animatedValue as Int
-        this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMove", toValue, -toValue.toDouble() / keyboardHeight))
+        this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMove", toValue, toValue.toDouble() / keyboardHeight))
       }
       animation.doOnEnd {
         this.emitEvent("KeyboardController::keyboardDidShow", getEventParams(keyboardHeight))
+        this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMoveEnd", keyboardHeight, 1.0))
       }
       animation.setDuration(250).startDelay = 0
       animation.start()
@@ -151,7 +153,7 @@ class KeyboardAnimationCallback(
     isTransitioning = false
     this.persistentKeyboardHeight = getCurrentKeyboardHeight()
     this.emitEvent("KeyboardController::" + if (!isKeyboardVisible) "keyboardDidHide" else "keyboardDidShow", getEventParams(this.persistentKeyboardHeight))
-    this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMoveStart", this.persistentKeyboardHeight, if (!isKeyboardVisible) 0.0 else 1.0))
+    this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMoveEnd", this.persistentKeyboardHeight, if (!isKeyboardVisible) 0.0 else 1.0))
   }
 
   private fun isKeyboardVisible(): Boolean {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManagerImpl.kt
@@ -58,8 +58,12 @@ class KeyboardControllerViewManagerImpl(reactContext: ReactApplicationContext) {
 
   fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
     val map: MutableMap<String, Any> = MapBuilder.of(
-      KeyboardTransitionEvent.EVENT_NAME,
-      MapBuilder.of("registrationName", "onKeyboardMove")
+      "topKeyboardMove",
+      MapBuilder.of("registrationName", "onKeyboardMove"),
+      "topKeyboardMoveStart",
+      MapBuilder.of("registrationName", "onKeyboardMoveStart"),
+      "topKeyboardMoveEnd",
+      MapBuilder.of("registrationName", "onKeyboardMoveEnd"),
     )
 
     return map

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManagerImpl.kt
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
-import com.reactnativekeyboardcontroller.events.KeyboardTransitionEvent
 
 class KeyboardControllerViewManagerImpl(reactContext: ReactApplicationContext) {
   private val TAG = KeyboardControllerViewManagerImpl::class.qualifiedName

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
@@ -4,8 +4,8 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class KeyboardTransitionEvent(private val viewId: Int, private val height: Int, private val progress: Double) : Event<KeyboardTransitionEvent>(viewId) {
-  override fun getEventName() = EVENT_NAME
+class KeyboardTransitionEvent(viewId: Int, private val event: String, private val height: Int, private val progress: Double) : Event<KeyboardTransitionEvent>(viewId) {
+  override fun getEventName() = event
 
   // TODO: All events for a given view can be coalesced?
   override fun getCoalescingKey(): Short = 0
@@ -15,9 +15,5 @@ class KeyboardTransitionEvent(private val viewId: Int, private val height: Int, 
     map.putDouble("progress", progress)
     map.putInt("height", height)
     rctEventEmitter.receiveEvent(viewTag, eventName, map)
-  }
-
-  companion object {
-    const val EVENT_NAME = "topKeyboardMove"
   }
 }

--- a/example/src/constants/screenNames.ts
+++ b/example/src/constants/screenNames.ts
@@ -7,4 +7,5 @@ export enum ScreenNames {
   LOTTIE = 'LOTTIE',
   EXAMPLES_STACK = 'EXAMPLES_STACK',
   EXAMPLES = 'EXAMPLES',
+  NON_UI_PROPS = 'NON_UI_PROPS',
 }

--- a/example/src/navigation/ExamplesStack/index.tsx
+++ b/example/src/navigation/ExamplesStack/index.tsx
@@ -9,6 +9,7 @@ import Events from '../../screens/Examples/Events';
 import AwareScrollView from '../../screens/Examples/AwareScrollView';
 import StatusBar from '../../screens/Examples/StatusBar';
 import LottieAnimation from '../../screens/Examples/Lottie';
+import NonUIProps from '../../screens/Examples/NonUIProps';
 
 type ExamplesStackParamList = {
   [ScreenNames.ANIMATED_EXAMPLE]: undefined;
@@ -17,6 +18,7 @@ type ExamplesStackParamList = {
   [ScreenNames.AWARE_SCROLL_VIEW]: undefined;
   [ScreenNames.STATUS_BAR]: undefined;
   [ScreenNames.LOTTIE]: undefined;
+  [ScreenNames.NON_UI_PROPS]: undefined;
 };
 
 const Stack = createStackNavigator<ExamplesStackParamList>();
@@ -40,6 +42,9 @@ const options = {
   },
   [ScreenNames.LOTTIE]: {
     title: 'Lottie animation',
+  },
+  [ScreenNames.NON_UI_PROPS]: {
+    title: 'Non UI Props',
   },
 };
 
@@ -74,6 +79,11 @@ const ExamplesStack = () => (
       name={ScreenNames.LOTTIE}
       component={LottieAnimation}
       options={options[ScreenNames.LOTTIE]}
+    />
+    <Stack.Screen
+      name={ScreenNames.NON_UI_PROPS}
+      component={NonUIProps}
+      options={options[ScreenNames.NON_UI_PROPS]}
     />
   </Stack.Navigator>
 );

--- a/example/src/screens/Examples/Lottie/index.tsx
+++ b/example/src/screens/Examples/Lottie/index.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { StyleSheet, TextInput, View } from 'react-native';
 import Lottie from 'lottie-react-native';
-import { useKeyboardAnimation } from 'react-native-keyboard-controller';
+import { useKeyboardHandler } from 'react-native-keyboard-controller';
+import Reanimated, {
+  interpolate,
+  useAnimatedProps,
+  useSharedValue,
+} from 'react-native-reanimated';
 
 // animation is taken from lottie public animations: https://lottiefiles.com/46216-lock-debit-card-morph
 import LockDebitCardMorph from './animation.json';
@@ -22,23 +27,41 @@ const styles = StyleSheet.create({
   },
 });
 
-function LottieAnimation() {
-  const { progress } = useKeyboardAnimation();
+const ReanimatedLottieView = Reanimated.createAnimatedComponent(Lottie);
 
-  const animation = progress.interpolate({
-    inputRange: [0, 1],
-    // 104 - total frames
-    // 7 frame - transition begins
-    // 35 frame - transition ends
-    outputRange: [7 / 104, 35 / 104],
+function LottieAnimation() {
+  const progress = useSharedValue(0);
+
+  useKeyboardHandler(
+    {
+      onMove: (e) => {
+        'worklet';
+
+        progress.value = e.progress;
+      },
+    },
+    []
+  );
+
+  const animatedProps = useAnimatedProps(() => {
+    return {
+      progress: interpolate(
+        progress.value,
+        [0, 1],
+        // 104 - total frames
+        // 7 frame - transition begins
+        // 35 frame - transition ends
+        [7 / 104, 35 / 104]
+      ),
+    };
   });
 
   return (
     <View style={styles.container}>
-      <Lottie
+      <ReanimatedLottieView
         style={styles.lottie}
         source={LockDebitCardMorph}
-        progress={animation}
+        animatedProps={animatedProps}
       />
       <TextInput style={styles.input} />
     </View>

--- a/example/src/screens/Examples/Main/constants.ts
+++ b/example/src/screens/Examples/Main/constants.ts
@@ -24,4 +24,9 @@ export const examples: Example[] = [
     info: ScreenNames.LOTTIE,
     icons: '⚠️ 🎞',
   },
+  {
+    title: 'Non UI Props',
+    info: ScreenNames.NON_UI_PROPS,
+    icons: '🚀',
+  },
 ];

--- a/example/src/screens/Examples/NonUIProps/index.tsx
+++ b/example/src/screens/Examples/NonUIProps/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { View } from 'react-native';
+import { TextInput } from 'react-native-gesture-handler';
+import { useKeyboardHandler } from 'react-native-keyboard-controller';
+import Reanimated, {
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+function useGradualKeyboardAnimation() {
+  const height = useSharedValue(0);
+  const progress = useSharedValue(0);
+
+  useKeyboardHandler(
+    {
+      onMove: (e) => {
+        'worklet';
+
+        height.value = e.height;
+        progress.value = e.progress;
+      },
+      onEnd: (e) => {
+        'worklet';
+
+        height.value = e.height;
+        progress.value = progress.value;
+      },
+    },
+    []
+  );
+
+  return { height, progress };
+}
+
+function NonUIProps() {
+  const { height, progress } = useGradualKeyboardAnimation();
+
+  const rStyle = useAnimatedStyle(() => {
+    return {
+      backgroundColor: 'gray',
+      height: Math.abs(height.value),
+      width: interpolate(progress.value, [0, 1], [100, 200]),
+    };
+  });
+
+  return (
+    <View style={{ flex: 1 }}>
+      <TextInput
+        style={{ width: '100%', height: 50, backgroundColor: 'red' }}
+      />
+      <Reanimated.View style={rStyle} />
+    </View>
+  );
+}
+
+export default NonUIProps;

--- a/example/src/screens/Examples/NonUIProps/index.tsx
+++ b/example/src/screens/Examples/NonUIProps/index.tsx
@@ -39,7 +39,7 @@ function NonUIProps() {
   const rStyle = useAnimatedStyle(() => {
     return {
       backgroundColor: 'gray',
-      height: Math.abs(height.value),
+      height: height.value,
       width: interpolate(progress.value, [0, 1], [100, 200]),
     };
   });

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,5 +1,9 @@
 disabled_rules:
   - trailing_comma
 
+line_length:
+  warning: 120
+  ignores_urls: true
+
 excluded:
   - Pods

--- a/ios/KeyboardControllerView.mm
+++ b/ios/KeyboardControllerView.mm
@@ -44,13 +44,30 @@ using namespace facebook::react;
     _props = defaultProps;
 
     observer = [[KeyboardMovementObserver alloc]
-        initWithHandler:^(NSNumber *height, NSNumber *progress) {
+        initWithHandler:^(NSString *event, NSNumber *height, NSNumber *progress) {
           if (self->_eventEmitter) {
-            std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(
-                self->_eventEmitter)
-                ->onKeyboardMove(
-                    facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMove{
-                        .height = [height intValue], .progress = static_cast<Float>(self.tag)});
+            // TODO: use reflection to reduce code duplication?
+            if ([event isEqualToString:@"onKeyboardMoveStart"]) {
+              std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(
+                  self->_eventEmitter)
+                  ->onKeyboardMoveStart(
+                      facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMoveStart{
+                          .height = [height intValue], .progress = [progress floatValue]});
+            }
+            if ([event isEqualToString:@"onKeyboardMove"]) {
+              std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(
+                  self->_eventEmitter)
+                  ->onKeyboardMove(
+                      facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMove{
+                          .height = [height intValue], .progress = [progress floatValue]});
+            }
+            if ([event isEqualToString:@"onKeyboardMoveEnd"]) {
+              std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(
+                  self->_eventEmitter)
+                  ->onKeyboardMoveEnd(
+                      facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMoveEnd{
+                          .height = [height intValue], .progress = [progress floatValue]});
+            }
           }
 
           // TODO: use built-in _eventEmitter once NativeAnimated module will use ModernEventemitter
@@ -58,6 +75,7 @@ using namespace facebook::react;
           if (bridge) {
             KeyboardMoveEvent *keyboardMoveEvent =
                 [[KeyboardMoveEvent alloc] initWithReactTag:@(self.tag)
+                                                      event:event
                                                      height:height
                                                    progress:progress];
             [bridge.eventDispatcher sendEvent:keyboardMoveEvent];

--- a/ios/KeyboardControllerViewManager.mm
+++ b/ios/KeyboardControllerViewManager.mm
@@ -2,6 +2,8 @@
 
 @interface RCT_EXTERN_MODULE (KeyboardControllerViewManager, RCTViewManager)
 
+RCT_EXPORT_VIEW_PROPERTY(onKeyboardMoveStart, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onKeyboardMove, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onKeyboardMoveEnd, RCTDirectEventBlock);
 
 @end

--- a/ios/KeyboardControllerViewManager.swift
+++ b/ios/KeyboardControllerViewManager.swift
@@ -12,7 +12,9 @@ class KeyboardControllerViewManager: RCTViewManager {
 class KeyboardControllerView: UIView {
   private var keyboardObserver: KeyboardMovementObserver?
   private var eventDispatcher: RCTEventDispatcherProtocol
+  @objc var onKeyboardMoveStart: RCTDirectEventBlock?
   @objc var onKeyboardMove: RCTDirectEventBlock?
+  @objc var onKeyboardMoveEnd: RCTDirectEventBlock?
 
   init(frame: CGRect, eventDispatcher: RCTEventDispatcherProtocol) {
     self.eventDispatcher = eventDispatcher
@@ -39,10 +41,11 @@ class KeyboardControllerView: UIView {
     }
   }
 
-  func onEvent(height: NSNumber, progress: NSNumber) {
+  func onEvent(event: NSString, height: NSNumber, progress: NSNumber) {
     eventDispatcher.send(
       KeyboardMoveEvent(
         reactTag: reactTag,
+        event: event as String,
         height: height,
         progress: progress
       )

--- a/ios/KeyboardMoveEvent.h
+++ b/ios/KeyboardMoveEvent.h
@@ -12,6 +12,7 @@
 @interface KeyboardMoveEvent : NSObject <RCTEvent>
 
 - (instancetype)initWithReactTag:(NSNumber *)reactTag
+                           event:(NSString *)event
                           height:(NSNumber *)height
                         progress:(NSNumber *)progress;
 

--- a/ios/KeyboardMoveEvent.m
+++ b/ios/KeyboardMoveEvent.m
@@ -69,11 +69,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (NSArray *)arguments
 {
-  return @[
-    self.viewTag,
-    RCTNormalizeInputEventName(self.eventName),
-    [self body]
-  ];
+  return @[ self.viewTag, RCTNormalizeInputEventName(self.eventName), [self body] ];
 }
 
 @end

--- a/ios/KeyboardMoveEvent.m
+++ b/ios/KeyboardMoveEvent.m
@@ -19,13 +19,14 @@
 @synthesize eventName = _eventName;
 
 - (instancetype)initWithReactTag:(NSNumber *)reactTag
+                           event:(NSString *)event
                           height:(NSNumber *)height
                         progress:(NSNumber *)progress
 {
   RCTAssertParam(reactTag);
 
   if ((self = [super init])) {
-    _eventName = @"onKeyboardMove";
+    _eventName = [event copy];
     _viewTag = reactTag;
     _progress = progress;
     _height = height;
@@ -68,7 +69,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (NSArray *)arguments
 {
-  return @[ self.viewTag, RCTNormalizeInputEventName(self.eventName), [self body] ];
+  return @[
+    self.viewTag,
+    RCTNormalizeInputEventName(self.eventName),
+    [self body]
+  ];
 }
 
 @end

--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -120,6 +120,7 @@ public class KeyboardMovementObserver: NSObject {
 
   @objc func setupKeyboardWatcher() {
     displayLink = CADisplayLink(target: self, selector: #selector(updateKeyboardFrame))
+    displayLink?.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
     displayLink?.add(to: .main, forMode: .common)
   }
 

--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -31,7 +31,10 @@ public class KeyboardMovementObserver: NSObject {
   private var displayLink: CADisplayLink?
   private var keyboardHeight: CGFloat = 0.0
 
-  @objc public init(handler: @escaping (NSString, NSNumber, NSNumber) -> Void, onNotify: @escaping (String, Any) -> Void) {
+  @objc public init(
+    handler: @escaping (NSString, NSNumber, NSNumber) -> Void,
+    onNotify: @escaping (String, Any) -> Void
+  ) {
     onEvent = handler
     self.onNotify = onNotify
   }
@@ -120,7 +123,7 @@ public class KeyboardMovementObserver: NSObject {
 
   @objc func setupKeyboardWatcher() {
     displayLink = CADisplayLink(target: self, selector: #selector(updateKeyboardFrame))
-    displayLink?.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
+    displayLink?.preferredFramesPerSecond = 120 // will fallback to 60 fps for devices without Pro Motion display
     displayLink?.add(to: .main, forMode: .common)
   }
 
@@ -138,9 +141,9 @@ public class KeyboardMovementObserver: NSObject {
       if window.description.hasPrefix("<UITextEffectsWindow") {
         for subview in window.subviews {
           if subview.description.hasPrefix("<UIInputSetContainerView") {
-            for sv in subview.subviews {
-              if sv.description.hasPrefix("<UIInputSetHostView") {
-                result = sv as? UIView
+            for hostView in subview.subviews {
+              if hostView.description.hasPrefix("<UIInputSetHostView") {
+                result = hostView as? UIView
                 break
               }
             }

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,7 +6,7 @@ import type { KeyboardHandlers } from './types';
 
 export type AnimatedContext = {
   progress: Animated.Value;
-  height: Animated.Value;
+  height: Animated.AnimatedMultiplication<number>;
 };
 export type ReanimatedContext = {
   progress: SharedValue<number>;

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 import { Animated } from 'react-native';
 
 import type { SharedValue } from 'react-native-reanimated';
+import type { KeyboardHandlers } from './types';
 
 export type AnimatedContext = {
   progress: Animated.Value;
@@ -14,6 +15,7 @@ export type ReanimatedContext = {
 export type KeyboardAnimationContext = {
   animated: AnimatedContext;
   reanimated: ReanimatedContext;
+  setHandlers: (handlers: KeyboardHandlers) => void;
 };
 const defaultContext: KeyboardAnimationContext = {
   animated: {
@@ -24,5 +26,6 @@ const defaultContext: KeyboardAnimationContext = {
     progress: { value: 0 },
     height: { value: 0 },
   },
+  setHandlers: () => {},
 };
 export const KeyboardContext = createContext(defaultContext);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -30,19 +30,11 @@ export const useReanimatedKeyboardAnimation = (): ReanimatedContext => {
   return context.reanimated;
 };
 
-/**
- * // 1. add listener to context
- * // 2. useMemo here?
- * // 3. remove listener from context on unmount
- */
-export function useKeyboardHandler(
+export function useGenericKeyboardHandler(
   handler: KeyboardHandler,
   deps?: ReadonlyArray<unknown>
 ) {
-  // TODO: ideally this hook should be splitted in two hooks (first just works with context, second combines first and set adjustResize)
-  useResizeMode(); // TODO: we need to switch to adjustResize - is it good enough to use this hook here?
   const context = useContext(KeyboardContext);
-  // TODO: do we need memo here?
   const memoizedHandler = useMemo(() => handler, deps);
 
   useEffect(() => {
@@ -54,4 +46,12 @@ export function useKeyboardHandler(
       context.setHandlers({ [key]: undefined });
     };
   }, [memoizedHandler]);
+}
+
+export function useKeyboardHandler(
+  handler: KeyboardHandler,
+  deps?: ReadonlyArray<unknown>
+) {
+  useResizeMode();
+  useGenericKeyboardHandler(handler, deps);
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo } from 'react';
+import { DependencyList, useContext, useEffect } from 'react';
 
 import { AnimatedContext, KeyboardContext, ReanimatedContext } from './context';
 import { AndroidSoftInputModes, KeyboardController } from './native';
@@ -32,10 +32,9 @@ export const useReanimatedKeyboardAnimation = (): ReanimatedContext => {
 
 export function useGenericKeyboardHandler(
   handler: KeyboardHandler,
-  deps?: ReadonlyArray<unknown>
+  deps?: DependencyList
 ) {
   const context = useContext(KeyboardContext);
-  const memoizedHandler = useMemo(() => handler, deps);
 
   useEffect(() => {
     const key = uuid();
@@ -45,12 +44,12 @@ export function useGenericKeyboardHandler(
     return () => {
       context.setHandlers({ [key]: undefined });
     };
-  }, [memoizedHandler]);
+  }, deps);
 }
 
 export function useKeyboardHandler(
   handler: KeyboardHandler,
-  deps?: ReadonlyArray<unknown>
+  deps?: DependencyList
 ) {
   useResizeMode();
   useGenericKeyboardHandler(handler, deps);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,7 +1,10 @@
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 
 import { AnimatedContext, KeyboardContext, ReanimatedContext } from './context';
 import { AndroidSoftInputModes, KeyboardController } from './native';
+import { uuid } from './utils';
+
+import type { KeyboardHandler } from './types';
 
 export const useResizeMode = () => {
   useEffect(() => {
@@ -26,3 +29,29 @@ export const useReanimatedKeyboardAnimation = (): ReanimatedContext => {
 
   return context.reanimated;
 };
+
+/**
+ * // 1. add listener to context
+ * // 2. useMemo here?
+ * // 3. remove listener from context on unmount
+ */
+export function useKeyboardHandler(
+  handler: KeyboardHandler,
+  deps?: ReadonlyArray<unknown>
+) {
+  // TODO: ideally this hook should be splitted in two hooks (first just works with context, second combines first and set adjustResize)
+  useResizeMode(); // TODO: we need to switch to adjustResize - is it good enough to use this hook here?
+  const context = useContext(KeyboardContext);
+  // TODO: do we need memo here?
+  const memoizedHandler = useMemo(() => handler, deps);
+
+  useEffect(() => {
+    const key = uuid();
+
+    context.setHandlers({ [key]: handler });
+
+    return () => {
+      context.setHandlers({ [key]: undefined });
+    };
+  }, [memoizedHandler]);
+}

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react';
 import { useEvent, useHandler, useSharedValue } from 'react-native-reanimated';
 
-import type { EventWithName, NativeEvent } from './types';
+import type { EventWithName, Handlers, NativeEvent } from './types';
 
 export function useAnimatedKeyboardHandler<
   TContext extends Record<string, unknown>
@@ -41,11 +41,18 @@ export function useAnimatedKeyboardHandler<
   );
 }
 
-type Handlers<T> = Record<string, T>;
-
-// TODO: T - overkill?
-// TODO: make types correct (type is not a string)
-export function useSharedHandlers<T>() {
+/**
+ * Hook for storing worklet handlers (objects with keys, where values are worklets).
+ * Returns methods for setting handlers and broadcasting events in them.
+ *
+ * T is a generic that looks like:
+ * @example
+ * {
+ *  onEvent: () => {},
+ *  onEvent2: () => {},
+ * }
+ */
+export function useSharedHandlers<T extends Record<string, Function>>() {
   const handlers = useSharedValue<Handlers<T>>({});
   const jsHandlers = useRef<Handlers<T>>({});
 
@@ -68,7 +75,7 @@ export function useSharedHandlers<T>() {
     };
     updateSharedHandlers();
   }, []);
-  const broadcast = (type: string, event: NativeEvent) => {
+  const broadcast = (type: keyof T, event: NativeEvent) => {
     'worklet';
 
     Object.keys(handlers.value).forEach((key) =>

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,4 +1,5 @@
-import { useEvent, useHandler } from 'react-native-reanimated';
+import { useCallback, useRef } from 'react';
+import { useEvent, useHandler, useSharedValue } from 'react-native-reanimated';
 
 import type { EventWithName, NativeEvent } from './types';
 
@@ -6,7 +7,9 @@ export function useAnimatedKeyboardHandler<
   TContext extends Record<string, unknown>
 >(
   handlers: {
+    onKeyboardMoveStart?: (e: NativeEvent, context: TContext) => void;
     onKeyboardMove?: (e: NativeEvent, context: TContext) => void;
+    onKeyboardMoveEnd?: (e: NativeEvent, context: TContext) => void;
   },
   dependencies?: ReadonlyArray<unknown>
 ) {
@@ -15,13 +18,63 @@ export function useAnimatedKeyboardHandler<
   return useEvent(
     (event: EventWithName<NativeEvent>) => {
       'worklet';
-      const { onKeyboardMove } = handlers;
+      const { onKeyboardMoveStart, onKeyboardMove, onKeyboardMoveEnd } =
+        handlers;
+
+      if (
+        onKeyboardMoveStart &&
+        event.eventName.endsWith('onKeyboardMoveStart')
+      ) {
+        onKeyboardMoveStart(event, context);
+      }
 
       if (onKeyboardMove && event.eventName.endsWith('onKeyboardMove')) {
         onKeyboardMove(event, context);
       }
+
+      if (onKeyboardMoveEnd && event.eventName.endsWith('onKeyboardMoveEnd')) {
+        onKeyboardMoveEnd(event, context);
+      }
     },
-    ['onKeyboardMove'],
+    ['onKeyboardMoveStart', 'onKeyboardMove', 'onKeyboardMoveEnd'],
     doDependenciesDiffer
   );
+}
+
+type Handlers<T> = Record<string, T>;
+
+// TODO: T - overkill?
+// TODO: make types correct (type is not a string)
+export function useSharedHandlers<T>() {
+  const handlers = useSharedValue<Handlers<T>>({});
+  const jsHandlers = useRef<Handlers<T>>({});
+
+  // since js -> worklet -> js call is asynchronous, we can not write handlers
+  // straight into shared variable (using current shared value as a previous result),
+  // since there may be a race condition in a call, and closure may have out-of-dated
+  // values. As a result, some of handlers may be not written to "all handlers" object.
+  // Below we are writing all handlers to `ref` and afterwards synchronize them with
+  // shared value (since `refs` are not referring to actual value in worklets).
+  // This approach allow us to update synchronously handlers in js thread (and it assures,
+  // that it will have all of them) and then update them in worklet thread (calls are
+  // happening in FIFO order, so we will always have actual value).
+  const updateSharedHandlers = () => {
+    handlers.value = jsHandlers.current;
+  };
+  const setHandlers = useCallback((handler: Handlers<T>) => {
+    jsHandlers.current = {
+      ...jsHandlers.current,
+      ...handler,
+    };
+    updateSharedHandlers();
+  }, []);
+  const broadcast = (type: string, event: NativeEvent) => {
+    'worklet';
+
+    Object.keys(handlers.value).forEach((key) =>
+      handlers.value[key]?.[type]?.(event)
+    );
+  };
+
+  return { setHandlers, broadcast };
 }

--- a/src/specs/KeyboardControllerViewNativeComponent.ts
+++ b/src/specs/KeyboardControllerViewNativeComponent.ts
@@ -14,8 +14,12 @@ type KeyboardMoveEvent = Readonly<{
 }>;
 
 export interface NativeProps extends ViewProps {
+  // props
   statusBarTranslucent?: boolean;
+  // callbacks
   onKeyboardMove?: DirectEventHandler<KeyboardMoveEvent>;
+  onKeyboardMoveStart?: DirectEventHandler<KeyboardMoveEvent>;
+  onKeyboardMoveEnd?: DirectEventHandler<KeyboardMoveEvent>;
 }
 
 export default codegenNativeComponent<NativeProps>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,15 @@ export type EventWithName<T> = {
 // native View/Module declarations
 
 export type KeyboardControllerProps = {
-  onKeyboardMove: (e: NativeSyntheticEvent<EventWithName<NativeEvent>>) => void;
+  onKeyboardMoveStart?: (
+    e: NativeSyntheticEvent<EventWithName<NativeEvent>>
+  ) => void;
+  onKeyboardMove?: (
+    e: NativeSyntheticEvent<EventWithName<NativeEvent>>
+  ) => void;
+  onKeyboardMoveEnd?: (
+    e: NativeSyntheticEvent<EventWithName<NativeEvent>>
+  ) => void;
   // fake prop used to activate reanimated bindings
   onKeyboardMoveReanimated: (
     e: NativeSyntheticEvent<EventWithName<NativeEvent>>
@@ -40,3 +48,12 @@ export type KeyboardControllerEvents =
 export type KeyboardEventData = {
   height: number;
 };
+
+// package types
+
+export type KeyboardHandler = {
+  onStart?: (e: NativeEvent) => void;
+  onMove?: (e: NativeEvent) => void;
+  onEnd?: (e: NativeEvent) => void;
+};
+export type KeyboardHandlers = Record<string, KeyboardHandler | undefined>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,9 +51,10 @@ export type KeyboardEventData = {
 
 // package types
 
+export type Handlers<T> = Record<string, T | undefined>;
 export type KeyboardHandler = {
   onStart?: (e: NativeEvent) => void;
   onMove?: (e: NativeEvent) => void;
   onEnd?: (e: NativeEvent) => void;
 };
-export type KeyboardHandlers = Record<string, KeyboardHandler | undefined>;
+export type KeyboardHandlers = Handlers<KeyboardHandler>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,1 @@
+export const uuid = () => Math.random().toString(36).slice(-6);


### PR DESCRIPTION
## 📜 Description

Added new hook `useKeyboardHandler` that has gradual `height`/`progress` values on iOS. Also it has a little bit different API than already existing hooks. See **Motivation and Context** section to get more insights of why this approach was chosen.

## Related issues
- https://github.com/kirillzyusko/react-native-keyboard-controller/issues/85
- https://github.com/kirillzyusko/react-native-keyboard-controller/discussions/56

## 💡 Motivation and Context

The current limitation of this library on iOS was the fact, that `height` and `progress` values didn't have intermediate values. So if you are trying to animate NonUiProps, such as `height`, `width` etc. - you get instant transitions, that looks not well. That's where `useKeyboardHandler` comes into play.

This hook allows you to get intermediate values. Unfortunately values in `onMove` handler are not perfectly synchronised with the keyboard positions (I did a big research on how to get intermediate values and a little bit later I will open a new issue describing all nuances I found). Since these values are not synchronized - it makes it impossible to add them in already existing `useKeyboardAnimation` hooks, since all chat-like apps will have unsynchronised keyboard/text input animations and most of all iOS users will notice it.

That's why I decided to go in a little bit different way and introduce new hook. In my opinion this hook gives minimal (but at the same time very powerful) API. You can control every aspect of the keyboard movement, detect start/end of the animations and get intermediate values.

Later I will write a new docs for this hook where I will highlight all nuances of the usage. Current iOS implementation was highly inspired by https://github.com/JunyuKuang/KeyboardUtility

## 📢 Changelog

### JS
- added two new methods for `KeyboardControllerView`: `onKeyboardMoveStart` and `onKeyboardMoveEnd`;
- added new hook `useKeyboardHandler`;
- added new example;

### iOS
- watch keyboard position during animation via `CADisplayLink`;

## 🤔 How Has This Been Tested?

Tested manually on:
- iPhone 11 (iOS 15.5);
- Pixel 3 (API 32);

## 📸 Screenshots (if appropriate):

### Lottie example (iOS)

|Before|After|
|-------|-----|
|<video src="https://user-images.githubusercontent.com/22820318/195279279-b1284f86-3053-4ef8-a3d2-b18741677f06.mp4">|<video src="https://user-images.githubusercontent.com/22820318/195278696-278a81ed-9893-4c63-82e3-8372c76be4c7.mp4">|

### Non UI props

|Before|After|
|------|-----|
|<video src="https://user-images.githubusercontent.com/22820318/195279766-777da551-a81d-40f2-be38-f9a1bda298f5.mp4">|<video src="https://user-images.githubusercontent.com/22820318/195279862-c5a07328-b226-4578-93bf-057d3a6740cb.mp4">|

## 📝 Checklist

- [x] CI successfully passed