### PR TITLE
refactor: support for non-transitive R-classes

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -35,7 +35,7 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
         onApplyWindowInsetsListener = { v, insets ->
           val content =
             reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
-              R.id.action_bar_root,
+              androidx.appcompat.R.id.action_bar_root,
             )
           content?.setPadding(
             0,


### PR DESCRIPTION
## 📜 Description

Added support for upcoming non-transitive R-classes.

## 💡 Motivation and Context

For upcoming Android Studio Flamingo release and Android Gradle Plugin (AGP) 8.0 it's important to support transitive R-classes. Otherwise the build will fail.

In this PR I've changed `R.id.action_bar_root,` to `androidx.appcompat.R.id.action_bar_root`. Initially Android Studio offers to use `com.facebook.react` prefix, but I believe `androidx.appcompat` is more appropriate prefix, since `R.id.action_bar_root` is available for all android apps even built without react-native.

## 📢 Changelog

### Android
- changed`R.id.action_bar_root` -> `androidx.appcompat.R.id.action_bar_root`;

## 🤔 How Has This Been Tested?

Tested manually on example app.

## 📸 Screenshots (if appropriate):

I've added `android.nonTransitiveRClass=true` to `gradle.properties` - build is successful:

<img width="873" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/2698b914-e45c-4010-8ae5-c72a2bbf8da4">

## 📝 Checklist

- [x] CI successfully passed