### PR TITLE
fix: cast `UIResponder.current` to `UIView` instead of `RCTUITextField`

### DIFF
--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -46,9 +46,9 @@ public extension UIResponder {
 public extension Optional where Wrapped == UIResponder {
   var reactViewTag: NSNumber {
     #if KEYBOARD_CONTROLLER_NEW_ARCH_ENABLED
-      return ((self as? RCTUITextField)?.superview?.tag ?? -1) as NSNumber
+      return ((self as? UIView)?.superview?.tag ?? -1) as NSNumber
     #else
-      return (self as? RCTUITextField)?.superview?.reactTag ?? -1
+      return (self as? UIView)?.superview?.reactTag ?? -1
     #endif
   }
 }

--- a/ios/KeyboardController-Bridging-Header.h
+++ b/ios/KeyboardController-Bridging-Header.h
@@ -1,2 +1,1 @@
-#import <React/RCTUITextField.h>
 #import <React/RCTViewManager.h>


### PR DESCRIPTION
## 📜 Description

Cast `UIResponder.current` to `UIView` instead of `RCTUITextField`.

## 💡 Motivation and Context

It seems like casting to `RCTUITextField` may not always succeed because internal layout may be different per different TextInput types (multiline vs not-multiline), see table below:

|Single input|Multiline input|
|------------|--------------|
|<img width="194" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/b55a76f4-6103-4081-853b-807bb985bbe8">|<img width="195" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/c4d94f54-7612-492a-8460-cdf06e97e1a1">|

To overcome this problem I've decided to cast `UIResponder.current` to `UIView`. This casting is successful in both cases (multiline and not-multiline) and give expected (actual) values 😊 

Also such rework allow us to delete import `#import <React/RCTUITextField.h>`, because we don't need this class anymore 😎 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/224

## 📢 Changelog

### iOS
- cast `UIResponder.current` to `UIView` instead of `RCTUITextField`;

## 🤔 How Has This Been Tested?

Tested iPhone 14 Pro (iOS 16.4).

## 📸 Screenshots (if appropriate):

https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/5c60a349-eebc-4030-b407-8dc6a31e6d60

## 📝 Checklist

- [x] CI successfully passed