### PR TITLE
docs: appearance -> movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Keyboard manager which works in identical way on both iOS and Android.
 
 ## Key features
 
-- mapping keyboard appearance to animated values 😎
+- mapping keyboard movement to animated values 😎
 - missing `keyboardWillShow` / `keyboardWillHide` events are available on Android 😍
 - module for changing soft input mode on Android 🤔
 - reanimated support 🚀

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -19,7 +19,7 @@ const FeatureList: FeatureItem[] = [
     lottie: transform,
     description: (
       <>
-        Take an advantage of mapping keyboard appearance to animated values and
+        Take an advantage of mapping keyboard movement to animated values and
         apply any UI transformations that you can imagine 😎
       </>
     ),


### PR DESCRIPTION
## 📜 Description

Changed `appearance` word to `movement`.

## 💡 Motivation and Context

Better to use `movement` since it better describes what this package does.

## 📢 Changelog

### Docs
- appearance -> movement in README;
- appearance -> movement in docs;

## 🤔 How Has This Been Tested?

Tested manually via .md preview.

## 📝 Checklist

- [x] CI successfully passed