### PR TITLE
fix: conflict when using `fullScreenModal` presentation in native-stack

### DIFF
--- a/ios/views/KeyboardControllerViewManager.swift
+++ b/ios/views/KeyboardControllerViewManager.swift
@@ -44,17 +44,16 @@ class KeyboardControllerView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 
-  override func willMove(toWindow newWindow: UIWindow?) {
-    if newWindow == nil {
-      // Will be removed from a window
+  // for mounting/unmounting observers for lifecycle events we're using willMove(toSuperview) method (not willMove(toWindow))
+  // for more information see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/271
+  override func willMove(toSuperview newSuperview: UIView?) {
+    super.willMove(toSuperview: newSuperview)
+
+    if newSuperview == nil {
+      // The view is about to be removed from its superview (destroyed)
       inputObserver?.unmount()
       keyboardObserver?.unmount()
-    }
-  }
-
-  override func didMoveToWindow() {
-    if window != nil {
-      // Added to a window
+    } else {
       inputObserver = FocusedInputLayoutObserver(handler: onInput)
       inputObserver?.mount()
       keyboardObserver = KeyboardMovementObserver(handler: onEvent, onNotify: onNotify)


### PR DESCRIPTION
## 📜 Description
<!-- Describe your changes in detail -->

## 💡 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/271

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS
- 
- 

### iOS
- 
- 

### Android
- 
- 

## 🤔 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):
<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed