### PR TITLE
fix: race condition in `onApplyWindowInsets`

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -41,6 +41,7 @@ class KeyboardAnimationCallback(
   private var isTransitioning = false
   private var duration = 0
   private var viewTagFocused = -1
+  private var animation: ValueAnimator? = null
 
   // listeners
   private val focusListener = OnGlobalFocusChangeListener { oldFocus, newFocus ->
@@ -133,6 +134,7 @@ class KeyboardAnimationCallback(
     val isKeyboardSizeEqual = this.persistentKeyboardHeight == keyboardHeight
 
     if (isKeyboardFullyVisible && !isKeyboardSizeEqual && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      Log.i(TAG, "onApplyWindowInsets ${this.persistentKeyboardHeight} -> ${keyboardHeight}")
       layoutObserver?.syncUpLayout()
       this.emitEvent("KeyboardController::keyboardWillShow", getEventParams(keyboardHeight))
       context.dispatchEvent(
@@ -179,9 +181,12 @@ class KeyboardAnimationCallback(
             viewTagFocused,
           ),
         )
+        this.animation = null
       }
       animation.setDuration(DEFAULT_ANIMATION_TIME.toLong()).startDelay = 0
+      this.animation?.cancel()
       animation.start()
+      this.animation = animation
 
       this.persistentKeyboardHeight = keyboardHeight
     }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -105,10 +105,6 @@ class KeyboardAnimationCallback(
    * behavior should be consistent across all versions of platform. To level the difference we
    * have to implement `onApplyWindowInsets` listener and simulate onStart/onProgress/onEnd
    * events when keyboard changes its size.
-   * In the method below we fully recreate the logic that is implemented on old android versions:
-   * - we dispatch `keyboardWillShow` (onStart);
-   * - we dispatch change height/progress as animated values (onProgress);
-   * - we dispatch `keyboardDidShow` (onEnd).
    */
   override fun onApplyWindowInsets(v: View, insets: WindowInsetsCompat): WindowInsetsCompat {
     val keyboardHeight = getCurrentKeyboardHeight()
@@ -134,61 +130,9 @@ class KeyboardAnimationCallback(
     val isKeyboardSizeEqual = this.persistentKeyboardHeight == keyboardHeight
 
     if (isKeyboardFullyVisible && !isKeyboardSizeEqual && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      Log.i(TAG, "onApplyWindowInsets ${this.persistentKeyboardHeight} -> ${keyboardHeight}")
+      Log.i(TAG, "onApplyWindowInsets: ${this.persistentKeyboardHeight} -> $keyboardHeight")
       layoutObserver?.syncUpLayout()
-      this.emitEvent("KeyboardController::keyboardWillShow", getEventParams(keyboardHeight))
-      context.dispatchEvent(
-        view.id,
-        KeyboardTransitionEvent(
-          surfaceId,
-          view.id,
-          "topKeyboardMoveStart",
-          keyboardHeight,
-          1.0,
-          DEFAULT_ANIMATION_TIME,
-          viewTagFocused,
-        ),
-      )
-
-      val animation =
-        ValueAnimator.ofFloat(this.persistentKeyboardHeight.toFloat(), keyboardHeight.toFloat())
-      animation.addUpdateListener { animator ->
-        val toValue = animator.animatedValue as Float
-        context.dispatchEvent(
-          view.id,
-          KeyboardTransitionEvent(
-            surfaceId,
-            view.id,
-            "topKeyboardMove",
-            toValue.toDouble(),
-            toValue.toDouble() / keyboardHeight,
-            DEFAULT_ANIMATION_TIME,
-            viewTagFocused,
-          ),
-        )
-      }
-      animation.doOnEnd {
-        this.emitEvent("KeyboardController::keyboardDidShow", getEventParams(keyboardHeight))
-        context.dispatchEvent(
-          view.id,
-          KeyboardTransitionEvent(
-            surfaceId,
-            view.id,
-            "topKeyboardMoveEnd",
-            keyboardHeight,
-            1.0,
-            DEFAULT_ANIMATION_TIME,
-            viewTagFocused,
-          ),
-        )
-        this.animation = null
-      }
-      animation.setDuration(DEFAULT_ANIMATION_TIME.toLong()).startDelay = 0
-      this.animation?.cancel()
-      animation.start()
-      this.animation = animation
-
-      this.persistentKeyboardHeight = keyboardHeight
+      this.onKeyboardResized(keyboardHeight)
     }
 
     return insets
@@ -323,6 +267,78 @@ class KeyboardAnimationCallback(
   fun destroy() {
     view.viewTreeObserver.removeOnGlobalFocusChangeListener(focusListener)
     layoutObserver?.destroy()
+  }
+
+  /*
+   * In the method below we recreate the logic that used when keyboard appear/disappear:
+   * - we dispatch `keyboardWillShow` (onStart);
+   * - we dispatch change height/progress as animated values (onProgress);
+   * - we dispatch `keyboardDidShow` (onEnd). 
+   */
+  private fun onKeyboardResized(keyboardHeight: Double) {
+    if (this.animation?.isRunning == true) {
+      Log.i(TAG, "onKeyboardResized -> cancelling animation that is in progress")
+      // if animation is in progress, then we are:
+      // - removing listeners (update, onEnd)
+      // - updating `persistentKeyboardHeight` to latest animated value
+      // - cancelling animation to free up CPU resources
+      this.animation?.removeAllListeners()
+      this.persistentKeyboardHeight = (this.animation?.animatedValue as Float).toDouble()
+      this.animation?.cancel()
+    }
+
+    this.emitEvent("KeyboardController::keyboardWillShow", getEventParams(keyboardHeight))
+    context.dispatchEvent(
+      view.id,
+      KeyboardTransitionEvent(
+        surfaceId,
+        view.id,
+        "topKeyboardMoveStart",
+        keyboardHeight,
+        1.0,
+        DEFAULT_ANIMATION_TIME,
+        viewTagFocused,
+      ),
+    )
+
+    val animation =
+      ValueAnimator.ofFloat(this.persistentKeyboardHeight.toFloat(), keyboardHeight.toFloat())
+    animation.addUpdateListener { animator ->
+      val toValue = animator.animatedValue as Float
+      context.dispatchEvent(
+        view.id,
+        KeyboardTransitionEvent(
+          surfaceId,
+          view.id,
+          "topKeyboardMove",
+          toValue.toDouble(),
+          toValue.toDouble() / keyboardHeight,
+          DEFAULT_ANIMATION_TIME,
+          viewTagFocused,
+        ),
+      )
+    }
+    animation.doOnEnd {
+      this.emitEvent("KeyboardController::keyboardDidShow", getEventParams(keyboardHeight))
+      context.dispatchEvent(
+        view.id,
+        KeyboardTransitionEvent(
+          surfaceId,
+          view.id,
+          "topKeyboardMoveEnd",
+          keyboardHeight,
+          1.0,
+          DEFAULT_ANIMATION_TIME,
+          viewTagFocused,
+        ),
+      )
+      this.animation = null
+    }
+    animation.setDuration(DEFAULT_ANIMATION_TIME.toLong()).startDelay = 0
+    animation.start()
+
+    this.animation = animation
+    this.persistentKeyboardHeight = keyboardHeight
   }
 
   private fun isKeyboardVisible(): Boolean {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -273,7 +273,7 @@ class KeyboardAnimationCallback(
    * In the method below we recreate the logic that used when keyboard appear/disappear:
    * - we dispatch `keyboardWillShow` (onStart);
    * - we dispatch change height/progress as animated values (onProgress);
-   * - we dispatch `keyboardDidShow` (onEnd). 
+   * - we dispatch `keyboardDidShow` (onEnd).
    */
   private fun onKeyboardResized(keyboardHeight: Double) {
     if (this.animation?.isRunning == true) {


### PR DESCRIPTION
## 📜 Description

Fixed race condition in `onApplyWindowInsets`.

## 💡 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

A rare case. I've reproduced it when I used `Microsoft SwiftKey Keyboard`.

I had a full cycle of `onStart`/`onProgress`/`onEnd` events (keyboard height was 283). And then two events were dispatched to `onApplyWindowInsets` (changing height to 213 and then to 283).

With a previous implementation we were running an animation from 283 -> 213 and in parallel from 213 to 283. As a result an animated view was jumpy.

With new implementation we're cancelling our previous animations, so we have monotonic values.

## 📢 Changelog

### Android
- added `onKeyboardResized` method (copied part of body of `onApplyWindowInsets`);
- save current `ValueAnimator` when animation starts;
- clean (set to `null`) current animation in `doOnEnd`;
- cancel animation if previous one is in progress and `onApplyWindowInsets` is dispatched;
- update `persistentKeyboardHeight` if we cancel animation;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro:
- API 34 (Android 14);
- API 31 (Android 12).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="482" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/a16f84b9-5990-435d-8862-43834131fe71">|<img width="505" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e3448a07-5955-4e3d-a128-751d8294cad8">|

## 📝 Checklist

- [x] CI successfully passed