### PR TITLE
refactor: send `height` as `double` value

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
-class KeyboardTransitionEvent(viewId: Int, private val event: String, private val height: Int, private val progress: Double) : Event<KeyboardTransitionEvent>(viewId) {
+class KeyboardTransitionEvent(viewId: Int, private val event: String, private val height: Double, private val progress: Double) : Event<KeyboardTransitionEvent>(viewId) {
   override fun getEventName() = event
 
   // TODO: All events for a given view can be coalesced?
@@ -13,7 +13,7 @@ class KeyboardTransitionEvent(viewId: Int, private val event: String, private va
   override fun dispatch(rctEventEmitter: RCTEventEmitter) {
     val map = Arguments.createMap()
     map.putDouble("progress", progress)
-    map.putInt("height", height)
+    map.putDouble("height", height)
     rctEventEmitter.receiveEvent(viewTag, eventName, map)
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/Float.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/Float.kt
@@ -2,7 +2,7 @@ package com.reactnativekeyboardcontroller.extensions
 
 import android.content.res.Resources
 
-val Float.dp: Int
-  get() = (this / Resources.getSystem().displayMetrics.density).toInt()
-val Float.px: Int
-  get() = (this * Resources.getSystem().displayMetrics.density).toInt()
+val Float.dp: Double
+  get() = (this / Resources.getSystem().displayMetrics.density).toDouble()
+val Float.px: Double
+  get() = (this * Resources.getSystem().displayMetrics.density).toDouble()

--- a/ios/KeyboardControllerView.mm
+++ b/ios/KeyboardControllerView.mm
@@ -52,21 +52,21 @@ using namespace facebook::react;
                   self->_eventEmitter)
                   ->onKeyboardMoveStart(
                       facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMoveStart{
-                          .height = [height intValue], .progress = [progress floatValue]});
+                          .height = [height doubleValue], .progress = [progress doubleValue]});
             }
             if ([event isEqualToString:@"onKeyboardMove"]) {
               std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(
                   self->_eventEmitter)
                   ->onKeyboardMove(
                       facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMove{
-                          .height = [height intValue], .progress = [progress floatValue]});
+                          .height = [height doubleValue], .progress = [progress doubleValue]});
             }
             if ([event isEqualToString:@"onKeyboardMoveEnd"]) {
               std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(
                   self->_eventEmitter)
                   ->onKeyboardMoveEnd(
                       facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMoveEnd{
-                          .height = [height intValue], .progress = [progress floatValue]});
+                          .height = [height doubleValue], .progress = [progress doubleValue]});
             }
           }
 

--- a/src/specs/KeyboardControllerViewNativeComponent.ts
+++ b/src/specs/KeyboardControllerViewNativeComponent.ts
@@ -2,14 +2,13 @@ import type { HostComponent } from 'react-native';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {
   DirectEventHandler,
-  Float,
-  Int32,
+  Double,
 } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 type KeyboardMoveEvent = Readonly<{
-  height: Int32;
-  progress: Float;
+  height: Double;
+  progress: Double;
 }>;
 
 export interface NativeProps extends ViewProps {


### PR DESCRIPTION
## 📜 Description

Return `height` value as `double` instead of `integer`.

## 💡 Motivation and Context

Rounded values can create an effect of "laggy" animations. It's hard to notice when keyboard simply opens and closes, but it's easy to notice when keyboard becomes interactive (i. e. position can be controlled via gesture). To fix this effect we need to send as precise as possible values.

## 📢 Changelog

### JS
- changed spec of `KeyboardViewController` (now both `progress` and `double` are returned as `double`);

### iOS
- send `height` as double on Fabric architecture;

### Android
- send `height` as double;
- fixed Android studio warnings;

## 🤔 How Has This Been Tested?

Tested both (fabric & paper) on:
- Pixel 7 Pro (real device, Android 13);
- iPhone 14 Pro (emulator, iOS 16.2).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://user-images.githubusercontent.com/22820318/227630300-98ca4ac9-6c15-4d3c-b705-6d8cc87d1fe1.mp4" />|<video src="https://user-images.githubusercontent.com/22820318/227630393-4923b68b-245c-41f6-a072-90a2d92a2ee1.mp4" />|

## 📝 Checklist

- [x] CI successfully passed