### PR TITLE
fix: return `KeyboardAvoidingView` to its initial size after keyboard closing

### DIFF
--- a/FabricExample/src/screens/Examples/KeyboardAvoidingView/index.tsx
+++ b/FabricExample/src/screens/Examples/KeyboardAvoidingView/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   KeyboardAvoidingView as RNKeyboardAvoidingView,
+  KeyboardAvoidingViewProps,
   Text,
   TextInput,
   TouchableOpacity,
@@ -13,21 +14,38 @@ import styles from './styles';
 
 type Props = StackScreenProps<ExamplesStackParamList>;
 
+type Behavior = KeyboardAvoidingViewProps['behavior'];
+const behaviors: Behavior[] = ['padding', 'height', 'position'];
+
 export default function KeyboardAvoidingViewExample({ navigation }: Props) {
+  const [behavior, setBehavior] = useState<Behavior>(behaviors[0]);
   const [isPackageImplementation, setPackageImplementation] = useState(true);
 
   useEffect(() => {
     navigation.setOptions({
       headerRight: () => (
-        <Text
-          style={styles.header}
-          onPress={() => setPackageImplementation((value) => !value)}
-        >
-          {isPackageImplementation ? 'Package' : 'RN'}
-        </Text>
+        <View style={styles.row}>
+          <Text
+            style={styles.header}
+            onPress={() => setPackageImplementation((value) => !value)}
+          >
+            {isPackageImplementation ? 'Package' : 'RN'}
+          </Text>
+          <Text
+            style={styles.header}
+            onPress={() => {
+              const index = behaviors.indexOf(behavior);
+              setBehavior(
+                behaviors[index === behaviors.length - 1 ? 0 : index + 1]
+              );
+            }}
+          >
+            {behavior}
+          </Text>
+        </View>
       ),
     });
-  }, [isPackageImplementation]);
+  }, [isPackageImplementation, behavior]);
 
   const Container = isPackageImplementation
     ? KeyboardAvoidingView
@@ -35,7 +53,7 @@ export default function KeyboardAvoidingViewExample({ navigation }: Props) {
 
   return (
     <Container
-      behavior="padding"
+      behavior={behavior}
       contentContainerStyle={styles.container}
       keyboardVerticalOffset={100}
       style={styles.content}

--- a/FabricExample/src/screens/Examples/KeyboardAvoidingView/styles.ts
+++ b/FabricExample/src/screens/Examples/KeyboardAvoidingView/styles.ts
@@ -8,6 +8,9 @@ export default StyleSheet.create({
   container: {
     flex: 1,
   },
+  row: {
+    flexDirection: 'row',
+  },
   content: {
     flex: 1,
     maxHeight: 600,

--- a/example/src/screens/Examples/KeyboardAvoidingView/index.tsx
+++ b/example/src/screens/Examples/KeyboardAvoidingView/index.tsx
@@ -35,7 +35,7 @@ export default function KeyboardAvoidingViewExample({ navigation }: Props) {
 
   return (
     <Container
-      behavior="padding"
+      behavior="height"
       contentContainerStyle={styles.container}
       keyboardVerticalOffset={100}
       style={styles.content}

--- a/example/src/screens/Examples/KeyboardAvoidingView/index.tsx
+++ b/example/src/screens/Examples/KeyboardAvoidingView/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   KeyboardAvoidingView as RNKeyboardAvoidingView,
+  KeyboardAvoidingViewProps,
   Text,
   TextInput,
   TouchableOpacity,
@@ -13,21 +14,38 @@ import styles from './styles';
 
 type Props = StackScreenProps<ExamplesStackParamList>;
 
+type Behavior = KeyboardAvoidingViewProps['behavior'];
+const behaviors: Behavior[] = ['padding', 'height', 'position'];
+
 export default function KeyboardAvoidingViewExample({ navigation }: Props) {
+  const [behavior, setBehavior] = useState<Behavior>(behaviors[0]);
   const [isPackageImplementation, setPackageImplementation] = useState(true);
 
   useEffect(() => {
     navigation.setOptions({
       headerRight: () => (
-        <Text
-          style={styles.header}
-          onPress={() => setPackageImplementation((value) => !value)}
-        >
-          {isPackageImplementation ? 'Package' : 'RN'}
-        </Text>
+        <View style={styles.row}>
+          <Text
+            style={styles.header}
+            onPress={() => setPackageImplementation((value) => !value)}
+          >
+            {isPackageImplementation ? 'Package' : 'RN'}
+          </Text>
+          <Text
+            style={styles.header}
+            onPress={() => {
+              const index = behaviors.indexOf(behavior);
+              setBehavior(
+                behaviors[index === behaviors.length - 1 ? 0 : index + 1]
+              );
+            }}
+          >
+            {behavior}
+          </Text>
+        </View>
       ),
     });
-  }, [isPackageImplementation]);
+  }, [isPackageImplementation, behavior]);
 
   const Container = isPackageImplementation
     ? KeyboardAvoidingView
@@ -35,7 +53,7 @@ export default function KeyboardAvoidingViewExample({ navigation }: Props) {
 
   return (
     <Container
-      behavior="height"
+      behavior={behavior}
       contentContainerStyle={styles.container}
       keyboardVerticalOffset={100}
       style={styles.content}

--- a/example/src/screens/Examples/KeyboardAvoidingView/styles.ts
+++ b/example/src/screens/Examples/KeyboardAvoidingView/styles.ts
@@ -8,6 +8,9 @@ export default StyleSheet.create({
   container: {
     flex: 1,
   },
+  row: {
+    flexDirection: 'row',
+  },
   content: {
     flex: 1,
     maxHeight: 600,

--- a/src/components/KeyboardAvoidingView/hooks.ts
+++ b/src/components/KeyboardAvoidingView/hooks.ts
@@ -5,6 +5,7 @@ export const useKeyboardAnimation = () => {
   const heightWhenOpened = useSharedValue(0);
   const height = useSharedValue(0);
   const progress = useSharedValue(0);
+  const isClosed = useSharedValue(true);
 
   useKeyboardHandler(
     {
@@ -12,6 +13,7 @@ export const useKeyboardAnimation = () => {
         'worklet';
 
         if (e.height > 0) {
+          isClosed.value = false;
           heightWhenOpened.value = e.height;
         }
       },
@@ -21,9 +23,14 @@ export const useKeyboardAnimation = () => {
         progress.value = e.progress;
         height.value = e.height;
       },
+      onEnd: (e) => {
+        'worklet';
+
+        isClosed.value = e.height === 0;
+      },
     },
     []
   );
 
-  return { height, progress, heightWhenOpened };
+  return { height, progress, heightWhenOpened, isClosed };
 };

--- a/src/components/KeyboardAvoidingView/index.tsx
+++ b/src/components/KeyboardAvoidingView/index.tsx
@@ -11,6 +11,7 @@ import Reanimated, {
   useSharedValue,
   useDerivedValue,
   interpolate,
+  runOnUI,
 } from 'react-native-reanimated';
 import { useKeyboardAnimation } from './hooks';
 
@@ -76,11 +77,14 @@ const KeyboardAvoidingView = forwardRef<View, React.PropsWithChildren<Props>>(
       return Math.max(frame.value.y + frame.value.height - keyboardY, 0);
     }, [screenHeight, keyboardVerticalOffset]);
 
+    const onLayoutWorklet = useWorkletCallback((layout: LayoutRectangle) => {
+      if (keyboard.isClosed.value) {
+        initialFrame.value = layout;
+      }
+    });
     const onLayout = useCallback<NonNullable<ViewProps['onLayout']>>(
       (e) => {
-        if (initialFrame.value === null) {
-          initialFrame.value = e.nativeEvent.layout;
-        }
+        runOnUI(onLayoutWorklet)(e.nativeEvent.layout);
         onLayoutProps?.(e);
       },
       [onLayoutProps]

--- a/src/components/KeyboardAvoidingView/index.tsx
+++ b/src/components/KeyboardAvoidingView/index.tsx
@@ -96,7 +96,7 @@ const KeyboardAvoidingView = forwardRef<View, React.PropsWithChildren<Props>>(
 
       switch (behavior) {
         case 'height':
-          if (bottomHeight > 0) {
+          if (!keyboard.isClosed.value) {
             return {
               height: frame.value.height - bottomHeight,
               flex: 0,


### PR DESCRIPTION
## 📜 Description

Return `KeyboardAvoidingView` to its initial size when keyboard gets closed.

## 💡 Motivation and Context

Usage of `if (bottomHeight > 0) {` is incorrect, because in this case we are not returning a view to its original size. Let's imagine that `frame.value.height = 500`. And `bottomHeight` goes from `300` to `0`. Last two values could be `1.33` and `0`. In this case we will set `height` to `500 - 1.33` as final frame, but it's incorrect, because we should return it back to `500` when keyboard is getting closed.

So in this PR I'm adding new `isClosed` variable, that will be `true` only when keyboard is fully closed. When keyboard begin the movement - value will be `false`. And instead of relying on `if (bottomHeight > 0) {` I'm relying now on `isClosed` variable: `if (!keyboard.isClosed.value) {`.

Such approach will return view its initial size and a switch between implementations will not produce jump anymore 😊  

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/238

## 📢 Changelog

### JS
- added `isClosed` variable to `useKeyboardAnimation` (`true` only when keyboard is invisible);
- use `if (!keyboard.isClosed.value) {` instead of `if (bottomHeight > 0) {`;
- update initial layout not only on mount;
- dynamic behavior switch.

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro (Android 13).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/8e8e612d-8ee7-4e86-91b3-5ef50eb8f5ce">|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/9c29456b-1e5e-42ff-84ff-fcdb1b9da43b">|

## 📝 Checklist

- [x] CI successfully passed