### PR TITLE
fix: ignore invalid values from KVO

### DIFF
--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -103,7 +103,7 @@ public class KeyboardMovementObserver: NSObject {
       // if keyboard height is not equal to its bounds - we can ignore
       // values, since they'll be invalid and will cause UI jumps
       if keyboardView?.bounds.size.height != keyboardHeight {
-         return
+        return
       }
 
       // swiftlint:disable:next force_cast

--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -100,6 +100,11 @@ public class KeyboardMovementObserver: NSObject {
       if displayLink != nil {
         return
       }
+      // if keyboard height is not equal to its bounds - we can ignore
+      // values, since they'll be invalid and will cause UI jumps
+      if keyboardView?.bounds.size.height != keyboardHeight {
+         return
+      }
 
       // swiftlint:disable:next force_cast
       let keyboardFrameY = (change?[.newKey] as! NSValue).cgPointValue.y


### PR DESCRIPTION
## 📜 Description

Ignore values from KVO when they're considered as invalid.

## 💡 Motivation and Context

There was a problem, that on some devices when you complete interaction with the keyboard KVO may submit two random events, for example (below I include last valid event + 2 subsequent invalid events):
- 52/160/108;
- 15/123/108;
- 103/211/108;
- 56/164/108.

It's values for `keyboardPosition` variable which is calculated in next way:

```swift
let keyboardFrameY = (change?[.newKey] as! NSValue).cgPointValue.y
let keyboardWindowH = keyboardView?.window?.bounds.size.height ?? 0
let keyboardPosition = keyboardWindowH - keyboardFrameY
```

As you can see there is a pattern:
- we take last event and sum it up with 2 random event -> we get first random event (52+108=160);
- we submit last event as constant (it never changes over time - 108).

After some investigation I've discovered, that 108 directly depends on screen size. Initially I wanted to create a map with screen size/magic value, but such solution will add an unbelievable amount of complexity. So I decided to go further and compare my implementation with other implementations.

I compared it with `react-native-ui-lib` by `Wix`, and discovered, that they also take `bounds` of `superview` (read it as `keyboardView`) into consideration. I've reused their code, and their code submit only one invalid value. I've decided to log every value for each variable and discovered, that when keyboard is under interactive gesture, then it has bounds equal to its height. And when it reports invalid values - bounds are not equal to the size of the keyboard (in my case it was 75 (`bounds`) vs 336 (`keyboardHeight`) on iPhone 14 Pro).

Taking the info from above I decided to add one `if` statement to avoid unnecessary values from KVO. I've tested new implementation and it works really good 😎 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/184

## 📢 Changelog

### iOS
- compare bounds of `keyboardView` with `keyboardHeight`.

## 🤔 How Has This Been Tested?

Tested manually on:
- iPhone 14 Pro (iOS 16.4, simulator);
- iPhone 11 (iOS 16.5.1, real device).

## 📸 Screenshots (if appropriate):

|Before|After|
|------|-----|
|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/530d08c1-4855-45d9-8c34-d451db52c10b">|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/13159f54-2e85-4623-a169-5aae7f5df7ea">|

## 📝 Checklist

- [x] CI successfully passed