### PR TITLE
chore: add color for right header in Chat example

### DIFF
--- a/FabricExample/src/screens/Examples/ReanimatedChat/styles.ts
+++ b/FabricExample/src/screens/Examples/ReanimatedChat/styles.ts
@@ -6,6 +6,7 @@ export default StyleSheet.create({
     flex: 1,
   },
   header: {
+    color: 'black',
     marginRight: 12,
   },
   inverted: {

--- a/example/src/screens/Examples/ReanimatedChat/styles.ts
+++ b/example/src/screens/Examples/ReanimatedChat/styles.ts
@@ -6,6 +6,7 @@ export default StyleSheet.create({
     flex: 1,
   },
   header: {
+    color: 'black',
     marginRight: 12,
   },
   inverted: {


### PR DESCRIPTION
## 📜 Description

Specified color for text in right header (chat example).

## 💡 Motivation and Context

If dark theme is turned on on Android devices, then Android may change colors automatically. To assure it looks the same across all themes we need to specify color.

## 📢 Changelog

### JS
- added `color: 'black'` for `header` style in chat example screen;

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro (Android 13).

## 📸 Screenshots (if appropriate):

|Before|After|
|------|------|
|![telegram-cloud-photo-size-2-5221974934337734638-y](https://user-images.githubusercontent.com/22820318/224700833-9d2fa00e-43fc-4210-8305-cefcf904b1f2.jpg)|![telegram-cloud-photo-size-2-5221974934337734639-y](https://user-images.githubusercontent.com/22820318/224700882-6db85f0e-a213-42b0-ad68-17e9cd3e355b.jpg)|

## 📝 Checklist

- [x] CI successfully passed