### PR TITLE
chore: specify paths on push for e2e tests

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -11,6 +11,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/android-e2e-test.yml'
+      - 'package.json'
+      - 'android/**'
+      - 'example/**'
+      - 'e2e/**'
+      - 'src/**'
 
 jobs:
   test:

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -12,6 +12,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/ios-e2e-test.yml'
+      - 'react-native-keyboard-controller.podspec'
+      - 'package.json'
+      - 'ios/**'
+      - 'example/**'
+      - 'e2e/**'
+      - 'src/**'
 
 jobs:
   test:


### PR DESCRIPTION
## 📜 Description

Specify `paths` on `push` for `e2e` tests.

## 💡 Motivation and Context

Without these paths we'll run e2e every time on push to main branch. It's not consistent behavior across other CI scripts (and actually there is no sense not to run e2e pipeline on pull_request and run it on push).

So in this PR I'm adding these paths to have a consistent behavior across all CI scripts.

## 📢 Changelog

### CI
- added `paths` on push for e2e tests (the same as on pull_request);

## 🤔 How Has This Been Tested?

There is no way to test it 😅 

## 📝 Checklist

- [x] CI successfully passed