### PR TITLE
chore: set library namespace in build script

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,11 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.reactnativekeyboardcontroller"
+  }
+
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')


### PR DESCRIPTION
## 📜 Description

Set library namespace in `build.gradle` script.

## 💡 Motivation and Context

In preparation for RN 0.73 and AGP 8.0 we need to specify `namespace` in `build.gradle` and remove `package` from `AndroidManifest.xml`.

In this PR I'm specifying `namespace`, because on AGP < 7 it may lead to build failures.

Also I'm not removing `package` from `AndroidManifest.xml`, since if I do this, then builds on AGP < 8 will fail. With `package` present in `AndroidManifest.xml` and AGP > 8 it'll just show a warning. I decided to go in this direction - maybe later I'll remove `package` from `AndroidManifest.xml` when AGP 8 will be a standard in RN community.

## 📢 Changelog

### Android
- specified `namespace` conditionally;

## 🤔 How Has This Been Tested?

Tested via manual build and builds on CI 🙂 

## 📝 Checklist

- [x] CI successfully passed