### PR TITLE
refactor: short names for `KeyboardGestureArea` component props

### DIFF
--- a/FabricExample/src/screens/Examples/InteractiveKeyboard/index.tsx
+++ b/FabricExample/src/screens/Examples/InteractiveKeyboard/index.tsx
@@ -86,7 +86,7 @@ function InteractiveKeyboard({ navigation }: Props) {
       <KeyboardGestureArea
         style={styles.content}
         interpolator={interpolator}
-        allowToShowKeyboardFromHiddenStateBySwipeUp
+        showOnSwipeUp
       >
         <Reanimated.ScrollView
           showsVerticalScrollIndicator={false}

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
@@ -32,16 +32,13 @@ class KeyboardGestureAreaViewManager(mReactContext: ReactApplicationContext) :
     manager.setInterpolator(view as KeyboardGestureAreaReactViewGroup, value ?: "linear")
   }
 
-  @ReactProp(name = "allowToShowKeyboardFromHiddenStateBySwipeUp")
-  override fun setAllowToShowKeyboardFromHiddenStateBySwipeUp(
-    view: ReactViewGroup,
-    value: Boolean,
-  ) {
+  @ReactProp(name = "showOnSwipeUp")
+  override fun setShowOnSwipeUp(view: ReactViewGroup, value: Boolean) {
     manager.setScrollKeyboardOnScreenWhenNotVisible(view as KeyboardGestureAreaReactViewGroup, value)
   }
 
-  @ReactProp(name = "allowToDragKeyboardFromShownStateBySwipes")
-  override fun setAllowToDragKeyboardFromShownStateBySwipes(view: ReactViewGroup?, value: Boolean) {
+  @ReactProp(name = "enableSwipeToDismiss")
+  override fun setEnableSwipeToDismiss(view: ReactViewGroup?, value: Boolean) {
     manager.setScrollKeyboardOffScreenWhenVisible(view as KeyboardGestureAreaReactViewGroup, value)
   }
 }

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
@@ -21,12 +21,12 @@ class KeyboardGestureAreaViewManager(mReactContext: ReactApplicationContext) : R
     manager.setInterpolator(view, interpolator)
   }
 
-  @ReactProp(name = "allowToShowKeyboardFromHiddenStateBySwipeUp")
+  @ReactProp(name = "showOnSwipeUp")
   fun setScrollKeyboardOnScreenWhenNotVisible(view: KeyboardGestureAreaReactViewGroup, value: Boolean) {
     manager.setScrollKeyboardOnScreenWhenNotVisible(view, value)
   }
 
-  @ReactProp(name = "allowToDragKeyboardFromShownStateBySwipes")
+  @ReactProp(name = "enableSwipeToDismiss")
   fun setScrollKeyboardOffScreenWhenVisible(view: KeyboardGestureAreaReactViewGroup, value: Boolean) {
     manager.setScrollKeyboardOffScreenWhenVisible(view, value)
   }

--- a/docs/docs/api/keyboard-gesture-area.md
+++ b/docs/docs/api/keyboard-gesture-area.md
@@ -19,11 +19,11 @@ String with possible values `linear` and `ios`:
 - **ios** - interactive keyboard dismissing will work as in iOS: swipes in non-keyboard area will not affect keyboard positioning, but if your swipe touches keyboard - keyboard will follow finger position.
 - **linear** - gestures inside the component will linearly affect the position of the keyboard, i.e. if the user swipes down by 20 pixels, then the keyboard will also be moved down by 20 pixels, even if the gesture was not made over the keyboard area.
 
-#### `allowToShowKeyboardFromHiddenStateBySwipeUp`
+#### `showOnSwipeUp`
 
 A boolean prop which allows to customize interactive keyboard behavior. If set to `true` then it allows to show keyboard (if it's already closed) by swipe up gesture. `false` by default.
 
-#### `allowToDragKeyboardFromShownStateBySwipes`
+#### `enableSwipeToDismiss`
 
 A boolean prop which allows to customize interactive keyboard behavior. If set to `false`, then any gesture will not affect keyboard position if the keyboard is shown. `true` by default.
 

--- a/docs/versioned_docs/version-1.5.0/api/keyboard-gesture-area.md
+++ b/docs/versioned_docs/version-1.5.0/api/keyboard-gesture-area.md
@@ -19,11 +19,11 @@ String with possible values `linear` and `ios`:
 - **ios** - interactive keyboard dismissing will work as in iOS: swipes in non-keyboard area will not affect keyboard positioning, but if your swipe touches keyboard - keyboard will follow finger position.
 - **linear** - gestures inside the component will linearly affect the position of the keyboard, i.e. if the user swipes down by 20 pixels, then the keyboard will also be moved down by 20 pixels, even if the gesture was not made over the keyboard area.
 
-#### `allowToShowKeyboardFromHiddenStateBySwipeUp`
+#### `showOnSwipeUp`
 
 A boolean prop which allows to customize interactive keyboard behavior. If set to `true` then it allows to show keyboard (if it's already closed) by swipe up gesture. `false` by default.
 
-#### `allowToDragKeyboardFromShownStateBySwipes`
+#### `enableSwipeToDismiss`
 
 A boolean prop which allows to customize interactive keyboard behavior. If set to `false`, then any gesture will not affect keyboard position if the keyboard is shown. `true` by default.
 

--- a/example/src/screens/Examples/InteractiveKeyboard/index.tsx
+++ b/example/src/screens/Examples/InteractiveKeyboard/index.tsx
@@ -86,7 +86,7 @@ function InteractiveKeyboard({ navigation }: Props) {
       <KeyboardGestureArea
         style={styles.content}
         interpolator={interpolator}
-        allowToShowKeyboardFromHiddenStateBySwipeUp
+        showOnSwipeUp
       >
         <Reanimated.ScrollView
           showsVerticalScrollIndicator={false}

--- a/src/specs/KeyboardGestureAreaNativeComponent.ts
+++ b/src/specs/KeyboardGestureAreaNativeComponent.ts
@@ -5,8 +5,8 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 
 export interface NativeProps extends ViewProps {
   interpolator?: WithDefault<'linear' | 'ios', 'linear'>;
-  allowToShowKeyboardFromHiddenStateBySwipeUp?: boolean;
-  allowToDragKeyboardFromShownStateBySwipes?: boolean;
+  showOnSwipeUp?: boolean;
+  enableSwipeToDismiss?: boolean;
 }
 
 export default codegenNativeComponent<NativeProps>('KeyboardGestureArea', {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,13 +39,13 @@ export type KeyboardGestureAreaProps = {
    * Whether to allow to show a keyboard from dismissed state by swipe up.
    * Default to `false`.
    */
-  allowToShowKeyboardFromHiddenStateBySwipeUp?: boolean;
+  showOnSwipeUp?: boolean;
   /**
    * Whether to allow to control a keyboard by gestures. The strategy how
    * it should be controlled is determined by `interpolator` property.
    * Defaults to `true`.
    */
-  allowToDragKeyboardFromShownStateBySwipes?: boolean;
+  enableSwipeToDismiss?: boolean;
 } & ViewProps;
 
 export type KeyboardControllerModule = {


### PR DESCRIPTION
## 📜 Description

Use shorter name for `KeyboardGestureArea` props.

- `allowToShowKeyboardFromHiddenStateBySwipeUp` -> `showOnSwipeUp`
- `allowToDragKeyboardFromShownStateBySwipes` -> `enableSwipeToDismiss`

## 💡 Motivation and Context

Short names are better. Honestly I also didn't like such big names, but at the time of the implementation I decided not to think about correct names 😅 

By gathering a feedback I've decided to rename it (I've decided not to mark old props as deprecated because it would bring more confusions). I highly doubt there are any people who just started to use this new feature and already shipped it to theirs applications, so I'm going to do a small `1.5.1` release after merging this PR.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS
- renamed props;

### Docs
- renamed props;

### Android
- renamed props and corresponding setters;

## 🤔 How Has This Been Tested?

Tested on emulator.

## 📝 Checklist

- [x] CI successfully passed