### PR TITLE
fix: react native 0.73.x build failing when new arch is enabled on iOS

### DIFF
--- a/.github/workflows/build-ios-fabric.yml
+++ b/.github/workflows/build-ios-fabric.yml
@@ -17,6 +17,7 @@ on:
       - main
     paths:
       - '.github/workflows/build-ios-fabric.yml'
+      - 'react-native-keyboard-controller.podspec'
       - 'ios/**'
       - 'FabricExample/ios/**'
       - 'yarn.lock'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -16,6 +16,7 @@ on:
       - main
     paths:
       - '.github/workflows/build-ios.yml'
+      - 'react-native-keyboard-controller.podspec'
       - 'ios/**'
       - 'example/ios/**'
       - 'yarn.lock'

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1407,7 +1407,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-keyboard-controller: e5f3a9a87ed7594ee6b400accc74d012f44b969e
+  react-native-keyboard-controller: 567097b4c14e2632a3fd6cce7a583cff8e5734e2
   react-native-safe-area-context: a283130af276caa22ecfed30c3d1eb450bc83439
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -697,7 +697,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f
   Flipper: 6edb735e6c3e332975d1b17956bcc584eccf5818
@@ -709,7 +709,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 81191603c4eaa01f5e4ae5737a9efcf64756c7b2
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: 809ecf2d460ed650a6aed7aa88b2ec45fab4779c

--- a/react-native-keyboard-controller.podspec
+++ b/react-native-keyboard-controller.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
     s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"${PODS_ROOT}/Headers/Private/Yoga\"",
       "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
       "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
       # This is handy when we want to detect if new arch is enabled in Swift code


### PR DESCRIPTION
## 📜 Description
Updating Pod to add Yoga style to HEADER_SEARCH_PATHS for new architecture

## 💡 Motivation and Context
For react native (0.73.X) build failing when new architecture is enabled on iOS.

## 📢 Changelog
Fix:  `yoga/style/Style.h` not found  when new arch is enabled on iOS

### iOS
- `yoga/style/Style.h` header has added to `HEADER_SEARCH_PATHS` on iOS Pods.

## 🤔 How Has This Been Tested?

## 📸 Screenshots (if appropriate):
<img width="1352" alt="keyboard-controller" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/52624436/5504a6e4-5627-41ad-ac46-df8a3d3bd762">


## 📝 Checklist

- [X] CI successfully passed