### PR TITLE
chore: sync android styles between example apps (paper & fabric)

### DIFF
--- a/FabricExample/android/app/src/main/res/values/styles.xml
+++ b/FabricExample/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,11 @@
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+
+        <!-- Optional: set to transparent if your app is drawing behind the status bar. -->
+        <item name="android:statusBarColor">
+          @android:color/transparent
+        </item>
     </style>
 
 </resources>


### PR DESCRIPTION
## 📜 Description

Make `StatusBar` translucent on Fabric, since it's also translucent in Paper example.

## 💡 Motivation and Context

Both examples app should have the same codebase (including styles).

## 📢 Changelog

### Android
- `android:statusBarColor=@android:color/transparent`

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro (API 33, real device).

## 📝 Checklist

- [x] CI successfully passed