### PR TITLE
refactor: move `interpolate` function to Extensions

### DIFF
--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  Extensions.swift
+//  KeyboardController
+//
+//  Created by Kiryl Ziusko on 10/06/2023.
+//  Copyright © 2023 Facebook. All rights reserved.
+//
+
+import Foundation
+
+public extension CGFloat {
+    static func interpolate(inputRange: [CGFloat], outputRange: [CGFloat], currentValue: CGFloat) -> CGFloat {
+      let inputMin = inputRange.min() ?? 0
+      let inputMax = inputRange.max() ?? 1
+      let outputMin = outputRange.min() ?? 0
+      let outputMax = outputRange.max() ?? 1
+
+      let normalizedValue = (currentValue - inputMin) / (inputMax - inputMin)
+      let interpolatedValue = outputMin + (outputMax - outputMin) * normalizedValue
+
+      return interpolatedValue
+    }
+}

--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -9,15 +9,15 @@
 import Foundation
 
 public extension CGFloat {
-    static func interpolate(inputRange: [CGFloat], outputRange: [CGFloat], currentValue: CGFloat) -> CGFloat {
-      let inputMin = inputRange.min() ?? 0
-      let inputMax = inputRange.max() ?? 1
-      let outputMin = outputRange.min() ?? 0
-      let outputMax = outputRange.max() ?? 1
+  static func interpolate(inputRange: [CGFloat], outputRange: [CGFloat], currentValue: CGFloat) -> CGFloat {
+    let inputMin = inputRange.min() ?? 0
+    let inputMax = inputRange.max() ?? 1
+    let outputMin = outputRange.min() ?? 0
+    let outputMax = outputRange.max() ?? 1
 
-      let normalizedValue = (currentValue - inputMin) / (inputMax - inputMin)
-      let interpolatedValue = outputMin + (outputMax - outputMin) * normalizedValue
+    let normalizedValue = (currentValue - inputMin) / (inputMax - inputMin)
+    let interpolatedValue = outputMin + (outputMax - outputMin) * normalizedValue
 
-      return interpolatedValue
-    }
+    return interpolatedValue
+  }
 }

--- a/ios/KeyboardController.xcodeproj/project.pbxproj
+++ b/ios/KeyboardController.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0807071E2A34807B00C05A19 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0807071D2A34807B00C05A19 /* Extensions.swift */; };
 		F333F8D428996B8D0015B05F /* KeyboardControllerView.mm in Sources */ = {isa = PBXBuildFile; fileRef = F333F8D228996B8D0015B05F /* KeyboardControllerView.mm */; };
 		F359D34F28133C26000B6AFE /* KeyboardControllerModule.mm in Sources */ = {isa = PBXBuildFile; fileRef = F359D34E28133C26000B6AFE /* KeyboardControllerModule.mm */; };
 		F3626A0728B3FE760021B2D9 /* KeyboardMovementObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3626A0628B3FE760021B2D9 /* KeyboardMovementObserver.swift */; };
@@ -27,6 +28,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0807071D2A34807B00C05A19 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libKeyboardController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libKeyboardController.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5891CC2AC0600A0062D /* KeyboardControllerViewManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = KeyboardControllerViewManager.mm; sourceTree = "<group>"; };
 		F333F8D128996B1C0015B05F /* KeyboardControllerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardControllerView.h; sourceTree = "<group>"; };
@@ -62,6 +64,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				0807071D2A34807B00C05A19 /* Extensions.swift */,
 				F3F50667289E653B003091D6 /* KeyboardMoveEvent.h */,
 				F3F50668289E653B003091D6 /* KeyboardMoveEvent.m */,
 				F3626A0628B3FE760021B2D9 /* KeyboardMovementObserver.swift */,
@@ -134,6 +137,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F3626A0728B3FE760021B2D9 /* KeyboardMovementObserver.swift in Sources */,
+				0807071E2A34807B00C05A19 /* Extensions.swift in Sources */,
 				F359D34F28133C26000B6AFE /* KeyboardControllerModule.mm in Sources */,
 				F4FF95D7245B92E800C19C63 /* KeyboardControllerViewManager.swift in Sources */,
 				F333F8D428996B8D0015B05F /* KeyboardControllerView.mm in Sources */,

--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -8,18 +8,6 @@
 
 import Foundation
 
-func interpolate(inputRange: [CGFloat], outputRange: [CGFloat], currentValue: CGFloat) -> CGFloat {
-  let inputMin = inputRange.min() ?? 0
-  let inputMax = inputRange.max() ?? 1
-  let outputMin = outputRange.min() ?? 0
-  let outputMax = outputRange.max() ?? 1
-
-  let normalizedValue = (currentValue - inputMin) / (inputMax - inputMin)
-  let interpolatedValue = outputMin + (outputMax - outputMin) * normalizedValue
-
-  return interpolatedValue
-}
-
 @objc(KeyboardMovementObserver)
 public class KeyboardMovementObserver: NSObject {
   // class members
@@ -137,7 +125,7 @@ public class KeyboardMovementObserver: NSObject {
       let keyboardFrameY = (change?[.newKey] as! NSValue).cgPointValue.y
       let keyboardWindowH = keyboardView?.window?.bounds.size.height ?? 0
       let keyboardPosition = keyboardWindowH - keyboardFrameY
-      let position = interpolate(
+      let position = CGFloat.interpolate(
         inputRange: [keyboardHeight / 2, -keyboardHeight / 2],
         outputRange: [keyboardHeight, 0],
         currentValue: keyboardPosition


### PR DESCRIPTION
## 📜 Description

Moved `interpolate` function to Extensions.

## 💡 Motivation and Context

To follow SOLID principles -> each file should have own responsibility. From my point of view it's not correct to keep `interpolate` function in `KeyboardMovementObserver`, so in this PR I've created a new file and moved `interpolate` implementation to this file.

In future I'll create more extensions 🙂 

## 📢 Changelog

### iOS
- added `Extensions.swift` file;
- move `interpolate` function to `Extensions.swift`.

## 🤔 How Has This Been Tested?

Tested manually on simulator.

## 📝 Checklist

- [x] CI successfully passed