### PR TITLE
chore: switch to `actions/checkout@v3` instead of `actions/checkout@v2`

### DIFF
--- a/.github/workflows/build-android-fabric.yml
+++ b/.github/workflows/build-android-fabric.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build Android Fabric Example App
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build Android Example App
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/build-ios-fabric.yml
+++ b/.github/workflows/build-ios-fabric.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         working-directory: FabricExample/ios
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get yarn cache directory path
         id: fabric-yarn-cache-dir-path

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -28,7 +28,7 @@ jobs:
       run:
         working-directory: example/ios
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: ./docs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/.github/workflows/verify-android.yml
+++ b/.github/workflows/verify-android.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Kotlin Lint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: touchlab-lab/ktlint-action-setup@1.0.0
         with:
           ktlint_version: 0.45.2
@@ -31,7 +31,7 @@ jobs:
       run:
         working-directory: ./android
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/verify-cpp.yml
+++ b/.github/workflows/verify-cpp.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/verify-ios.yml
+++ b/.github/workflows/verify-ios.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Swift Lint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run SwiftLint GitHub Action (--strict)
         uses: norio-nomura/action-swiftlint@master
         with:
@@ -33,7 +33,7 @@ jobs:
       run:
         working-directory: ./ios
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install SwiftFormat
         run: brew install swiftformat
@@ -47,7 +47,7 @@ jobs:
     runs-on: macOS-latest
     name: ObjC Lint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/verify-js.yml
+++ b/.github/workflows/verify-js.yml
@@ -13,7 +13,7 @@ jobs:
     name: Compile TS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -29,7 +29,7 @@ jobs:
     name: Lint TS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -42,7 +42,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x


### PR DESCRIPTION
## 📜 Description

Switch to `actions/checkout@v3` instead of `actions/checkout@v2`.

## 💡 Motivation and Context

Since checkout@v2 is using NodeJS v12 and the usage of v12 soon will be deprecated on GitHub actions I decided to update checkout actions to latest v3 version which is using NodeJS v16 by default.

## 📢 Changelog

### CI
- switch to `actions/checkout@v3` instead of `actions/checkout@v2`.

## 🤔 How Has This Been Tested?

Tested on GitHub actions. Everything seems to be working fine 😁 

## 📝 Checklist

- [x] CI successfully passed