### PR TITLE
fix: allow contributors to run `check-diff` job

### DIFF
--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -11,6 +11,8 @@ jobs:
   check-diff:
     name: 🔬 Find npm package size diff
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout to target branch
         uses: actions/checkout@v3


### PR DESCRIPTION
## 📜 Description

Allow contributors to run `check-diff` job.

## 💡 Motivation and Context

Specified `permission` as `pull-requests: write` to fix **Error: Resource not accessible by integration**.

A sample of error: https://github.com/kirillzyusko/react-native-keyboard-controller/actions/runs/6406320042/job/17390681956?pr=252

## 📢 Changelog

### CI
- specify `permission` as `pull-requests: write`.

## 🤔 How Has This Been Tested?

I'll merge it and will test later in another PR.

## 📝 Checklist

- [x] CI successfully passed