### PR TITLE
refactor: rotate on `180deg` instead of `scaleY: -1` to eliminate freezes of ScrollView on Android

### DIFF
--- a/FabricExample/src/screens/Examples/ReanimatedChat/styles.ts
+++ b/FabricExample/src/screens/Examples/ReanimatedChat/styles.ts
@@ -11,7 +11,7 @@ export default StyleSheet.create({
   inverted: {
     transform: [
       {
-        scaleY: -1,
+        rotate: '180deg',
       },
     ],
   },

--- a/example/src/screens/Examples/ReanimatedChat/styles.ts
+++ b/example/src/screens/Examples/ReanimatedChat/styles.ts
@@ -11,7 +11,7 @@ export default StyleSheet.create({
   inverted: {
     transform: [
       {
-        scaleY: -1,
+        rotate: '180deg',
       },
     ],
   },


### PR DESCRIPTION
## 📜 Description

Changed a way of achieving inverted `ScrollView`. Old way could cause significant FPS drop if app has long running animation.

## 💡 Motivation and Context

Originally fix/improvement was made in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/76
But it seems like any animation + `scaleY: -1` may lead to significant FPS drop.

The suggested way from comments is the usage of `rotate: '180deg'` instead of `scaleY: -1`. I verified and it works much better and I didn't encounter any issues, so let's rework the approach a little bit and use `rotate: '180deg'` for now.

## 📢 Changelog

### JS
- changed `scaleY: -1` to `rotate: '180deg'`;

## 🤔 How Has This Been Tested?

Tested manually (only example app) on:
- Google Pixel 7 Pro (Android 13, real device);
- iPhone 14 Pro (iOS 16.2, simulator).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://user-images.githubusercontent.com/22820318/216794156-6669db43-2eec-482a-a873-710fdf041fa3.mp4" />|<video src="https://user-images.githubusercontent.com/22820318/216794173-489309a4-66a6-40a2-b100-56a8ef7095fe.mp4" />|

## 📝 Checklist

- [x] CI successfully passed