### PR TITLE
fix: pass `velocityY=null` if keyboard didn't change its height

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,2 @@
+- (x) keyboard is shown, scroll to top, press button to hide keyboard -> transition without animation (because persistedHeight is updated to 0)
+- (x) keyboard is shown, scroll to top, press button to hide keyboard, open lottie example -> lottie is not reacting on keyboard movement (because InteractiveKeyboard.isInteractive is not resetting to false)

--- a/TODO
+++ b/TODO
@@ -1,2 +1,0 @@
-- (x) keyboard is shown, scroll to top, press button to hide keyboard -> transition without animation (because persistedHeight is updated to 0)
-- (x) keyboard is shown, scroll to top, press button to hide keyboard, open lottie example -> lottie is not reacting on keyboard movement (because InteractiveKeyboard.isInteractive is not resetting to false)

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
@@ -145,12 +145,14 @@ class KeyboardAnimationCallback(
     super.onEnd(animation)
 
     isTransitioning = false
+
+    var keyboardHeight = this.persistentKeyboardHeight
     // if keyboard becomes shown after interactive animation completion
     // getCurrentKeyboardHeight() will be `0` and isKeyboardVisible will be `false`
     // it's not correct behavior, so we are handling it here
     val isKeyboardShown = InteractiveKeyboardProvider.shown
     if (!isKeyboardShown) {
-      this.persistentKeyboardHeight = getCurrentKeyboardHeight()
+      keyboardHeight = getCurrentKeyboardHeight()
     } else {
       // if keyboard is shown after interactions and the animation has finished
       // then we need to reset the state
@@ -158,8 +160,8 @@ class KeyboardAnimationCallback(
     }
     isKeyboardVisible = isKeyboardVisible || isKeyboardShown
 
-    this.emitEvent("KeyboardController::" + if (!isKeyboardVisible) "keyboardDidHide" else "keyboardDidShow", getEventParams(this.persistentKeyboardHeight))
-    this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMoveEnd", this.persistentKeyboardHeight, if (!isKeyboardVisible) 0.0 else 1.0))
+    this.emitEvent("KeyboardController::" + if (!isKeyboardVisible) "keyboardDidHide" else "keyboardDidShow", getEventParams(keyboardHeight))
+    this.sendEventToJS(KeyboardTransitionEvent(view.id, "topKeyboardMoveEnd", keyboardHeight, if (!isKeyboardVisible) 0.0 else 1.0))
   }
 
   private fun isKeyboardVisible(): Boolean {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationController.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationController.kt
@@ -284,8 +284,14 @@ internal class KeyboardAnimationController {
         velocityY = velocityY,
       )
       // The current inset matches either the shown/hidden inset, finish() immediately
-      current == shown -> controller.finish(true)
-      current == hidden -> controller.finish(false)
+      current == shown -> {
+        InteractiveKeyboardProvider.shown = true
+        controller.finish(true)
+      }
+      current == hidden -> {
+        InteractiveKeyboardProvider.shown = false
+        controller.finish(false)
+      }
       else -> {
         // Otherwise, we'll look at the current position...
         if (controller.currentFraction >= SCROLL_THRESHOLD) {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
@@ -31,6 +31,7 @@ class KeyboardGestureAreaReactViewGroup(private val reactContext: ThemedReactCon
   private var lastTouchX = 0f
   private var lastTouchY = 0f
   private var lastWindowY = 0
+  private var keyboardHeight = 0
 
   // react props
   private var interpolator: Interpolator = LinearInterpolator()
@@ -87,6 +88,9 @@ class KeyboardGestureAreaReactViewGroup(private val reactContext: ThemedReactCon
 
         if (isHandling) {
           if (controller.isInsetAnimationInProgress()) {
+            if (keyboardHeight == 0) {
+              this.keyboardHeight = controller.getCurrentKeyboardHeight()
+            }
             // If we currently have control, we can update the IME insets to 'scroll'
             // the IME in
             val moveBy = this.interpolator.interpolate(dy.roundToInt(), this.getWindowHeight() - event.rawY.toInt(), controller.getCurrentKeyboardHeight())
@@ -122,10 +126,18 @@ class KeyboardGestureAreaReactViewGroup(private val reactContext: ThemedReactCon
         // Calculate the current velocityY, over 500 milliseconds
         velocityTracker?.computeCurrentVelocity(500)
         val velocityY = velocityTracker?.yVelocity
+        val isKeyboardPositionChanged =
+          // check `isInsetAnimationInProgress()` before, since direct usage of `getCurrentKeyboardHeight()`
+          // may throw exception
+          !controller.isInsetAnimationInProgress() ||
+            this.keyboardHeight != controller.getCurrentKeyboardHeight()
+        // if keyboard was changed after finger movement -> we need to calculate final position
+        // and make an animated transition
+        val passedVelocityY = if (isKeyboardPositionChanged) velocityY else null
 
         // If we received a ACTION_UP event, end any current WindowInsetsAnimation passing
         // in the calculated Y velocity
-        controller.animateToFinish(velocityY)
+        controller.animateToFinish(passedVelocityY)
 
         // Reset our touch handling state
         reset()
@@ -162,6 +174,7 @@ class KeyboardGestureAreaReactViewGroup(private val reactContext: ThemedReactCon
     lastTouchX = 0f
     lastTouchY = 0f
     lastWindowY = 0
+    keyboardHeight = 0
     bounds.setEmpty()
 
     velocityTracker?.recycle()

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
@@ -131,7 +131,7 @@ class KeyboardGestureAreaReactViewGroup(private val reactContext: ThemedReactCon
           // may throw exception
           !controller.isInsetAnimationInProgress() ||
             this.keyboardHeight != controller.getCurrentKeyboardHeight()
-        // if keyboard was changed after finger movement -> we need to calculate final position
+        // if keyboard height was changed after finger movement -> we need to calculate final position
         // and make an animated transition
         val passedVelocityY = if (isKeyboardPositionChanged) velocityY else null
 


### PR DESCRIPTION
## 📜 Description

Don't hide keyboard if gesture didn't affect its position.

## 💡 Motivation and Context

Initially I fixed this problem by excluding a call to `animateToFinish`. However it brought more problems:
- since `InteractiveKeyboard.isInteractive` value couldn't be reset in some cases (when interaction with keyboard was completed), it could lead to unpredictable results (for example `onInteractive` event will be emitted instead of `onMove` for plain keyboard events);
- when you hide a keyboard by pressing hide button when interactive gestures were finished - `onMove` events were not coming (because `progress` was `Infinity` and couldn't be serialised via bridge - it happened because in `onEnd` callback we were updating `persistentKeyboardHeight` value, but `getCurrentKeyboardHeight()` was returning `0` - it happened because `InteractiveKeyboardProvider.shown` had incorrect values).

To overcome issue 1 I decided to call `animateToFinish(null)` if keyboard size wasn't changed. In this case we specify `InteractiveKeyboardProvider.isInteractive = false` and `isInteractive` state becomes correct one.

To overcome issue 2 I had few ideas:
- do not update `persistentKeyboardHeight` in `onEnd` - it fixes the problem, but since we update `isVisible` value in `onEnd` -> state machine becomes broken, because `isVisible` will be `false`, and as a result handler in `onApplyWindowInsets` will not be called;
- update `InteractiveKeyboardProvider.shown` in `KeyboardAnimationController` - it fully fixes the problem (actually we always should update `InteractiveKeyboardProvider.shown` before a call to `controller.finish(boolean)`).

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/185

## 📢 Changelog

### Android
- pass `velocityY=null` if keyboard size wasn't changed;
- update `InteractiveKeyboard.shown` before call `controller.finish(boolean)`

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/fe4c01d6-b82d-42e9-a4cb-f3ce619edebf">|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/567c509b-22c8-4bf5-872d-9273b59a2e13">|

## 📝 Checklist

- [x] CI successfully passed