### PR TITLE
chore: update gradle & kotlin versions

### DIFF
--- a/FabricExample/android/build.gradle
+++ b/FabricExample/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33
+        kotlinVersion = "1.6.0"
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-KeyboardController_kotlinVersion=1.6.21
+KeyboardController_kotlinVersion=1.8.22
 KeyboardController_compileSdkVersion=33
 KeyboardController_targetSdkVersion=33
 KeyboardController_minSdkVersion=16

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 📜 Description

Updated `gradle` to `6.9.4` and `kotlin` to `1.8.22`.

## 💡 Motivation and Context

It was needed to fix compilation issues in https://github.com/kirillzyusko/react-native-keyboard-controller/actions/runs/6580087395/job/17877337926?pr=257

```bash
...
e: /home/runner/work/react-native-keyboard-controller/react-native-keyboard-controller/android/src/paper/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt: (24, 12): Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.8.0, expected version is 1.6.0.
The class is loaded from /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.8.10/6d5560a229477df9406943d5feda5618e98eb64c/kotlin-stdlib-1.8.10.jar!/kotlin/Unit.class
e: /home/runner/work/react-native-keyboard-controller/react-native-keyboard-controller/android/src/paper/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt: (29, 12): Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.8.0, expected version is 1.6.0.
The class is loaded from /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.8.10/6d5560a229477df9406943d5feda5618e98eb64c/kotlin-stdlib-1.8.10.jar!/kotlin/Unit.class
...
```

## 📢 Changelog

### Android
- updated `gradle` to `6.9.4`;
- updated `kotlin` to `1.8.22`.
- specified `kotlinVersion` in `FabricExample` as in `example`;

## 🤔 How Has This Been Tested?

Tested via CI in this PR.

## 📝 Checklist

- [x] CI successfully passed