### PR TITLE
refactor: migrate from deprecated `RCTEventEmitter`

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/KeyboardAnimationCallback.kt
@@ -32,6 +32,7 @@ class KeyboardAnimationCallback(
   dispatchMode: Int = DISPATCH_MODE_STOP,
   val context: ThemedReactContext?,
 ) : WindowInsetsAnimationCompat.Callback(dispatchMode), OnApplyWindowInsetsListener {
+  private val surfaceId = UIManagerHelper.getSurfaceId(view)
   private var persistentKeyboardHeight = 0.0
   private var isKeyboardVisible = false
   private var isTransitioning = false
@@ -57,6 +58,7 @@ class KeyboardAnimationCallback(
           // can bring breaking changes
           this.sendEventToJS(
             KeyboardTransitionEvent(
+              surfaceId,
               view.id,
               "topKeyboardMoveStart",
               this.persistentKeyboardHeight,
@@ -67,6 +69,7 @@ class KeyboardAnimationCallback(
           )
           this.sendEventToJS(
             KeyboardTransitionEvent(
+              surfaceId,
               view.id,
               "topKeyboardMoveEnd",
               this.persistentKeyboardHeight,
@@ -115,6 +118,7 @@ class KeyboardAnimationCallback(
       this.emitEvent("KeyboardController::keyboardWillShow", getEventParams(keyboardHeight))
       this.sendEventToJS(
         KeyboardTransitionEvent(
+          surfaceId,
           view.id,
           "topKeyboardMoveStart",
           keyboardHeight,
@@ -129,6 +133,7 @@ class KeyboardAnimationCallback(
         val toValue = animator.animatedValue as Float
         this.sendEventToJS(
           KeyboardTransitionEvent(
+            surfaceId,
             view.id,
             "topKeyboardMove",
             toValue.toDouble(),
@@ -142,6 +147,7 @@ class KeyboardAnimationCallback(
         this.emitEvent("KeyboardController::keyboardDidShow", getEventParams(keyboardHeight))
         this.sendEventToJS(
           KeyboardTransitionEvent(
+            surfaceId,
             view.id,
             "topKeyboardMoveEnd",
             keyboardHeight,
@@ -182,6 +188,7 @@ class KeyboardAnimationCallback(
     Log.i(TAG, "HEIGHT:: $keyboardHeight TAG:: $viewTagFocused")
     this.sendEventToJS(
       KeyboardTransitionEvent(
+        surfaceId,
         view.id,
         "topKeyboardMoveStart",
         keyboardHeight,
@@ -223,7 +230,7 @@ class KeyboardAnimationCallback(
     Log.i(TAG, "DiffY: $diffY $height $progress ${InteractiveKeyboardProvider.isInteractive} $viewTagFocused")
 
     val event = if (InteractiveKeyboardProvider.isInteractive) "topKeyboardMoveInteractive" else "topKeyboardMove"
-    this.sendEventToJS(KeyboardTransitionEvent(view.id, event, height, progress, duration, viewTagFocused))
+    this.sendEventToJS(KeyboardTransitionEvent(surfaceId, view.id, event, height, progress, duration, viewTagFocused))
 
     return insets
   }
@@ -254,6 +261,7 @@ class KeyboardAnimationCallback(
     )
     this.sendEventToJS(
       KeyboardTransitionEvent(
+        surfaceId,
         view.id,
         "topKeyboardMoveEnd",
         keyboardHeight,

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
@@ -1,28 +1,27 @@
 package com.reactnativekeyboardcontroller.events
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class KeyboardTransitionEvent(
+  surfaceId: Int,
   viewId: Int,
   private val event: String,
   private val height: Double,
   private val progress: Double,
   private val duration: Int,
   private val target: Int,
-) : Event<KeyboardTransitionEvent>(viewId) {
+) : Event<KeyboardTransitionEvent>(surfaceId, viewId) {
   override fun getEventName() = event
 
   // All events for a given view can be coalesced?
   override fun getCoalescingKey(): Short = 0
 
-  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    val map = Arguments.createMap()
-    map.putDouble("progress", progress)
-    map.putDouble("height", height)
-    map.putInt("duration", duration)
-    map.putInt("target", target)
-    rctEventEmitter.receiveEvent(viewTag, eventName, map)
+  override fun getEventData(): WritableMap? = Arguments.createMap().apply {
+    putDouble("progress", progress)
+    putDouble("height", height)
+    putInt("duration", duration)
+    putInt("target", target)
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
+@Suppress("detekt:LongParameterList")
 class KeyboardTransitionEvent(
   surfaceId: Int,
   viewId: Int,

--- a/docs/docs/guides/compatibility.md
+++ b/docs/docs/guides/compatibility.md
@@ -6,7 +6,17 @@ keywords: [react-native-keyboard-controller, compatibility, react-native version
 
 # Compatibility
 
+:::info
+
+If you found an incompatibility or conflict with other open source libraries - don't hesitate to open an [issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/new?assignees=kirillzyusko&labels=bug&template=bug_report.md&title=). It will help the project 🙏
+
+:::
+
 ## React Native
+
+Below you can find an information about compatibility with `react-native` package per different architectures.
+
+### Fabric (new) architecture
 
 Starting from `1.2.0` this library adds support for a new architecture called `Fabric`. Since a new architecture is still in adoption stage and it changes some APIs over time - it's highly recommended to use versions which are compatible and were intensively tested against specific `react-native` versions.
 
@@ -17,11 +27,14 @@ Below you can find a table with supported versions:
 |1.3.0+ | 0.70.0+            |
 |1.2.0+ | 0.69.0+            |
 
-:::info
+### Paper (old) architecture
 
-For `Paper` (old) architecture there is no any restrictions. If you found an incompatibility - don't hesitate to open an [issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/new?assignees=kirillzyusko&labels=bug&template=bug_report.md&title=). It will help the project 🙏
+This library supports as minimal `react-native` version as possible. However it was decided to drop a support for some really old versions for better development workflow and future support.
 
-:::
+|library version|react-native version|
+|-------|--------------------|
+|1.7.0+ | 0.65.0+            |
+|1.0.0+ | 0.62.0+            |
 
 ## Third-party libraries compatibility
 


### PR DESCRIPTION
## 📜 Description

Re-worked deprecated API for `RCTEventEmitter ` on Android. Minimal supported RN version is 0.65.

Updated compatibility page in docs.

## 💡 Motivation and Context

Deprecated API sooner or earlier will be removed, so there is no sense to keep the usage of deprecated API.

In this PR I've decided to drop a support of really old RN versions and remove usage of deprecated APIs. For that I reworked event dispatching API 🙂 

## 📢 Changelog

### Docs
- added info about minimal supported version of RN for paper architecture;

### Android
- added `surfaceId` to the event;
- removed `dispatch` method;
- override `getEventData` method.

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro (both fabric & paper). Works as before.

## 📝 Checklist

- [x] CI successfully passed