### PR TITLE
fix: Add compatibility with native iOS navigation

### DIFF
--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -151,21 +151,19 @@ export const KeyboardProvider = ({
         statusBarTranslucent={statusBarTranslucent}
         style={styles.container}
       >
-        <>
-          <Animated.View
-            // we are using this small hack, because if the component (where
-            // animated value has been used) is unmounted, then animation will
-            // stop receiving events (seems like it's react-native optimization).
-            // So we need to keep a reference to the animated value, to keep it's
-            // always mounted (keep a reference to an animated value).
-            //
-            // To test why it's needed, try to open screen which consumes Animated.Value
-            // then close it and open it again (for example 'Animated transition').
-            style={style}
-          />
-          {children}
-        </>
+            {children}
       </KeyboardControllerViewAnimated>
+      <Animated.View
+        // we are using this small hack, because if the component (where
+        // animated value has been used) is unmounted, then animation will
+        // stop receiving events (seems like it's react-native optimization).
+        // So we need to keep a reference to the animated value, to keep it's
+        // always mounted (keep a reference to an animated value).
+        //
+        // To test why it's needed, try to open screen which consumes Animated.Value
+        // then close it and open it again (for example 'Animated transition').
+        style={style}
+      />
     </KeyboardContext.Provider>
   );
 };

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -151,7 +151,7 @@ export const KeyboardProvider = ({
         statusBarTranslucent={statusBarTranslucent}
         style={styles.container}
       >
-            {children}
+        {children}
       </KeyboardControllerViewAnimated>
       <Animated.View
         // we are using this small hack, because if the component (where


### PR DESCRIPTION
## 📜 Description
On native ios navigation, tabBarController does not add blur unless scrollView is first in the component hierarchy. 
It is necessary that an empty view is declared only after children.
Wrong behavior:
<img width="340" alt="Снимок экрана 2023-06-13 в 17 23 37" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/63238943/5488bd74-5dea-4afa-8832-cf491566f707">
Right behavior:
<img width="345" alt="Снимок экрана 2023-06-13 в 17 23 49" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/63238943/15249057-bbc4-4cb9-bfe6-e051cab9191f">


## 💡 Motivation and Context
This fix adds maximum compatibility with native iOS navigation.

## 📢 Changelog
changed an order of the "view" component

## 🤔 How Has This Been Tested?
To test the change, I use my native navigation library for ios. In this case, we just need to test that the change didn't break keyboard behavior.

## 📝 Checklist
- [ ] CI successfully passed