### PR TITLE
feat: added warning if default context is consumed

### DIFF
--- a/docs/docs/guides/building-own-hook.md
+++ b/docs/docs/guides/building-own-hook.md
@@ -13,9 +13,9 @@ To prevent such behavior you can write own hook based on primitives from this li
 import { useContext, useCallback } from "react";
 import { useFocusEffect } from "@react-navigation/native";
 import {
-  KeyboardContext,
   KeyboardController,
-  AndroidSoftInputModes
+  AndroidSoftInputModes,
+  useKeyboardContext
 } from "react-native-keyboard-controller";
 
 function useKeyboardAnimation() {
@@ -29,7 +29,7 @@ function useKeyboardAnimation() {
     }, [])
   );
 
-  const context = useContext(KeyboardContext);
+  const context = useKeyboardContext();
 
   return context.animated;
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 import { Animated } from 'react-native';
 
 import type { SharedValue } from 'react-native-reanimated';
@@ -29,3 +29,14 @@ const defaultContext: KeyboardAnimationContext = {
   setHandlers: () => {},
 };
 export const KeyboardContext = createContext(defaultContext);
+export const useKeyboardContext = () => {
+  const context = useContext(KeyboardContext);
+
+  if (context === defaultContext) {
+    console.warn(
+      "Couldn't find real values for `KeyboardContext`. Are you inside a `KeyboardProvider`?"
+    );
+  }
+
+  return context;
+};

--- a/src/context.ts
+++ b/src/context.ts
@@ -32,9 +32,9 @@ export const KeyboardContext = createContext(defaultContext);
 export const useKeyboardContext = () => {
   const context = useContext(KeyboardContext);
 
-  if (context === defaultContext) {
+  if (__DEV__ && context === defaultContext) {
     console.warn(
-      "Couldn't find real values for `KeyboardContext`. Are you inside a `KeyboardProvider`?"
+      "Couldn't find real values for `KeyboardContext`. Please make sure you're inside of `KeyboardProvider` - otherwise functionality of `react-native-keyboard-controller` will not work."
     );
   }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,10 @@
-import { DependencyList, useContext, useEffect } from 'react';
+import { DependencyList, useEffect } from 'react';
 
-import { AnimatedContext, KeyboardContext, ReanimatedContext } from './context';
+import {
+  AnimatedContext,
+  ReanimatedContext,
+  useKeyboardContext,
+} from './context';
 import { KeyboardController } from './bindings';
 import { AndroidSoftInputModes } from './constants';
 import { uuid } from './utils';
@@ -19,14 +23,14 @@ export const useResizeMode = () => {
 
 export const useKeyboardAnimation = (): AnimatedContext => {
   useResizeMode();
-  const context = useContext(KeyboardContext);
+  const context = useKeyboardContext();
 
   return context.animated;
 };
 
 export const useReanimatedKeyboardAnimation = (): ReanimatedContext => {
   useResizeMode();
-  const context = useContext(KeyboardContext);
+  const context = useKeyboardContext();
 
   return context.reanimated;
 };
@@ -35,7 +39,7 @@ export function useGenericKeyboardHandler(
   handler: KeyboardHandler,
   deps?: DependencyList
 ) {
-  const context = useContext(KeyboardContext);
+  const context = useKeyboardContext();
 
   useEffect(() => {
     const key = uuid();


### PR DESCRIPTION
## 📜 Description

Added a warning if `defaultContext` is consumed.

## 💡 Motivation and Context

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/213

## 📢 Changelog

### JS
- added `useKeyboardContext` hook;
- added a check in `useKeyboardContext` that `defaultContext` is consumed and showing a warning;
- replaced `useContext(KeyboardContext)` with `useKeyboardContext`;

## 🤔 How Has This Been Tested?

Tested on iPhone 14 Pro (iOS 16.4).

## 📸 Screenshots (if appropriate):

|Minimized|Full screen|
|----------|-----------|
|![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/ae6ffc57-8ca3-4304-9059-a805c312f056)|![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/2e0ee8c6-afd6-4a56-bdf3-6ebf89f47b41)|

## 📝 Checklist

- [x] CI successfully passed