### PR TITLE
refactor: migrate off from `set-output`

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -53,8 +53,9 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install root dependencies
         run: yarn install
-      - name: Install node_modules for example/
-        run: yarn install --frozen-lockfile --cwd example
+      - name: Install example project dependencies
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: yarn
       - name: Install e2e dependencies
         run: yarn install --cwd e2e
       - name: Restore Gradle cache

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -42,7 +42,7 @@ jobs:
           java-version: '11'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/build-android-fabric.yml
+++ b/.github/workflows/build-android-fabric.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: fabric-yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/build-ios-fabric.yml
+++ b/.github/workflows/build-ios-fabric.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: fabric-yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -41,6 +41,17 @@ jobs:
         run: xcodebuild -version
       - name: Install AppleSimulatorUtils
         run: brew tap wix/brew && brew install applesimutils
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install root dependencies
         run: yarn install
       - name: Install example project dependencies


### PR DESCRIPTION
## 📜 Description

Migrate off from `set-output`.

## 💡 Motivation and Context

This command is deprecated and will be disabled in near future, so it's better to migrate to the variant that will not produce this warning.

## 📢 Changelog

### CI
- used modern syntax instead of `::set-output`;
- synchronized code between `e2e` actions;

## 🤔 How Has This Been Tested?

Tested via GH actions.

## 📸 Screenshots (if appropriate):

<img width="1351" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/1e801cf6-0ca4-4aff-9da8-0a7f41f0e2dd">

## 📝 Checklist

- [x] CI successfully passed