### PR TITLE
fix: enable `buildFeatures.buildConfig` for AGP 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,9 @@ android {
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
   if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
     namespace "com.reactnativekeyboardcontroller"
+    buildFeatures {
+      buildConfig true
+    }
   }
 
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')


### PR DESCRIPTION
## 📜 Description

Enabled `buildFeatures.buildConfig` for Android Gradle Plugin 8+.

## 💡 Motivation and Context

In new react-native version 0.73 FB team switched to AGP 8. For AGP 8+ it's crucial to add `buildConfig true` under `buildFeatures` if you are using `BuildConfig` with custom configuration (this package is using it for distinguishing 2 different architectures - paper and fabric).

I decided to add it under `AGP >= 7` condition because it will not break anything and such condition will be evaluated as `true` for AGP 8.

## 📢 Changelog

### Android
- added  `buildFeature { buildConfig true }` if AGP is 7+;

## 🤔 How Has This Been Tested?

Tested manually and via CI builds.

## 📝 Checklist

- [x] CI successfully passed