### PR TITLE
fix: typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install `react-native-keyboard-controller` package from npm:
 ```sh
 yarn add react-native-keyboard-controller
 # or
-# npm install react-native-keyboard-controller --save
+npm install react-native-keyboard-controller --save
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Keyboard manager which works in identical way on both iOS and Android.
 
 Install `react-native-keyboard-controller` package from npm:
 
-```sh
+```shell
 yarn add react-native-keyboard-controller
 # or
 npm install react-native-keyboard-controller --save

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -4,17 +4,31 @@ description: Guide dedicated to installation process
 keywords: [react-native-keyboard-controller, react-native keyboard, installation, setup, keyboard handling, keyboard animation, keyboard movement, troubleshooting]
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Installation
 
 ## Adding a library to the project
 
 Install the `react-native-keyboard-controller` package in your React Native project.
 
-```bash
+<Tabs>
+<TabItem value="yarn" label="YARN" default>
+
+```shell
 yarn add react-native-keyboard-controller
-# or with npm
-# npm install react-native-keyboard-controller --save
 ```
+
+</TabItem>
+<TabItem value="npm" label="NPM">
+
+```shell
+npm install react-native-keyboard-controller --save
+```
+
+</TabItem>
+</Tabs>
 
 ### Linking
 

--- a/docs/versioned_docs/version-1.9.0/installation.mdx
+++ b/docs/versioned_docs/version-1.9.0/installation.mdx
@@ -4,17 +4,31 @@ description: Guide dedicated to installation process
 keywords: [react-native-keyboard-controller, react-native keyboard, installation, setup, keyboard handling, keyboard animation, keyboard movement, troubleshooting]
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Installation
 
 ## Adding a library to the project
 
 Install the `react-native-keyboard-controller` package in your React Native project.
 
-```bash
+<Tabs>
+<TabItem value="yarn" label="YARN" default>
+
+```shell
 yarn add react-native-keyboard-controller
-# or with npm
-# npm install react-native-keyboard-controller --save
 ```
+
+</TabItem>
+<TabItem value="npm" label="NPM">
+
+```shell
+npm install react-native-keyboard-controller --save
+```
+
+</TabItem>
+</Tabs>
 
 ### Linking
 


### PR DESCRIPTION
## 📜 Description

Removed `#` to make installation instructions more explicit.

## 💡 Motivation and Context

Commented out code hard to read and notice.

Also added tabs for selection package manager in documentation.

## 📢 Changelog

### Docs
- removed `#` to make installation instructions more explicit in README;
- added npm/yarn tabs.

## 🤔 How Has This Been Tested?

Tested via preview on `localhost:3000` and github preview.

## 📸 Screenshots (if appropriate):

<img width="1003" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/fc32802a-7ac1-438c-9cab-182ce16c1b03">

## 📝 Checklist

- [ ] CI successfully passed