### PR TITLE
fix: create view using context provided by `createViewInstance` method

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
@@ -11,9 +11,9 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsAnimationCompat
 import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
@@ -26,7 +26,7 @@ class KeyboardAnimationCallback(
   val persistentInsetTypes: Int,
   val deferredInsetTypes: Int,
   dispatchMode: Int = DISPATCH_MODE_STOP,
-  val context: ReactApplicationContext?,
+  val context: ThemedReactContext?,
   val onApplyWindowInsetsListener: OnApplyWindowInsetsListener,
 ) : WindowInsetsAnimationCompat.Callback(dispatchMode), OnApplyWindowInsetsListener {
   private val TAG = KeyboardAnimationCallback::class.qualifiedName

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -13,14 +13,13 @@ import com.reactnativekeyboardcontroller.KeyboardAnimationCallback
 import com.reactnativekeyboardcontroller.R
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
-class KeyboardControllerViewManagerImpl(reactContext: ReactApplicationContext) {
+class KeyboardControllerViewManagerImpl(private val mReactContext: ReactApplicationContext) {
   private val TAG = KeyboardControllerViewManagerImpl::class.qualifiedName
-  private var mReactContext = reactContext
   private var isStatusBarTranslucent = false
 
   fun createViewInstance(reactContext: ThemedReactContext): ReactViewGroup {
     val view = EdgeToEdgeReactViewGroup(reactContext)
-    val activity = mReactContext.currentActivity
+    val activity = reactContext.currentActivity
 
     if (activity == null) {
       Log.w(TAG, "Can not setup keyboard animation listener, since `currentActivity` is null")
@@ -34,10 +33,10 @@ class KeyboardControllerViewManagerImpl(reactContext: ReactApplicationContext) {
       // We explicitly allow dispatch to continue down to binding.messageHolder's
       // child views, so that step 2.5 below receives the call
       dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
-      context = mReactContext,
+      context = reactContext,
       onApplyWindowInsetsListener = { v, insets ->
         val content =
-          mReactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
+          reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
             R.id.action_bar_root,
           )
         content?.setPadding(


### PR DESCRIPTION
## 📜 Description

Use context provided by `createViewInstance` for view creation.

## 💡 Motivation and Context

Partially fixes the problem described in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/113

We need to use actual context provided by `createViewInstance`. Otherwise after hot reloading context may be invalid and keyboard events will not be send to JS thread (since UIManager will be invalid).

## 📢 Changelog

### Android
- use `reactContext` from params instead of constructor value;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro and Xiaomi Redmi Note 5 Pro (real devices).

## 📝 Checklist

- [x] CI successfully passed