### PR TITLE
refactor: ignore `for_where` rule for swiftlint

### DIFF
--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,5 +1,6 @@
 disabled_rules:
   - trailing_comma
+  - for_where
 
 line_length:
   warning: 120


### PR DESCRIPTION
## 📜 Description

Fixed failed SwiftLint on CI.

## 💡 Motivation and Context

Don't know why it didn't fail before. Seems like new version of `swiftlint` has been released (`0.50.0`) where the rule has been rewritten. I think it's a cause of the issue.

I've tried to downgrade version of `swiftlint` in CI and lock it there, but I didn't find a way how to manage it 🤷‍♂️ 

## 📢 Changelog

### iOS
- ignore `for_where` rule for `swiftlint`;

## 🤔 How Has This Been Tested?

Tested on GitHub actions (CI).

## 📝 Checklist

- [x] CI successfully passed