### PR TITLE
refactor: rename `FocusedInputLayoutObserver` -> `FocusedInputObserver`

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/FocusedInputObserver.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/FocusedInputObserver.kt
@@ -22,7 +22,7 @@ val noFocusedInputEvent = FocusedInputLayoutChangedEventData(
   target = -1,
 )
 
-class FocusedInputLayoutObserver(val view: ReactViewGroup, private val context: ThemedReactContext?) {
+class FocusedInputObserver(val view: ReactViewGroup, private val context: ThemedReactContext?) {
   // constructor variables
   private val surfaceId = UIManagerHelper.getSurfaceId(view)
 

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -84,7 +84,7 @@ class KeyboardAnimationCallback(
       }
     }
   }
-  private var layoutObserver: FocusedInputLayoutObserver? = null
+  private var layoutObserver: FocusedInputObserver? = null
 
   init {
     require(persistentInsetTypes and deferredInsetTypes == 0) {
@@ -92,7 +92,7 @@ class KeyboardAnimationCallback(
         " same WindowInsetsCompat.Type values"
     }
 
-    layoutObserver = FocusedInputLayoutObserver(view = view, context = context)
+    layoutObserver = FocusedInputObserver(view = view, context = context)
     view.viewTreeObserver.addOnGlobalFocusChangeListener(focusListener)
   }
 

--- a/ios/KeyboardController.xcodeproj/project.pbxproj
+++ b/ios/KeyboardController.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		0807071E2A34807B00C05A19 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0807071D2A34807B00C05A19 /* Extensions.swift */; };
 		084AEEC62ACF49A8001A3069 /* FocusedInputLayoutChangedEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 084AEEC52ACF49A8001A3069 /* FocusedInputLayoutChangedEvent.m */; };
-		084AEEC82ACF4AB2001A3069 /* FocusedInputLayoutObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084AEEC72ACF4AB2001A3069 /* FocusedInputLayoutObserver.swift */; };
+		084AEEC82ACF4AB2001A3069 /* FocusedInputObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084AEEC72ACF4AB2001A3069 /* FocusedInputObserver.swift */; };
 		F333F8D428996B8D0015B05F /* KeyboardControllerView.mm in Sources */ = {isa = PBXBuildFile; fileRef = F333F8D228996B8D0015B05F /* KeyboardControllerView.mm */; };
 		F359D34F28133C26000B6AFE /* KeyboardControllerModule.mm in Sources */ = {isa = PBXBuildFile; fileRef = F359D34E28133C26000B6AFE /* KeyboardControllerModule.mm */; };
 		F3626A0728B3FE760021B2D9 /* KeyboardMovementObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3626A0628B3FE760021B2D9 /* KeyboardMovementObserver.swift */; };
@@ -33,7 +33,7 @@
 		0807071D2A34807B00C05A19 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		084AEEC22ACF479A001A3069 /* FocusedInputLayoutChangedEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FocusedInputLayoutChangedEvent.h; sourceTree = "<group>"; };
 		084AEEC52ACF49A8001A3069 /* FocusedInputLayoutChangedEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FocusedInputLayoutChangedEvent.m; sourceTree = "<group>"; };
-		084AEEC72ACF4AB2001A3069 /* FocusedInputLayoutObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedInputLayoutObserver.swift; sourceTree = "<group>"; };
+		084AEEC72ACF4AB2001A3069 /* FocusedInputObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedInputObserver.swift; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libKeyboardController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libKeyboardController.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5891CC2AC0600A0062D /* KeyboardControllerViewManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = KeyboardControllerViewManager.mm; sourceTree = "<group>"; };
 		F333F8D128996B1C0015B05F /* KeyboardControllerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardControllerView.h; sourceTree = "<group>"; };
@@ -73,7 +73,7 @@
 			isa = PBXGroup;
 			children = (
 				F3626A0628B3FE760021B2D9 /* KeyboardMovementObserver.swift */,
-				084AEEC72ACF4AB2001A3069 /* FocusedInputLayoutObserver.swift */,
+				084AEEC72ACF4AB2001A3069 /* FocusedInputObserver.swift */,
 			);
 			path = observers;
 			sourceTree = "<group>";
@@ -172,7 +172,7 @@
 				F3626A0728B3FE760021B2D9 /* KeyboardMovementObserver.swift in Sources */,
 				0807071E2A34807B00C05A19 /* Extensions.swift in Sources */,
 				F359D34F28133C26000B6AFE /* KeyboardControllerModule.mm in Sources */,
-				084AEEC82ACF4AB2001A3069 /* FocusedInputLayoutObserver.swift in Sources */,
+				084AEEC82ACF4AB2001A3069 /* FocusedInputObserver.swift in Sources */,
 				F4FF95D7245B92E800C19C63 /* KeyboardControllerViewManager.swift in Sources */,
 				F333F8D428996B8D0015B05F /* KeyboardControllerView.mm in Sources */,
 				F3F50669289E653B003091D6 /* KeyboardMoveEvent.m in Sources */,

--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -1,5 +1,5 @@
 //
-//  FocusedInputLayoutObserver.swift
+//  FocusedInputObserver.swift
 //  KeyboardController
 //
 //  Created by Kiryl Ziusko on 05/10/2023.
@@ -21,8 +21,8 @@ let noFocusedInputEvent: [String: Any] = [
   ],
 ]
 
-@objc(FocusedInputLayoutObserver)
-public class FocusedInputLayoutObserver: NSObject {
+@objc(FocusedInputObserver)
+public class FocusedInputObserver: NSObject {
   // class members
   var onEvent: (NSDictionary) -> Void
   // state variables

--- a/ios/views/KeyboardControllerView.mm
+++ b/ios/views/KeyboardControllerView.mm
@@ -31,7 +31,7 @@ using namespace facebook::react;
 
 @implementation KeyboardControllerView {
   KeyboardMovementObserver *keyboardObserver;
-  FocusedInputLayoutObserver *inputObserver;
+  FocusedInputObserver *inputObserver;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -45,7 +45,7 @@ using namespace facebook::react;
     static const auto defaultProps = std::make_shared<const KeyboardControllerViewProps>();
     _props = defaultProps;
 
-    inputObserver = [[FocusedInputLayoutObserver alloc] initWithHandler:^(NSDictionary *event) {
+    inputObserver = [[FocusedInputObserver alloc] initWithHandler:^(NSDictionary *event) {
       if (self->_eventEmitter) {
         int target = [event[@"target"] integerValue];
         double absoluteY = [event[@"layout"][@"absoluteY"] doubleValue];

--- a/ios/views/KeyboardControllerViewManager.swift
+++ b/ios/views/KeyboardControllerViewManager.swift
@@ -12,7 +12,7 @@ class KeyboardControllerViewManager: RCTViewManager {
 class KeyboardControllerView: UIView {
   // internal variables
   private var keyboardObserver: KeyboardMovementObserver?
-  private var inputObserver: FocusedInputLayoutObserver?
+  private var inputObserver: FocusedInputObserver?
   private var eventDispatcher: RCTEventDispatcherProtocol
   private var bridge: RCTBridge
   // react callbacks
@@ -35,7 +35,7 @@ class KeyboardControllerView: UIView {
     self.bridge = bridge
     eventDispatcher = bridge.eventDispatcher()
     super.init(frame: frame)
-    inputObserver = FocusedInputLayoutObserver(handler: onInput)
+    inputObserver = FocusedInputObserver(handler: onInput)
     keyboardObserver = KeyboardMovementObserver(handler: onEvent, onNotify: onNotify)
   }
 


### PR DESCRIPTION
## 📜 Description

Renamed `FocusedInputLayoutObserver` to `FocusedInputObserver`.

## 💡 Motivation and Context

I'm planning to extend library functionality. Soon apart of observing layout of focused input I'll also do other things (such as observing the text that user is typing).

Creating another class is kind of very expensive thing, because the functionality of these two classes will be toughly bound to each other (for example when observing text-value we'll need to sync-up layout - and it's a part of current `FocusedInputLayoutObserver`).

So taking it into consideration I decided to rename `FocusedInputLayoutObserver` class to make it more generic.

## 📢 Changelog

### iOS
- renamed `FocusedInputLayoutObserver.swift` file to `FocusedInputObserver.swift`;
- renamed all references of `FocusedInputLayoutObserver` to `FocusedInputObserver`.

### Android
- renamed `FocusedInputLayoutObserver.kt` file to `FocusedInputObserver.kt`;
- renamed all references of `FocusedInputLayoutObserver` to `FocusedInputObserver`.

## 🤔 How Has This Been Tested?

Tested manually on Pixel 3a (API 33, emulator).

## 📝 Checklist

- [x] CI successfully passed