### PR TITLE
fix: use old `keyboardView` reference for removing observer

### DIFF
--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -116,7 +116,7 @@ public class KeyboardMovementObserver: NSObject {
     }
 
     hasKVObserver = false
-    keyboardView?.removeObserver(self, forKeyPath: "center", context: nil)
+    _keyboardView?.removeObserver(self, forKeyPath: "center", context: nil)
   }
 
   // swiftlint:disable:next block_based_kvo


### PR DESCRIPTION
## 📜 Description

Use memoized `keyboardView` reference for removing observer.

## 💡 Motivation and Context

Since `keyboardView` is a getter there are some chances that it may return a new reference to a view when we access it.

In some cases it may be a problem, because it can return a reference to a view which doesn't contain an observer yet. As a result when we'll try to remove an observer from a view which doesn't have it -> we'll get a crash.

To prevent a crash in `removeKVObserver` we start to use `_keyboardView` instead of `keyboardView`. It'll give us an access to old view and we can safely remove the observer.

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/155

Potentially also fixes: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/152

## 📢 Changelog

### iOS
- use `_keyboardView` instead of `keyboardView` when remove observer;

## 🤔 How Has This Been Tested?

Tested on iPhone 14 (simulator, iOS 16.2) using following code:

```tsx
<Button title="show image picker" onPress={async () => {
  // You can also use as a promise without 'callback':
  const result = await launchImageLibrary();
}} />
```

## 📸 Screenshots (if appropriate):

|Before|After|
|------|-----|
|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/077f279e-f95b-4aea-ac09-41d8a7d4c846">|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e5a5e9aa-2204-42cc-b767-07d43053bf7d">|

## 📝 Checklist

- [x] CI successfully passed