### PR TITLE
fix: restart activity to avoid crashes

### DIFF
--- a/FabricExample/android/app/src/main/java/com/keyboardcontrollerfabricexample/MainActivity.java
+++ b/FabricExample/android/app/src/main/java/com/keyboardcontrollerfabricexample/MainActivity.java
@@ -1,5 +1,7 @@
 package com.keyboardcontrollerfabricexample;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
@@ -44,5 +46,10 @@ public class MainActivity extends ReactActivity {
       // More on this on https://reactjs.org/blog/2022/03/29/react-v18.html
       return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
     }
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
   }
 }

--- a/example/android/app/src/main/java/com/example/reactnativekeyboardcontroller/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/reactnativekeyboardcontroller/MainActivity.java
@@ -47,6 +47,6 @@ public class MainActivity extends ReactActivity {
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    super.onCreate(null);
   }
 }


### PR DESCRIPTION
## 📜 Description

Don't persist activity state and always restart it.

## 💡 Motivation and Context

I don't know why I didn't make it before, but it needs to be added in order to reduce amount of occasional crashes. You can read a great explanation [here](https://github.com/software-mansion/react-native-screens#android) on why it's needed.

## 📢 Changelog

### Android
- added `super.onCreate(null)` in `MainActivity` for example apps;

## 🤔 How Has This Been Tested?

Tested manually on emulators.

## 📝 Checklist

- [x] CI successfully passed