### PR TITLE
fix: check if `jsThread` is not null

### DIFF
--- a/ios/KeyboardControllerView.mm
+++ b/ios/KeyboardControllerView.mm
@@ -79,7 +79,7 @@ using namespace facebook::react;
 
           // TODO: use built-in _eventEmitter once NativeAnimated module will use ModernEventemitter
           RCTBridge *bridge = [RCTBridge currentBridge];
-          if (bridge) {
+          if (bridge && [bridge valueForKey@"_jsThread"]) {
             KeyboardMoveEvent *keyboardMoveEvent =
                 [[KeyboardMoveEvent alloc] initWithReactTag:@(self.tag)
                                                       event:event

--- a/ios/KeyboardControllerView.mm
+++ b/ios/KeyboardControllerView.mm
@@ -79,7 +79,7 @@ using namespace facebook::react;
 
           // TODO: use built-in _eventEmitter once NativeAnimated module will use ModernEventemitter
           RCTBridge *bridge = [RCTBridge currentBridge];
-          if (bridge && [bridge valueForKey@"_jsThread"]) {
+          if (bridge && [bridge valueForKey:@"_jsThread"]) {
             KeyboardMoveEvent *keyboardMoveEvent =
                 [[KeyboardMoveEvent alloc] initWithReactTag:@(self.tag)
                                                       event:event

--- a/ios/KeyboardControllerViewManager.swift
+++ b/ios/KeyboardControllerViewManager.swift
@@ -22,7 +22,7 @@ class KeyboardControllerView: UIView {
 
   init(frame: CGRect, bridge: RCTBridge) {
     self.bridge = bridge
-    self.eventDispatcher = bridge.eventDispatcher()
+    eventDispatcher = bridge.eventDispatcher()
     super.init(frame: frame)
   }
 
@@ -47,18 +47,18 @@ class KeyboardControllerView: UIView {
   }
 
   func onEvent(event: NSString, height: NSNumber, progress: NSNumber) {
-      // we don't want to send event to JS before the JS thread is ready
-      if ((bridge.value(forKey: "_jsThread") == nil)) {
-          return
-      }
-      eventDispatcher.send(
-        KeyboardMoveEvent(
-          reactTag: reactTag,
-          event: event as String,
-          height: height,
-          progress: progress
-        )
+    // we don't want to send event to JS before the JS thread is ready
+    if bridge.value(forKey: "_jsThread") == nil {
+      return
+    }
+    eventDispatcher.send(
+      KeyboardMoveEvent(
+        reactTag: reactTag,
+        event: event as String,
+        height: height,
+        progress: progress
       )
+    )
   }
 
   func onNotify(event: String, data: Any) {


### PR DESCRIPTION
## 📜 Description

Added a check for `_jsThread==null` before sending event. Should prevent crash on startup in certain conditions.

## 💡 Motivation and Context

![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/55fe2e15-1e2e-4ca4-bf3b-2fe1ab87b197)

## 📢 Changelog

### iOS
- check `_jsThread` to exist before sending event;

## 🤔 How Has This Been Tested?

Will be tested in live 🙃 

## 📝 Checklist

- [x] CI successfully passed