### PR TITLE
fix: casting UIView to UIView always succeeds

### DIFF
--- a/ios/KeyboardMovementObserver.swift
+++ b/ios/KeyboardMovementObserver.swift
@@ -208,7 +208,7 @@ public class KeyboardMovementObserver: NSObject {
           if subview.description.hasPrefix("<UIInputSetContainerView") {
             for hostView in subview.subviews {
               if hostView.description.hasPrefix("<UIInputSetHostView") {
-                result = hostView as? UIView
+                result = hostView
                 break
               }
             }


### PR DESCRIPTION
## 📜 Description
<!-- Describe your changes in detail -->

The line `result = hostView as? UIView` will not give any error but it is superfluous.

You're traversing a hierarchy of subviews, which are all UIView objects. In Swift, subviews is an array of UIView.

## 💡 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Just housekeeping a bit :)

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS
- 
- 

### iOS
- 
- 

### Android
- 
- 

## 🤔 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iOS Device and Simulator

## 📸 Screenshots (if appropriate):
<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed