### PR TITLE
fix: view props setters on Fabric

### DIFF
--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -3,6 +3,7 @@ package com.reactnativekeyboardcontroller
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.KeyboardControllerViewManagerDelegate
 import com.facebook.react.viewmanagers.KeyboardControllerViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
@@ -23,10 +24,12 @@ class KeyboardControllerViewManager(mReactContext: ReactApplicationContext) : Re
     return manager.createViewInstance(context)
   }
 
+  @ReactProp(name = "statusBarTranslucent")
   override fun setStatusBarTranslucent(view: ReactViewGroup, value: Boolean) {
     return manager.setStatusBarTranslucent(view, value)
   }
 
+  @ReactProp(name = "navigationBarTranslucent")
   override fun setNavigationBarTranslucent(view: ReactViewGroup, value: Boolean) {
     return manager.setNavigationBarTranslucent(view, value)
   }


### PR DESCRIPTION
## 📜 Description

Added `@reactProp` annotation to make view property setters working.

## 💡 Motivation and Context

It seems for RN 0.70 and for fabric we still need to use `@ReactProp` annotation. See an example: https://reactnative.dev/docs/0.70/the-new-architecture/pillars-fabric-components#rtncenteredtextmanagerjava

## 📢 Changelog

### Android
- added `@ReactProp` annotation for view props (`statusBarTranslucent`, `navigationBarTranslucent`) for fabric view manager;

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro (API 33, real device).

## 📝 Checklist

- [x] CI successfully passed