### PR TITLE
fix: use minSdkVersion from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ if (isNewArchitectureEnabled()) {
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,6 @@
 KeyboardController_kotlinVersion=1.6.21
 KeyboardController_compileSdkVersion=33
 KeyboardController_targetSdkVersion=33
+KeyboardController_minSdkVersion=16
 
 android.useAndroidX=true


### PR DESCRIPTION
## 📜 Description

Use minSdkVersion from root project.

## 💡 Motivation and Context

If you try to assemble test build you'll get next error:

```
Manifest merger failed : uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-android:0.71.3] /Users/kirylziusko/.gradle/caches/transforms-3/8b07754142de06fa88289354ebe36ee0/transformed/jetified-react-android-0.71.3-debug/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
```

It happens because `16` is hardcoded in `minSdkVersion` of this project. Proper solution would be to try to take `minSdkVersion` from root/parent project and only if it doesn't exist fallback to `16`.

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/discussions/150

## 📢 Changelog

### Android
- added `KeyboardController_minSdkVersion=16` in `gradle.properties`;
- switched to `minSdkVersion getExtOrIntegerDefault('minSdkVersion')` instead of `minSdkVersion 16`;

## 🤔 How Has This Been Tested?

Tested via `./gradlew assembleAndroidTest` command in example project.

## 📸 Screenshots (if appropriate):

<img width="1028" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/6c086de8-58a3-43bb-80ff-155ffd177a71">

## 📝 Checklist

- [x] CI successfully passed