### PR TITLE
refactor: prevent synchronous calls to `setInputMode`/`setDefaultMode`

### DIFF
--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerModule.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerModule.kt
@@ -10,12 +10,12 @@ class KeyboardControllerModule(mReactContext: ReactApplicationContext) : ReactCo
 
   override fun getName(): String = KeyboardControllerModuleImpl.NAME
 
-  @ReactMethod(isBlockingSynchronousMethod = true)
+  @ReactMethod
   fun setInputMode(mode: Int) {
     module.setInputMode(mode)
   }
 
-  @ReactMethod(isBlockingSynchronousMethod = true)
+  @ReactMethod
   fun setDefaultMode() {
     module.setDefaultMode()
   }


### PR DESCRIPTION
## 📜 Description

Removed `isBlockingSynchronous=true` param from ``@ReactMethod` annotation :)

## 💡 Motivation and Context

I don't know why I've added this annotation, but it seems to have no effect at all (apart of making code slower 😅 ).

We're running a function synchronously, but in fact synchronous call is not needed, because new mode to `softInputMode` is applied asynchronously (since it schedules its execution in UI-thread -> `UiThreadUtil.runOnUiThread`).

Also from react-native [documentation](https://reactnative.dev/docs/native-modules-android#synchronous-methods) it's not recommended approach, since it'll only slow down the code and will make it impossible to use remote-debugger.

So in this PR I removed synchronous call (to speed up a code a little bit), brought more consistency across APIs on iOS/Android (now they both are not scheduling synchronous call) 😎 

## 📢 Changelog

### Android
- removed `isBlockingSynchronous=true`;

## 🤔 How Has This Been Tested?

Tested on Redmi Note 5 Pro.

## 📸 Screenshots (if appropriate):

Nothing is changed from UI perspective.

## 📝 Checklist

- [x] CI successfully passed