### PR TITLE
fix: request apply insets when the view is attached to the hierarchy

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
@@ -1,0 +1,30 @@
+package com.reactnativekeyboardcontroller.extensions
+
+import android.os.Build
+import android.view.View
+
+/**
+ * Call this everytime when using [ViewCompat.setOnApplyWindowInsetsListener]
+ * to ensure that insets are always received.
+ * @see https://stackoverflow.com/a/61909205/9272042
+ */
+fun View.requestApplyInsetsWhenAttached() {
+  // https://chris.banes.dev/2019/04/12/insets-listeners-to-layouts/
+  if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT && isAttachedToWindow) {
+    // We're already attached, just request as normal
+    requestApplyInsets()
+
+  } else {
+    // We're not attached to the hierarchy, add a listener to request when we are
+    addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+      override fun onViewAttachedToWindow(v: View) {
+        v.removeOnAttachStateChangeListener(this)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+          v.requestApplyInsets()
+        }
+      }
+
+      override fun onViewDetachedFromWindow(v: View) = Unit
+    })
+  }
+}

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
@@ -13,7 +13,6 @@ fun View.requestApplyInsetsWhenAttached() {
   if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT && isAttachedToWindow) {
     // We're already attached, just request as normal
     requestApplyInsets()
-
   } else {
     // We're not attached to the hierarchy, add a listener to request when we are
     addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -11,6 +11,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.KeyboardAnimationCallback
 import com.reactnativekeyboardcontroller.R
+import com.reactnativekeyboardcontroller.extensions.requestApplyInsetsWhenAttached
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
 class KeyboardControllerViewManagerImpl(private val mReactContext: ReactApplicationContext) {
@@ -51,6 +52,7 @@ class KeyboardControllerViewManagerImpl(private val mReactContext: ReactApplicat
     )
     ViewCompat.setWindowInsetsAnimationCallback(view, callback)
     ViewCompat.setOnApplyWindowInsetsListener(view, callback)
+    view.requestApplyInsetsWhenAttached()
 
     return view
   }


### PR DESCRIPTION
## 📜 Description

Call `requestApplyInsetsWhenAttached` when `onApplyWindowInsets` listener is added.

## 💡 Motivation and Context

It's needed in order to fix a situation, when after reloading JS bundle first keyboard events are not coming. The problem is reproducible only in bare project (i. e. no other 3rd party libraries), since if you add navigation to your app, then `react-native-screens` will "fix" the problem. But of course it's not reliable to rely on 3rd party libraries behaviour and the library should work in bare project too.

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/113#issuecomment-1424217269

## 📢 Changelog

### Android
- `requestApplyInsets` when the view is attached to the hierarchy;

## 🤔 How Has This Been Tested?

Tested manually on:
- Pixel 3 (API 28, emulator);
- Pixel 7 Pro (API 33, real device)

## 📝 Checklist

- [x] CI successfully passed