### PR TITLE
refactor: added `target` property to mock in unit tests

### DIFF
--- a/example/__tests__/keyboard-handler.spec.tsx
+++ b/example/__tests__/keyboard-handler.spec.tsx
@@ -64,21 +64,21 @@ describe('keyboard handler specification', () => {
 
     expect(getByTestId('view')).toHaveStyle({ transform: [{ translateY: 0 }] });
 
-    onStart({ height: 100, progress: 1, duration: 250 });
+    onStart({ height: 100, progress: 1, duration: 250, target: 123 });
     jest.advanceTimersByTime(100);
 
     expect(getByTestId('view')).toHaveAnimatedStyle({
       transform: [{ translateY: 100 }],
     });
 
-    onMove({ height: 20, progress: 0.2, duration: 250 });
+    onMove({ height: 20, progress: 0.2, duration: 250, target: 123 });
     jest.advanceTimersByTime(100);
 
     expect(getByTestId('view')).toHaveAnimatedStyle({
       transform: [{ translateY: 20 }],
     });
 
-    onEnd({ height: 100, progress: 1, duration: 250 });
+    onEnd({ height: 100, progress: 1, duration: 250, target: 123 });
     jest.advanceTimersByTime(100);
 
     expect(getByTestId('view')).toHaveAnimatedStyle({


### PR DESCRIPTION
## 📜 Description

Added `target: 123` to mock data in unit tests.

## 💡 Motivation and Context

Seems like I forgot to do that in original PR (https://github.com/kirillzyusko/react-native-keyboard-controller/pull/191) - so I'm adding it here 🙂 

## 📢 Changelog

### JS
- added missing `target` filed in tests;

## 🤔 How Has This Been Tested?

Tested via running a test 🙂 

## 📝 Checklist

- [x] CI successfully passed