### PR TITLE
fix: build iOS projects when main .podspec file is changed

### DIFF
--- a/.github/workflows/build-ios-fabric.yml
+++ b/.github/workflows/build-ios-fabric.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - '.github/workflows/build-ios-fabric.yml'
+      - 'react-native-keyboard-controller.podspec'
       - 'ios/**'
       - 'FabricExample/ios/**'
       - 'yarn.lock'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - '.github/workflows/build-ios.yml'
+      - 'react-native-keyboard-controller.podspec'
       - 'ios/**'
       - 'example/ios/**'
       - 'yarn.lock'


### PR DESCRIPTION
## 📜 Description

Build iOS projects when main .podspec file is changed.

## 💡 Motivation and Context

Was discovered in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/304

## 📢 Changelog

### CI
- added `'react-native-keyboard-controller.podspec'` to `paths`;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed