### PR TITLE
fix: react-native-navigation integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Keyboard manager which works in identical way on both iOS and Android.
 - module for changing soft input mode on Android 🤔
 - reanimated support 🚀
 - interactive keyboard dismissing 👆📱
+- works with any navigation library 🧭
 - and more is coming... Stay tuned! 😊
 
 ## Installation

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ViewGroup.kt
@@ -1,0 +1,10 @@
+package com.reactnativekeyboardcontroller.extensions
+
+import android.view.ViewGroup
+
+fun ViewGroup?.removeSelf() {
+  this ?: return
+  val parent = parent as? ViewGroup ?: return
+
+  parent.removeView(this)
+}

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
@@ -5,12 +5,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
 
 class KeyboardControllerModuleImpl(private val mReactContext: ReactApplicationContext) {
-  private val mDefaultMode: Int = mReactContext
-    .currentActivity
-    ?.window
-    ?.attributes
-    ?.softInputMode
-    ?: WindowManager.LayoutParams.SOFT_INPUT_STATE_UNSPECIFIED
+  private val mDefaultMode: Int = getCurrentMode()
 
   fun setInputMode(mode: Int) {
     setSoftInputMode(mode)
@@ -22,8 +17,19 @@ class KeyboardControllerModuleImpl(private val mReactContext: ReactApplicationCo
 
   private fun setSoftInputMode(mode: Int) {
     UiThreadUtil.runOnUiThread {
-      mReactContext.currentActivity?.window?.setSoftInputMode(mode)
+      if (getCurrentMode() != mode) {
+        mReactContext.currentActivity?.window?.setSoftInputMode(mode)
+      }
     }
+  }
+
+  private fun getCurrentMode(): Int {
+    return mReactContext
+      .currentActivity
+      ?.window
+      ?.attributes
+      ?.softInputMode
+      ?: WindowManager.LayoutParams.SOFT_INPUT_STATE_UNSPECIFIED
   }
 
   companion object {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -62,6 +62,7 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
     }
   }
 
+  // region View lifecycles
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
 
@@ -94,9 +95,19 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
         val content = this.getContentView()
         content?.setPadding(
           0,
-          if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0,
+          if (this.isStatusBarTranslucent) {
+            0
+          } else {
+            insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
+              ?: 0
+          },
           0,
-          if (this.isNavigationBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0,
+          if (this.isNavigationBarTranslucent) {
+            0
+          } else {
+            insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom
+              ?: 0
+          },
         )
 
         insets
@@ -115,7 +126,9 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
 
     eventView.removeSelf()
   }
+  // endregion
 
+  // region Props setters
   fun setStatusBarTranslucent(isStatusBarTranslucent: Boolean) {
     this.isStatusBarTranslucent = isStatusBarTranslucent
   }
@@ -123,6 +136,7 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
   fun setNavigationBarTranslucent(isNavigationBarTranslucent: Boolean) {
     this.isNavigationBarTranslucent = isNavigationBarTranslucent
   }
+  // endregion
 
   private fun getContentView(): FitWindowsLinearLayout? {
     return reactContext.currentActivity?.window?.decorView?.rootView?.findViewById(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -25,14 +25,70 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
   private var isNavigationBarTranslucent = false
   private var eventView: ReactViewGroup? = null
 
+  // region View lifecycles
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+
+    val activity = reactContext.currentActivity
+    if (activity == null) {
+      Log.w(TAG, "Can not setup keyboard animation listener, since `currentActivity` is null")
+      return
+    }
+
+    Handler(Looper.getMainLooper()).post(this::setupWindowInsets)
+    WindowCompat.setDecorFitsSystemWindows(
+      activity.window,
+      false,
+    )
+
+    eventView = ReactViewGroup(context)
+    val root = this.getContentView()
+    root?.addView(eventView)
+
+    val callback = KeyboardAnimationCallback(
+      view = this,
+      persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
+      deferredInsetTypes = WindowInsetsCompat.Type.ime(),
+      dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
+      context = reactContext,
+    )
+
+    eventView?.let {
+      ViewCompat.setWindowInsetsAnimationCallback(it, callback)
+      ViewCompat.setOnApplyWindowInsetsListener(it, callback)
+      it.requestApplyInsetsWhenAttached()
+    }
+  }
+
+  override fun onDetachedFromWindow() {
+    super.onDetachedFromWindow()
+
+    eventView.removeSelf()
+  }
+  // endregion
+
+  // region Props setters
+  fun setStatusBarTranslucent(isStatusBarTranslucent: Boolean) {
+    this.isStatusBarTranslucent = isStatusBarTranslucent
+  }
+
+  fun setNavigationBarTranslucent(isNavigationBarTranslucent: Boolean) {
+    this.isNavigationBarTranslucent = isNavigationBarTranslucent
+  }
+  // endregion
+
+  // region Private functions/class helpers
+  private fun getContentView(): FitWindowsLinearLayout? {
+    return reactContext.currentActivity?.window?.decorView?.rootView?.findViewById(
+      androidx.appcompat.R.id.action_bar_root,
+    )
+  }
+
   private fun setupWindowInsets() {
     val rootView = reactContext.rootView
     if (rootView != null) {
       ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
-        val content =
-          reactContext.rootView?.findViewById<FitWindowsLinearLayout>(
-            androidx.appcompat.R.id.action_bar_root,
-          )
+        val content = getContentView()
         val params = FrameLayout.LayoutParams(
           FrameLayout.LayoutParams.MATCH_PARENT,
           FrameLayout.LayoutParams.MATCH_PARENT,
@@ -61,86 +117,5 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
       }
     }
   }
-
-  // region View lifecycles
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-
-    Handler(Looper.getMainLooper()).post(this::setupWindowInsets)
-    reactContext.currentActivity?.let {
-      WindowCompat.setDecorFitsSystemWindows(
-        it.window,
-        false,
-      )
-    }
-
-    val activity = reactContext.currentActivity
-
-    if (activity == null) {
-      Log.w(TAG, "Can not setup keyboard animation listener, since `currentActivity` is null")
-      return
-    }
-
-    eventView = ReactViewGroup(context)
-    val root = this.getContentView()
-    root?.addView(eventView)
-
-    val callback = KeyboardAnimationCallback(
-      view = this,
-      persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
-      deferredInsetTypes = WindowInsetsCompat.Type.ime(),
-      dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
-      context = reactContext,
-      onApplyWindowInsetsListener = { _, insets ->
-        val content = this.getContentView()
-        content?.setPadding(
-          0,
-          if (this.isStatusBarTranslucent) {
-            0
-          } else {
-            insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
-              ?: 0
-          },
-          0,
-          if (this.isNavigationBarTranslucent) {
-            0
-          } else {
-            insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom
-              ?: 0
-          },
-        )
-
-        insets
-      },
-    )
-
-    eventView?.let {
-      ViewCompat.setWindowInsetsAnimationCallback(it, callback)
-      ViewCompat.setOnApplyWindowInsetsListener(it, callback)
-      it.requestApplyInsetsWhenAttached()
-    }
-  }
-
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-
-    eventView.removeSelf()
-  }
   // endregion
-
-  // region Props setters
-  fun setStatusBarTranslucent(isStatusBarTranslucent: Boolean) {
-    this.isStatusBarTranslucent = isStatusBarTranslucent
-  }
-
-  fun setNavigationBarTranslucent(isNavigationBarTranslucent: Boolean) {
-    this.isNavigationBarTranslucent = isNavigationBarTranslucent
-  }
-  // endregion
-
-  private fun getContentView(): FitWindowsLinearLayout? {
-    return reactContext.currentActivity?.window?.decorView?.rootView?.findViewById(
-      R.id.action_bar_root,
-    )
-  }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -13,6 +13,7 @@ import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.KeyboardAnimationCallback
+import com.reactnativekeyboardcontroller.extensions.removeSelf
 import com.reactnativekeyboardcontroller.extensions.requestApplyInsetsWhenAttached
 import com.reactnativekeyboardcontroller.extensions.rootView
 
@@ -22,27 +23,7 @@ private val TAG = EdgeToEdgeReactViewGroup::class.qualifiedName
 class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : ReactViewGroup(reactContext) {
   private var isStatusBarTranslucent = false
   private var isNavigationBarTranslucent = false
-
-  init {
-    val activity = reactContext.currentActivity
-
-    if (activity != null) {
-      val callback = KeyboardAnimationCallback(
-        view = this,
-        persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
-        deferredInsetTypes = WindowInsetsCompat.Type.ime(),
-        // We explicitly allow dispatch to continue down to binding.messageHolder's
-        // child views, so that step 2.5 below receives the call
-        dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
-        context = reactContext,
-      )
-      ViewCompat.setWindowInsetsAnimationCallback(this, callback)
-      ViewCompat.setOnApplyWindowInsetsListener(this, callback)
-      this.requestApplyInsetsWhenAttached()
-    } else {
-      Log.w(TAG, "Can not setup keyboard animation listener, since `currentActivity` is null")
-    }
-  }
+  private var eventView: ReactViewGroup? = null
 
   private fun setupWindowInsets() {
     val rootView = reactContext.rootView
@@ -91,6 +72,56 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
         false,
       )
     }
+
+    val activity = reactContext.currentActivity
+
+    if (activity == null) {
+      Log.w(TAG, "Can not setup keyboard animation listener, since `currentActivity` is null")
+      return
+    }
+
+    eventView = ReactViewGroup(context)
+    val root =
+      activity.window.decorView.rootView.findViewById<FitWindowsLinearLayout>(
+        R.id.action_bar_root,
+      )
+    root.addView(eventView)
+
+    val callback = KeyboardAnimationCallback(
+      view = this,
+      persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
+      deferredInsetTypes = WindowInsetsCompat.Type.ime(),
+      // We explicitly allow dispatch to continue down to binding.messageHolder's
+      // child views, so that step 2.5 below receives the call
+      dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
+      context = reactContext,
+      onApplyWindowInsetsListener = { _, insets ->
+        val content =
+          reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
+            R.id.action_bar_root,
+          )
+        content?.setPadding(
+          0,
+          if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0,
+          0,
+          if (this.isNavigationBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0,
+        )
+
+        insets
+      },
+    )
+
+    eventView?.let {
+      ViewCompat.setWindowInsetsAnimationCallback(it, callback)
+      ViewCompat.setOnApplyWindowInsetsListener(it, callback)
+      it.requestApplyInsetsWhenAttached()
+    }
+  }
+
+  override fun onDetachedFromWindow() {
+    super.onDetachedFromWindow()
+
+    eventView.removeSelf()
   }
 
   fun setStatusBarTranslucent(isStatusBarTranslucent: Boolean) {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -81,25 +81,17 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
     }
 
     eventView = ReactViewGroup(context)
-    val root =
-      activity.window.decorView.rootView.findViewById<FitWindowsLinearLayout>(
-        R.id.action_bar_root,
-      )
-    root.addView(eventView)
+    val root = this.getContentView()
+    root?.addView(eventView)
 
     val callback = KeyboardAnimationCallback(
       view = this,
       persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
       deferredInsetTypes = WindowInsetsCompat.Type.ime(),
-      // We explicitly allow dispatch to continue down to binding.messageHolder's
-      // child views, so that step 2.5 below receives the call
       dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
       context = reactContext,
       onApplyWindowInsetsListener = { _, insets ->
-        val content =
-          reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
-            R.id.action_bar_root,
-          )
+        val content = this.getContentView()
         content?.setPadding(
           0,
           if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0,
@@ -130,5 +122,11 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
 
   fun setNavigationBarTranslucent(isNavigationBarTranslucent: Boolean) {
     this.isNavigationBarTranslucent = isNavigationBarTranslucent
+  }
+
+  private fun getContentView(): FitWindowsLinearLayout? {
+    return reactContext.currentActivity?.window?.decorView?.rootView?.findViewById(
+      R.id.action_bar_root,
+    )
   }
 }


### PR DESCRIPTION
## 📜 Description

Fixed an integration with `react-native-navigation` without hacks.

## 💡 Motivation and Context

To overcome the initial problem I've decided to re-create callback between `onAttachedToWindow`/`onDetachFromWindow` lifecycles. It improves the situation, but at some point of time you still may inconsistent values returned by hook and actual keyboard position.

For me it seems like if the `WindowInsetsAnimationCompat.Callback` is attached to any parent view of the current screen (i. e. `decorView`, `rootView`, etc.), then it can be broken after some navigation cycles.

This solution was inspired by https://github.com/Omelyan/RNNKeyboardController-Test/commit/d5ee7eaf90e0ef90fcf9ed6d71dd1f44803e5e62. If we send events through overlay, then it's never broken. I had a look on a view hierarchy and realised, that overlays are not attached to parent views or to navigation tree:

<img width="672" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/629002ec-7b41-479e-83b0-6122e75c5827">

I got an inspiration from this idea and decided to replicate this mechanism in native code. I've decided to attach a view as a child to `@id/action_bar_root` and setup callback on this view. In this case this view will not be a parent of navigation tree and will not be inside of navigation tree:

<img width="675" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/18fc5714-6260-4b8f-b66a-7cee7ff3bc29">

However such approach didn't work out - it seems like if current view has `onAttachedToWindow`/`onDetachedFromWindow` calls, then Keyboard insets detection in the end will be broken on API < 30.

I've tried to remove this `eventView` in `onDetachedFromWindow` and re-create it again in `onAttachedToWindow` - and such combination worked out.

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/130

## 📢 Changelog

### Android
- setup callbacks in `onAttachedToWindow`;
- add `eventView` as a child of `@id/action_bar_root` view (in `onAttachedToWindow`);
- attach a callback to `eventView` rather than `EdgeToEdgeReactViewGroup` (but still send events through `EdgeToEdgeReactViewGroup` id)
- added `removeSelf` to `ViewGroup` extensions;
- remove `eventView` in `onDetachedFromWindow`;
- change `inputMode` only if new mode is not equal to current one;

### Docs
- update `README.md`;

## 🤔 How Has This Been Tested?

Tested on Pixel 6 Pro (API 28), emulator.

## 📸 Screenshots (if appropriate):

https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/923fe0b6-cdb3-4bca-92e2-44a2c7fe678d

## 📝 Checklist

- [x] CI successfully passed