### PR TITLE
docs: info about new fields

### DIFF
--- a/docs/docs/api/hooks/use-keyboard-handler/index.mdx
+++ b/docs/docs/api/hooks/use-keyboard-handler/index.mdx
@@ -50,7 +50,9 @@ Since `onMove` handler on iOS is based on `CADisplayLink` usage - you may need t
 ### Event structure
 
 - `height` - height of the keyboard;
-- `progress` - a value between `0` (closed) and `1` (opened) indicating relative keyboard position.
+- `progress` - a value between `0` (closed) and `1` (opened) indicating relative keyboard position;
+- `duration` - duration of the animation;
+- `target` - tag of the focused `TextInput` (or `-1` if the tag is not found).
 
 ### Handlers
 

--- a/docs/docs/api/keyboard-events.md
+++ b/docs/docs/api/keyboard-events.md
@@ -12,6 +12,19 @@ This library exposes 4 events which are available on all platforms:
 - keyboardDidShow
 - keyboardDidHide
 
+## Event structure
+
+All events have following properties:
+
+```ts
+type KeyboardEventData = {
+  height: number; // height of the keyboard
+  duration: number; // duration of the animation
+  timestamp: number; // timestamp of the event in a native thread
+  target: number; // tag of the focused TextInput
+};
+```
+
 ## Example
 
 ```ts

--- a/docs/docs/api/keyboard-events.md
+++ b/docs/docs/api/keyboard-events.md
@@ -20,7 +20,7 @@ All events have following properties:
 type KeyboardEventData = {
   height: number; // height of the keyboard
   duration: number; // duration of the animation
-  timestamp: number; // timestamp of the event in a native thread
+  timestamp: number; // timestamp of the event from native thread
   target: number; // tag of the focused TextInput
 };
 ```


### PR DESCRIPTION
## 📜 Description

Added a documentation about new fields:
- duration;
- timestamp;
- target;

## 💡 Motivation and Context

Without documentation it'll be hard to know, that these fields exist 😅 

## 📢 Changelog

### Docs
- added info about `duration`, `timestamp` and `target` fields;

## 🤔 How Has This Been Tested?

Tested on localhost:3000

## 📸 Screenshots (if appropriate):

<img width="1005" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/cb15a3d4-1214-4b9b-a2c6-6ca0b6d8870c">

<img width="1005" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/77bfc896-97ef-404e-b144-1898212f7912">

## 📝 Checklist

- [x] CI successfully passed