### PR TITLE
refactor: move logic away from manager to `EdgeToEdgeReactViewGroup`

### DIFF
--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -9,6 +9,7 @@ import com.facebook.react.viewmanagers.KeyboardControllerViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
 import com.reactnativekeyboardcontroller.managers.KeyboardControllerViewManagerImpl
+import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
 class KeyboardControllerViewManager(mReactContext: ReactApplicationContext) : ReactViewManager(), KeyboardControllerViewManagerInterface<ReactViewGroup> {
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
@@ -26,12 +27,12 @@ class KeyboardControllerViewManager(mReactContext: ReactApplicationContext) : Re
 
   @ReactProp(name = "statusBarTranslucent")
   override fun setStatusBarTranslucent(view: ReactViewGroup, value: Boolean) {
-    return manager.setStatusBarTranslucent(view, value)
+    return manager.setStatusBarTranslucent(view as EdgeToEdgeReactViewGroup, value)
   }
 
   @ReactProp(name = "navigationBarTranslucent")
   override fun setNavigationBarTranslucent(view: ReactViewGroup, value: Boolean) {
-    return manager.setNavigationBarTranslucent(view, value)
+    return manager.setNavigationBarTranslucent(view as EdgeToEdgeReactViewGroup, value)
   }
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -1,69 +1,21 @@
 package com.reactnativekeyboardcontroller.managers
 
-import android.util.Log
-import androidx.appcompat.widget.FitWindowsLinearLayout
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsAnimationCompat
-import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.views.view.ReactViewGroup
-import com.reactnativekeyboardcontroller.KeyboardAnimationCallback
-import com.reactnativekeyboardcontroller.R
-import com.reactnativekeyboardcontroller.extensions.requestApplyInsetsWhenAttached
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
 class KeyboardControllerViewManagerImpl(private val mReactContext: ReactApplicationContext) {
-  private val TAG = KeyboardControllerViewManagerImpl::class.qualifiedName
-  private var isStatusBarTranslucent = false
-  private var isNavigationBarTranslucent = false
-
-  fun createViewInstance(reactContext: ThemedReactContext): ReactViewGroup {
-    val view = EdgeToEdgeReactViewGroup(reactContext)
-    val activity = reactContext.currentActivity
-
-    if (activity == null) {
-      Log.w(TAG, "Can not setup keyboard animation listener, since `currentActivity` is null")
-      return view
-    }
-
-    val callback = KeyboardAnimationCallback(
-      view = view,
-      persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
-      deferredInsetTypes = WindowInsetsCompat.Type.ime(),
-      // We explicitly allow dispatch to continue down to binding.messageHolder's
-      // child views, so that step 2.5 below receives the call
-      dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
-      context = reactContext,
-      onApplyWindowInsetsListener = { v, insets ->
-        val content =
-          reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
-            R.id.action_bar_root,
-          )
-        content?.setPadding(
-          0,
-          if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0,
-          0,
-          if (this.isNavigationBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0,
-        )
-
-        insets
-      },
-    )
-    ViewCompat.setWindowInsetsAnimationCallback(view, callback)
-    ViewCompat.setOnApplyWindowInsetsListener(view, callback)
-    view.requestApplyInsetsWhenAttached()
-
-    return view
+  fun createViewInstance(reactContext: ThemedReactContext): EdgeToEdgeReactViewGroup {
+    return EdgeToEdgeReactViewGroup(reactContext)
   }
 
-  fun setStatusBarTranslucent(view: ReactViewGroup, isStatusBarTranslucent: Boolean) {
-    this.isStatusBarTranslucent = isStatusBarTranslucent
+  fun setStatusBarTranslucent(view: EdgeToEdgeReactViewGroup, isStatusBarTranslucent: Boolean) {
+    view.setStatusBarTranslucent(isStatusBarTranslucent)
   }
 
-  fun setNavigationBarTranslucent(view: ReactViewGroup, isNavigationBarTranslucent: Boolean) {
-    this.isNavigationBarTranslucent = isNavigationBarTranslucent
+  fun setNavigationBarTranslucent(view: EdgeToEdgeReactViewGroup, isNavigationBarTranslucent: Boolean) {
+    view.setNavigationBarTranslucent(isNavigationBarTranslucent)
   }
 
   fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -1,12 +1,70 @@
 package com.reactnativekeyboardcontroller.views
 
 import android.annotation.SuppressLint
+import android.util.Log
+import androidx.appcompat.widget.FitWindowsLinearLayout
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
+import com.reactnativekeyboardcontroller.KeyboardAnimationCallback
+import com.reactnativekeyboardcontroller.R
+import com.reactnativekeyboardcontroller.extensions.requestApplyInsetsWhenAttached
 
 @SuppressLint("ViewConstructor")
 class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : ReactViewGroup(reactContext) {
+  private val TAG = EdgeToEdgeReactViewGroup::class.qualifiedName
+  private var isStatusBarTranslucent = false
+  private var isNavigationBarTranslucent = false
+
+  init {
+    val activity = reactContext.currentActivity
+
+    if (activity != null) {
+
+      val callback = KeyboardAnimationCallback(
+        view = this,
+        persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
+        deferredInsetTypes = WindowInsetsCompat.Type.ime(),
+        // We explicitly allow dispatch to continue down to binding.messageHolder's
+        // child views, so that step 2.5 below receives the call
+        dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
+        context = reactContext,
+        onApplyWindowInsetsListener = { v, insets ->
+          val content =
+            reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
+              R.id.action_bar_root,
+            )
+          content?.setPadding(
+            0,
+            if (this.isStatusBarTranslucent) {
+              0
+            } else {
+              insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
+                ?: 0
+            },
+            0,
+            if (this.isNavigationBarTranslucent) {
+              0
+            } else {
+              insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom
+                ?: 0
+            },
+          )
+
+          insets
+        },
+      )
+      ViewCompat.setWindowInsetsAnimationCallback(this, callback)
+      ViewCompat.setOnApplyWindowInsetsListener(this, callback)
+      this.requestApplyInsetsWhenAttached()
+    } else {
+      Log.w(TAG, "Can not setup keyboard animation listener, since `currentActivity` is null")
+    }
+  }
+
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
 
@@ -16,5 +74,13 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
         false,
       )
     }
+  }
+
+  fun setStatusBarTranslucent(isStatusBarTranslucent: Boolean) {
+    this.isStatusBarTranslucent = isStatusBarTranslucent
+  }
+
+  fun setNavigationBarTranslucent(isNavigationBarTranslucent: Boolean) {
+    this.isNavigationBarTranslucent = isNavigationBarTranslucent
   }
 }

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -3,26 +3,26 @@ package com.reactnativekeyboardcontroller
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
 import com.reactnativekeyboardcontroller.managers.KeyboardControllerViewManagerImpl
+import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
 class KeyboardControllerViewManager(mReactContext: ReactApplicationContext) : ReactViewManager() {
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
 
   override fun getName(): String = KeyboardControllerViewManagerImpl.NAME
 
-  override fun createViewInstance(reactContext: ThemedReactContext): ReactViewGroup {
+  override fun createViewInstance(reactContext: ThemedReactContext): EdgeToEdgeReactViewGroup {
     return manager.createViewInstance(reactContext)
   }
 
   @ReactProp(name = "statusBarTranslucent")
-  fun setStatusBarTranslucent(view: ReactViewGroup, isStatusBarTranslucent: Boolean) {
+  fun setStatusBarTranslucent(view: EdgeToEdgeReactViewGroup, isStatusBarTranslucent: Boolean) {
     manager.setStatusBarTranslucent(view, isStatusBarTranslucent)
   }
 
   @ReactProp(name = "navigationBarTranslucent")
-  fun setNavigationBarTranslucent(view: ReactViewGroup, isNavigationBarTranslucent: Boolean) {
+  fun setNavigationBarTranslucent(view: EdgeToEdgeReactViewGroup, isNavigationBarTranslucent: Boolean) {
     manager.setNavigationBarTranslucent(view, isNavigationBarTranslucent)
   }
 


### PR DESCRIPTION
## 📜 Description

Moved logic from manager to `EdgeToEdgeReactViewGroup`.

## 💡 Motivation and Context

To align with standard approaches and unify codebase.

When I've added `KeyboardGestureView` I incapsulated all logic inside this view and delegated only method calls to manager. In this PR I've decided to stick with this approach and rework `EdgeToEdgeReactViewGroup`.

Just theoretically setting up of callbacks could be moved to `onAttachedToWindow` method, but I've decided to keep changes as minimal as possible, so I left it as it is.

## 📢 Changelog

### Android
- move logic away from manager to `EdgeToEdgeReactViewGroup`

## 🤔 How Has This Been Tested?

Tested on Pixel 6 (API 28). Both fabric & paper.

## 📝 Checklist

- [x] CI successfully passed