### PR TITLE
refactor: get rid off deprecated `useWorkletCallback`

### DIFF
--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.72.4",
     "react-native-gesture-handler": "2.12.1",
     "react-native-keyboard-controller": "link:../",
-    "react-native-reanimated": "3.4.2",
+    "react-native-reanimated": "3.6.0",
     "react-native-safe-area-context": "4.7.1",
     "react-native-screens": "3.24.0",
     "react-native-toast-message": "^2.1.6"

--- a/FabricExample/src/components/AwareScrollView/KeyboardAwareScrollView.tsx
+++ b/FabricExample/src/components/AwareScrollView/KeyboardAwareScrollView.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import { ScrollViewProps, useWindowDimensions } from 'react-native';
 import { FocusedInputLayoutChangedEvent, useReanimatedFocusedInput } from 'react-native-keyboard-controller';
 import Reanimated, {
@@ -9,7 +9,6 @@ import Reanimated, {
   useAnimatedScrollHandler,
   useAnimatedStyle,
   useSharedValue,
-  useWorkletCallback,
 } from 'react-native-reanimated';
 import { useSmoothKeyboardHandler } from './useSmoothKeyboardHandler';
 
@@ -84,7 +83,9 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
   /**
    * Function that will scroll a ScrollView as keyboard gets moving
    */
-  const maybeScroll = useWorkletCallback((e: number, animated: boolean = false) => {
+  const maybeScroll = useCallback((e: number, animated: boolean = false) => {
+    'worklet';
+
     const visibleRect = height - keyboardHeight.value;
     const point = (layout.value?.layout.absoluteY || 0) + (layout.value?.layout.height || 0);
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -497,35 +497,10 @@ PODS:
     - React-Core
   - RNGestureHandler (2.12.1):
     - React-Core
-  - RNReanimated (3.4.2):
-    - DoubleConversion
-    - FBLazyVector
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React-callinvoker
+  - RNReanimated (3.6.0):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
-    - React-Core/DevSupport
-    - React-Core/RCTWebSocket
-    - React-CoreModules
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-RCTActionSheet
-    - React-RCTAnimation
-    - React-RCTAppDelegate
-    - React-RCTBlob
-    - React-RCTImage
-    - React-RCTLinking
-    - React-RCTNetwork
-    - React-RCTSettings
-    - React-RCTText
     - ReactCommon/turbomodule/core
-    - Yoga
   - RNScreens (3.24.0):
     - React-Core
     - React-RCTImage
@@ -776,7 +751,7 @@ SPEC CHECKSUMS:
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
   RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
-  RNReanimated: 726395a2fa2f04cea340274ba57a4e659bc0d9c1
+  RNReanimated: 1dcf7602777a195cf34f1dcd658037a80a2c8af1
   RNScreens: b21dc57dfa2b710c30ec600786a3fc223b1b92e7
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981

--- a/example/package.json
+++ b/example/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.72.4",
     "react-native-gesture-handler": "2.12.1",
     "react-native-keyboard-controller": "link:../",
-    "react-native-reanimated": "3.4.2",
+    "react-native-reanimated": "3.6.0",
     "react-native-safe-area-context": "^4.7.1",
     "react-native-screens": "^3.24.0",
     "react-native-toast-message": "^2.1.6"

--- a/example/src/components/AwareScrollView/KeyboardAwareScrollView.tsx
+++ b/example/src/components/AwareScrollView/KeyboardAwareScrollView.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import { ScrollViewProps, useWindowDimensions } from 'react-native';
 import { FocusedInputLayoutChangedEvent, useReanimatedFocusedInput } from 'react-native-keyboard-controller';
 import Reanimated, {
@@ -9,7 +9,6 @@ import Reanimated, {
   useAnimatedScrollHandler,
   useAnimatedStyle,
   useSharedValue,
-  useWorkletCallback,
 } from 'react-native-reanimated';
 import { useSmoothKeyboardHandler } from './useSmoothKeyboardHandler';
 
@@ -84,7 +83,9 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
   /**
    * Function that will scroll a ScrollView as keyboard gets moving
    */
-  const maybeScroll = useWorkletCallback((e: number, animated: boolean = false) => {
+  const maybeScroll = useCallback((e: number, animated: boolean = false) => {
+    'worklet';
+
     const visibleRect = height - keyboardHeight.value;
     const point = (layout.value?.layout.absoluteY || 0) + (layout.value?.layout.height || 0);
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4940,10 +4940,10 @@ react-native-gesture-handler@2.12.1:
   version "0.0.0"
   uid ""
 
-react-native-reanimated@3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.4.2.tgz#744154fead6d8d31d5bd9ac617d8c84d74a6f697"
-  integrity sha512-FbtG+f1PB005vDTJSv4zAnTK7nNXi+FjFgbAM5gOzIZDajfph2BFMSUstzIsN8T77+OKuugUBmcTqLnQ24EBVg==
+react-native-reanimated@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.6.0.tgz#d2ca5f4c234f592af3d63bc749806e36d6e0a755"
+  integrity sha512-eDdhZTRYofrIqFB/Z5xLTWxcB7wDj4ifrNm+gZ2xHSZPjAQ747ukDdH9rglPyPmi+GcmDH7Wff411Xsw5fm45Q==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react": "18.2.0",
     "react-native": "0.72.4",
     "react-native-builder-bob": "^0.18.0",
-    "react-native-reanimated": "3.4.2",
+    "react-native-reanimated": "3.6.0",
     "release-it": "^14.2.2",
     "typescript": "^4.8.4"
   },

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -190,7 +190,6 @@ export const KeyboardProvider = ({
         onFocusedInputLayoutChangedReanimated={inputHandler}
         navigationBarTranslucent={navigationBarTranslucent}
         statusBarTranslucent={statusBarTranslucent}
-        // @ts-expect-error https://github.com/software-mansion/react-native-reanimated/pull/4923
         style={styles.container}
       >
         {children}

--- a/src/components/KeyboardAvoidingView/index.tsx
+++ b/src/components/KeyboardAvoidingView/index.tsx
@@ -6,7 +6,6 @@ import Reanimated, {
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
-  useWorkletCallback,
 } from 'react-native-reanimated';
 
 import { useKeyboardAnimation } from './hooks';
@@ -68,18 +67,22 @@ const KeyboardAvoidingView = forwardRef<View, React.PropsWithChildren<Props>>(
     const keyboard = useKeyboardAnimation();
     const { height: screenHeight } = useWindowDimensions();
 
-    const relativeKeyboardHeight = useWorkletCallback(() => {
+    const relativeKeyboardHeight = useCallback(() => {
+      'worklet';
+
       const keyboardY =
         screenHeight - keyboard.heightWhenOpened.value - keyboardVerticalOffset;
 
       return Math.max(frame.value.y + frame.value.height - keyboardY, 0);
     }, [screenHeight, keyboardVerticalOffset]);
 
-    const onLayoutWorklet = useWorkletCallback((layout: LayoutRectangle) => {
+    const onLayoutWorklet = useCallback((layout: LayoutRectangle) => {
+      'worklet';
+
       if (keyboard.isClosed.value) {
         initialFrame.value = layout;
       }
-    });
+    }, []);
     const onLayout = useCallback<NonNullable<ViewProps['onLayout']>>(
       (e) => {
         runOnUI(onLayoutWorklet)(e.nativeEvent.layout);
@@ -134,7 +137,6 @@ const KeyboardAvoidingView = forwardRef<View, React.PropsWithChildren<Props>>(
 
     return (
       <Reanimated.View
-        // @ts-expect-error because `ref` from reanimated is not compatible with react-native
         ref={ref}
         onLayout={onLayout}
         style={combinedStyles}

--- a/src/components/KeyboardStickyView/index.tsx
+++ b/src/components/KeyboardStickyView/index.tsx
@@ -48,12 +48,7 @@ const KeyboardStickyView = forwardRef<
     );
 
     return (
-      <Reanimated.View
-        // @ts-expect-error because `ref` from reanimated is not compatible with react-native
-        ref={ref}
-        style={styles}
-        {...props}
-      >
+      <Reanimated.View ref={ref} style={styles} {...props}>
         {children}
       </Reanimated.View>
     );

--- a/src/replicas.ts
+++ b/src/replicas.ts
@@ -1,11 +1,10 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Animated, Easing, Keyboard, Platform } from 'react-native';
 import {
   runOnUI,
   useAnimatedReaction,
   useDerivedValue,
   useSharedValue,
-  useWorkletCallback,
   withSpring,
 } from 'react-native-reanimated';
 
@@ -111,7 +110,9 @@ export const useReanimatedKeyboardAnimationReplica = () => {
 
   const progress = useDerivedValue(() => height.value / heightEvent.value);
 
-  const handler = useWorkletCallback((_height: number) => {
+  const handler = useCallback((_height: number) => {
+    'worklet';
+
     heightEvent.value = _height;
   }, []);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7769,10 +7769,10 @@ react-native-builder-bob@^0.18.0:
   optionalDependencies:
     jetifier "^2.0.0"
 
-react-native-reanimated@3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.4.2.tgz#744154fead6d8d31d5bd9ac617d8c84d74a6f697"
-  integrity sha512-FbtG+f1PB005vDTJSv4zAnTK7nNXi+FjFgbAM5gOzIZDajfph2BFMSUstzIsN8T77+OKuugUBmcTqLnQ24EBVg==
+react-native-reanimated@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.6.0.tgz#d2ca5f4c234f592af3d63bc749806e36d6e0a755"
+  integrity sha512-eDdhZTRYofrIqFB/Z5xLTWxcB7wDj4ifrNm+gZ2xHSZPjAQ747ukDdH9rglPyPmi+GcmDH7Wff411Xsw5fm45Q==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"


### PR DESCRIPTION
## 📜 Description
<!-- Describe your changes in detail -->

## 💡 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/289

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS
- 
- 

### iOS
- 
- 

### Android
- 
- 

## 🤔 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):
<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed