### PR TITLE
fix: cleanup kvo

### DIFF
--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -83,41 +83,41 @@ public class KeyboardMovementObserver: NSObject {
       name: UIWindow.didBecomeVisibleNotification,
       object: nil
     )
-      NotificationCenter.default.addObserver(
-        self,
-        selector: #selector(windowDidBecomeHidden),
-        name: UIWindow.didBecomeHiddenNotification,
-        object: nil
-      )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(windowDidBecomeHidden),
+      name: UIWindow.didBecomeHiddenNotification,
+      object: nil
+    )
   }
-    
-    @objc func windowDidBecomeHidden(_: Notification) {
-        removeKVObserver()
-    }
+
+  @objc func windowDidBecomeHidden(_: Notification) {
+    removeKVObserver()
+  }
 
   @objc func windowDidBecomeVisible(_: Notification) {
-      setupKVObserver()
+    setupKVObserver()
   }
-    
-    private func setupKVObserver() {
-        if (hasKVObserver) {
-            return
-        }
-        
-        if (keyboardView != nil) {
-            hasKVObserver = true
-            keyboardView?.addObserver(self, forKeyPath: "center", options: .new, context: nil)
-        }
+
+  private func setupKVObserver() {
+    if hasKVObserver {
+      return
     }
-    
-    private func removeKVObserver() {
-        if (!hasKVObserver) {
-            return
-        }
-        
-        hasKVObserver = false
-        keyboardView?.removeObserver(self, forKeyPath: "center", context: nil)
+
+    if keyboardView != nil {
+      hasKVObserver = true
+      keyboardView?.addObserver(self, forKeyPath: "center", options: .new, context: nil)
     }
+  }
+
+  private func removeKVObserver() {
+    if !hasKVObserver {
+      return
+    }
+
+    hasKVObserver = false
+    keyboardView?.removeObserver(self, forKeyPath: "center", context: nil)
+  }
 
   // swiftlint:disable:next block_based_kvo
   @objc override public func observeValue(


### PR DESCRIPTION
## 📜 Description

Remove KVO when keyboard disappears.

## 💡 Motivation and Context

It seems like we can not attach a single listener to the keyboard when it appeared for the first time. iOS may throw `KVO_IS_RETAINING_ALL_OBSERVERS_OF_THIS_OBJECT_IF_IT_CRASHES_AN_OBSERVER_WAS_OVERRELEASED_OR_SMASHED`, which means, that the memory for the listener was released and thus a handler is corrupted (KVO was released while still observing the key path).

To overcome the problem I've decided to remove observation when keyboard becomes hidden. To detect the moment when keyboard got hidden I used `UIWindow.didBecomeHiddenNotification` (since for attaching a KVO listener I've used `UIWindow.didBecomeVisibleNotification` - the motivation behind "why I've used these lifecycles" is the fact, that these lifecycle methods will be triggered only one time when keyboard appears/disappears, unlike other methods, which can be called several times).

Also I've added a local variable called `hasKVObserver` and two helper functions:
- `setupKVObserver`;
- `removeKVObserver`.

These functions control the value of `hasKVObserver` and assure that we will not call `.removeObserver` if listener is not attached (such situation will cause a crash and using `hasKVObserver` value we avoid it).

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/143

## 📢 Changelog

### iOS
- added `UIWindow.didBecomeVisibleNotification` listener;
- clean KVO when `UIWindow.didBecomeVisibleNotification` is emitted and KVO is present;

## 🤔 How Has This Been Tested?

Tested on:
- iPhone 14 Pro (iOS 16.2, simulator);
- iPhone 6s (iOS 15.7, real device);

## 📝 Checklist

- [x] CI successfully passed