### PR TITLE
fix: remove `isLaidOut` check from `copyBoundsInWindow` method

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
@@ -2,6 +2,7 @@ package com.reactnativekeyboardcontroller.extensions
 
 import android.graphics.Rect
 import android.os.Build
+import android.util.Log
 import android.view.View
 import androidx.annotation.RequiresApi
 
@@ -37,15 +38,12 @@ private val tmpIntArr = IntArray(2)
  */
 @RequiresApi(Build.VERSION_CODES.KITKAT)
 fun View.copyBoundsInWindow(rect: Rect) {
-  if (isLaidOut && isAttachedToWindow) {
+  if (isAttachedToWindow) {
     rect.set(0, 0, width, height)
     getLocationInWindow(tmpIntArr)
     rect.offset(tmpIntArr[0], tmpIntArr[1])
   } else {
-    throw IllegalArgumentException(
-      "Can not copy bounds as view is not laid out" +
-        " or attached to window",
-    )
+    Log.w("View.copyBoundsInWindow", "Can not copy bounds as view is not attached to window")
   }
 }
 


### PR DESCRIPTION
## 📜 Description
<!-- Describe your changes in detail -->

## 💡 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/274 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/203

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS
- 
- 

### iOS
- 
- 

### Android
- 
- 

## 🤔 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):
<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed