### PR TITLE
refactor: new way for handling insets

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
@@ -31,7 +31,6 @@ class KeyboardAnimationCallback(
   val deferredInsetTypes: Int,
   dispatchMode: Int = DISPATCH_MODE_STOP,
   val context: ThemedReactContext?,
-  val onApplyWindowInsetsListener: OnApplyWindowInsetsListener,
 ) : WindowInsetsAnimationCompat.Callback(dispatchMode), OnApplyWindowInsetsListener {
   private var persistentKeyboardHeight = 0.0
   private var isKeyboardVisible = false
@@ -158,7 +157,7 @@ class KeyboardAnimationCallback(
       this.persistentKeyboardHeight = keyboardHeight
     }
 
-    return onApplyWindowInsetsListener.onApplyWindowInsets(v, insets)
+    return insets
   }
 
   override fun onStart(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
@@ -1,0 +1,7 @@
+package com.reactnativekeyboardcontroller.extensions
+
+import android.view.View
+import com.facebook.react.uimanager.ThemedReactContext
+
+val ThemedReactContext.rootView: View?
+  get() = this.currentActivity?.window?.decorView?.rootView

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -51,13 +51,26 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
           reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
             androidx.appcompat.R.id.action_bar_root,
           )
-        val params = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
+        val params = FrameLayout.LayoutParams(
+          FrameLayout.LayoutParams.MATCH_PARENT,
+          FrameLayout.LayoutParams.MATCH_PARENT,
+        )
 
         params.setMargins(
           0,
-          if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0,
+          if (this.isStatusBarTranslucent) {
+            0
+          } else {
+            insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
+              ?: 0
+          },
           0,
-          if (this.isNavigationBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0,
+          if (this.isNavigationBarTranslucent) {
+            0
+          } else {
+            insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom
+              ?: 0
+          },
         )
 
         content?.layoutParams = params

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -14,6 +14,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.KeyboardAnimationCallback
 import com.reactnativekeyboardcontroller.extensions.requestApplyInsetsWhenAttached
+import com.reactnativekeyboardcontroller.extensions.rootView
 
 private val TAG = EdgeToEdgeReactViewGroup::class.qualifiedName
 
@@ -44,11 +45,11 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
   }
 
   private fun setupWindowInsets() {
-    val v = reactContext.currentActivity?.window?.decorView?.rootView
-    if (v != null) {
-      ViewCompat.setOnApplyWindowInsetsListener(v) { v, insets ->
+    val rootView = reactContext.rootView
+    if (rootView != null) {
+      ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
         val content =
-          reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
+          reactContext.rootView?.findViewById<FitWindowsLinearLayout>(
             androidx.appcompat.R.id.action_bar_root,
           )
         val params = FrameLayout.LayoutParams(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -1,16 +1,15 @@
 package com.reactnativekeyboardcontroller.views
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
+import android.widget.FrameLayout
 import androidx.appcompat.widget.FitWindowsLinearLayout
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsAnimationCompat
-import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.*
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.KeyboardAnimationCallback
-import com.reactnativekeyboardcontroller.R
 import com.reactnativekeyboardcontroller.extensions.requestApplyInsetsWhenAttached
 
 private val TAG = EdgeToEdgeReactViewGroup::class.qualifiedName
@@ -24,7 +23,6 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
     val activity = reactContext.currentActivity
 
     if (activity != null) {
-
       val callback = KeyboardAnimationCallback(
         view = this,
         persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
@@ -33,30 +31,6 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
         // child views, so that step 2.5 below receives the call
         dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
         context = reactContext,
-        onApplyWindowInsetsListener = { v, insets ->
-          val content =
-            reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
-              androidx.appcompat.R.id.action_bar_root,
-            )
-          content?.setPadding(
-            0,
-            if (this.isStatusBarTranslucent) {
-              0
-            } else {
-              insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
-                ?: 0
-            },
-            0,
-            if (this.isNavigationBarTranslucent) {
-              0
-            } else {
-              insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom
-                ?: 0
-            },
-          )
-
-          insets
-        },
       )
       ViewCompat.setWindowInsetsAnimationCallback(this, callback)
       ViewCompat.setOnApplyWindowInsetsListener(this, callback)
@@ -66,9 +40,45 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
     }
   }
 
+  private fun setupWindowInsets() {
+    val v = reactContext.currentActivity?.window?.decorView?.rootView
+    if (v != null) {
+      ViewCompat.setOnApplyWindowInsetsListener(v) { v, insets ->
+        val content =
+          reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
+            androidx.appcompat.R.id.action_bar_root,
+          )
+        println(
+          "12121212 ${insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top}, ${
+            insets?.getInsets(
+              WindowInsetsCompat.Type.navigationBars()
+            )?.bottom
+          }"
+        )
+        val params = FrameLayout.LayoutParams(
+          FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT
+        )
+
+        params.setMargins(
+          0,
+          if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
+            ?: 0,
+          0,
+          if (this.isNavigationBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom
+            ?: 0
+        )
+
+        content?.layoutParams = params
+
+        insets
+      }
+    }
+  }
+
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
 
+    Handler(Looper.getMainLooper()).post(this::setupWindowInsets)
     reactContext.currentActivity?.let {
       WindowCompat.setDecorFitsSystemWindows(
         it.window,

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -6,7 +6,10 @@ import android.os.Looper
 import android.util.Log
 import android.widget.FrameLayout
 import androidx.appcompat.widget.FitWindowsLinearLayout
-import androidx.core.view.*
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.KeyboardAnimationCallback
@@ -48,24 +51,13 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
           reactContext.currentActivity?.window?.decorView?.rootView?.findViewById<FitWindowsLinearLayout>(
             androidx.appcompat.R.id.action_bar_root,
           )
-        println(
-          "12121212 ${insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top}, ${
-            insets?.getInsets(
-              WindowInsetsCompat.Type.navigationBars()
-            )?.bottom
-          }"
-        )
-        val params = FrameLayout.LayoutParams(
-          FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT
-        )
+        val params = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
 
         params.setMargins(
           0,
-          if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
-            ?: 0,
+          if (this.isStatusBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0,
           0,
-          if (this.isNavigationBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom
-            ?: 0
+          if (this.isNavigationBarTranslucent) 0 else insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0,
         )
 
         content?.layoutParams = params


### PR DESCRIPTION
## 📜 Description

Setup `onApplyWindowInsetsListener` that manages `systemBars` and `navigationBar` on `rootView` to get correct and constant insets.

## 💡 Motivation and Context

If we setup `onApplyWindowInsetsListener` on `EdgeToEdgeReactViewGroup`, then sometimes insets are including keyboard size (it's is `0, 1225` (top, bottom) instead of expected `144, 84`).

I discovered that if we setup `onApplyWindowInsetsListener` on `rootVIew` - in this case insets are always stable. So I reworked this part (worth to note that `onApplyWindowInsetsListener` that detects keyboard size changes still should listen to `EdgeToEdgeReactViewGroup` because otherwise it's not working).

It fixes a problem with content jump, however the old approach (setting `padding` for `action_bar_root`) is not working anymore - instead we should apply margin. Last, but not least - we should setup it asynchronously, because if we setup it in `onAttachedToWindow`/`init` then it'll add undesired padding:

<p align="center">
  <img width="257" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/bac5586a-c91b-4162-8098-831b63607323">
</p>
<p align="center">
<i>Area in blue - undesired margin</i>
</p>

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/51

## 📢 Changelog

### Android
- apply `margin` to `action_bar_root` instead of `padding`;
- for managing paddings setup `onApplyWindowInsetsListener` on `rootView`, keep `onApplyWindowInsetsListener` on `EdgeToEdgeView` just for detecting keyboard size changes;
- setup `onApplyWindowInsetsListener` on `rootView` asynchronously (to avoid unnecessary margin on mount);
- added `ThemedReactContext` extension that returns `rootView`;

## 🤔 How Has This Been Tested?

Tested (fabric/paper) on:
- Pixel 7 Pro (Android 13);
- Redmi note 5 Pro (Android 9);

## 📸 Screenshots (if appropriate):

|Before|After|
|------|-----|
|![telegram-cloud-photo-size-2-5402402906965133775-y](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e89ac555-4ef6-463d-81b6-7f66178fe506)|![telegram-cloud-photo-size-2-5402402906965133774-y](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/1b94cb28-ce09-4977-967a-c7d1487377f9)|

## 📝 Checklist

- [x] CI successfully passed