### PR TITLE
fix: avoid usage of forced unwrapping

### DIFF
--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -161,8 +161,8 @@ public class KeyboardMovementObserver: NSObject {
       return
     }
 
-    var keyboardFrameY = keyboardView!.layer.presentation()!.frame.origin.y
-    var keyboardWindowH = keyboardView!.window!.bounds.size.height
+    var keyboardFrameY = keyboardView?.layer.presentation()?.frame.origin.y ?? 0
+    var keyboardWindowH = keyboardView?.window?.bounds.size.height ?? 0
     var keyboardPosition = keyboardWindowH - keyboardFrameY
 
     if keyboardPosition == prevKeyboardPosition || keyboardFrameY == 0 {


### PR DESCRIPTION
## 📜 Description

Added optional chaining instead of forced unwrapping. Fixes crash described in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/93

## 💡 Motivation and Context

In fact it's not a fix and is more avoiding NPE rather than a full fix. But anyway, missing animation is better, than a crash of application 🤷‍♂️ 

## 📢 Changelog

### iOS
- avoid usage of forced unwrapping

## 🤔 How Has This Been Tested?

Tested locally on:
- iPhone 13 Pro (iOS 15.0);

## 📝 Checklist

- [x] CI successfully passed