### PR TITLE
fix: missing components mocks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,3 +42,4 @@
 ## 📝 Checklist
 
 - [ ] CI successfully passed
+- [ ] I added new mocks and corresponding unit-tests if library API was changed

--- a/.github/workflows/label-sponsors.yml
+++ b/.github/workflows/label-sponsors.yml
@@ -7,7 +7,7 @@ jobs:
     name: is-sponsor-label
     runs-on: ubuntu-latest
     steps:
-      - uses: JasonEtco/is-sponsor-label-action@v1.2.0
+      - uses: JasonEtco/is-sponsor-label-action@v2.0.0
         with:
           label: Sponsor 💖
         env:

--- a/FabricExample/__tests__/__snapshots__/components-rendering.spec.tsx.snap
+++ b/FabricExample/__tests__/__snapshots__/components-rendering.spec.tsx.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components rendering should render \`KeyboardAvoidingView\` 1`] = `
+<View
+  behavior="height"
+  style={
+    {
+      "marginBottom": 20,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "backgroundColor": "black",
+        "height": 20,
+        "width": 20,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`components rendering should render \`KeyboardAwareScrollView\` 1`] = `
+<RCTScrollView
+  bottomOffset={20}
+  style={
+    {
+      "marginBottom": 20,
+    }
+  }
+>
+  <View>
+    <View
+      style={
+        {
+          "backgroundColor": "black",
+          "height": 20,
+          "width": 20,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
 exports[`components rendering should render \`KeyboardControllerView\` 1`] = `
 <KeyboardControllerView
   statusBarTranslucent={true}
@@ -20,4 +64,30 @@ exports[`components rendering should render \`KeyboardProvider\` 1`] = `
     }
   />
 </KeyboardProvider>
+`;
+
+exports[`components rendering should render \`KeyboardStickyView\` 1`] = `
+<View
+  offset={
+    {
+      "closed": -20,
+      "opened": -40,
+    }
+  }
+  style={
+    {
+      "marginBottom": 20,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "backgroundColor": "black",
+        "height": 20,
+        "width": 20,
+      }
+    }
+  />
+</View>
 `;

--- a/FabricExample/__tests__/components-rendering.spec.tsx
+++ b/FabricExample/__tests__/components-rendering.spec.tsx
@@ -2,9 +2,16 @@ import { render } from "@testing-library/react-native";
 import React from "react";
 import { View } from "react-native";
 import {
+  KeyboardAvoidingView,
+  KeyboardAwareScrollView,
   KeyboardControllerView,
   KeyboardProvider,
+  KeyboardStickyView,
 } from "react-native-keyboard-controller";
+
+function EmptyView() {
+  return <View style={{ width: 20, height: 20, backgroundColor: "black" }} />;
+}
 
 function KeyboardControllerViewTest() {
   return <KeyboardControllerView statusBarTranslucent />;
@@ -13,8 +20,36 @@ function KeyboardControllerViewTest() {
 function KeyboardProviderTest() {
   return (
     <KeyboardProvider statusBarTranslucent>
-      <View style={{ width: 20, height: 20, backgroundColor: "black" }} />
+      <EmptyView />
     </KeyboardProvider>
+  );
+}
+
+const style = { marginBottom: 20 };
+
+function KeyboardAvoidingViewTest() {
+  return (
+    <KeyboardAvoidingView behavior="height" style={style}>
+      <EmptyView />
+    </KeyboardAvoidingView>
+  );
+}
+
+function KeyboardAwareScrollViewTest() {
+  return (
+    <KeyboardAwareScrollView bottomOffset={20} style={style}>
+      <EmptyView />
+    </KeyboardAwareScrollView>
+  );
+}
+
+const offset = { closed: -20, opened: -40 };
+
+function KeyboardStickyViewTest() {
+  return (
+    <KeyboardStickyView offset={offset} style={style}>
+      <EmptyView />
+    </KeyboardStickyView>
   );
 }
 
@@ -25,5 +60,17 @@ describe("components rendering", () => {
 
   it("should render `KeyboardProvider`", () => {
     expect(render(<KeyboardProviderTest />)).toMatchSnapshot();
+  });
+
+  it("should render `KeyboardAvoidingView`", () => {
+    expect(render(<KeyboardAvoidingViewTest />)).toMatchSnapshot();
+  });
+
+  it("should render `KeyboardAwareScrollView`", () => {
+    expect(render(<KeyboardAwareScrollViewTest />)).toMatchSnapshot();
+  });
+
+  it("should render `KeyboardStickyView`", () => {
+    expect(render(<KeyboardStickyViewTest />)).toMatchSnapshot();
   });
 });

--- a/FabricExample/__tests__/module-hook.spec.tsx
+++ b/FabricExample/__tests__/module-hook.spec.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+import { Button } from "react-native";
+import { useKeyboardController } from "react-native-keyboard-controller";
+
+function SwitchModuleOnOff() {
+  const { setEnabled, enabled } = useKeyboardController();
+
+  return (
+    <Button
+      title="Toggle module"
+      testID="toggle_module"
+      onPress={() => setEnabled(!enabled)}
+    />
+  );
+}
+
+describe("switching module on/off", () => {
+  it("should call `setEnabled` with expected params", () => {
+    const setEnabled = jest.fn();
+    (useKeyboardController as jest.Mock).mockReturnValue({
+      setEnabled,
+      enabled: true,
+    });
+    const { getByTestId } = render(<SwitchModuleOnOff />);
+
+    fireEvent.press(getByTestId("toggle_module"));
+
+    expect(setEnabled).toHaveBeenCalledTimes(1);
+    expect(setEnabled).toHaveBeenCalledWith(false);
+  });
+});

--- a/example/__tests__/__snapshots__/components-rendering.spec.tsx.snap
+++ b/example/__tests__/__snapshots__/components-rendering.spec.tsx.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components rendering should render \`KeyboardAvoidingView\` 1`] = `
+<View
+  behavior="height"
+  style={
+    {
+      "marginBottom": 20,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "backgroundColor": "black",
+        "height": 20,
+        "width": 20,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`components rendering should render \`KeyboardAwareScrollView\` 1`] = `
+<RCTScrollView
+  bottomOffset={20}
+  style={
+    {
+      "marginBottom": 20,
+    }
+  }
+>
+  <View>
+    <View
+      style={
+        {
+          "backgroundColor": "black",
+          "height": 20,
+          "width": 20,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
 exports[`components rendering should render \`KeyboardControllerView\` 1`] = `
 <KeyboardControllerView
   statusBarTranslucent={true}
@@ -20,4 +64,30 @@ exports[`components rendering should render \`KeyboardProvider\` 1`] = `
     }
   />
 </KeyboardProvider>
+`;
+
+exports[`components rendering should render \`KeyboardStickyView\` 1`] = `
+<View
+  offset={
+    {
+      "closed": -20,
+      "opened": -40,
+    }
+  }
+  style={
+    {
+      "marginBottom": 20,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "backgroundColor": "black",
+        "height": 20,
+        "width": 20,
+      }
+    }
+  />
+</View>
 `;

--- a/example/__tests__/components-rendering.spec.tsx
+++ b/example/__tests__/components-rendering.spec.tsx
@@ -2,9 +2,16 @@ import { render } from "@testing-library/react-native";
 import React from "react";
 import { View } from "react-native";
 import {
+  KeyboardAvoidingView,
+  KeyboardAwareScrollView,
   KeyboardControllerView,
   KeyboardProvider,
+  KeyboardStickyView,
 } from "react-native-keyboard-controller";
+
+function EmptyView() {
+  return <View style={{ width: 20, height: 20, backgroundColor: "black" }} />;
+}
 
 function KeyboardControllerViewTest() {
   return <KeyboardControllerView statusBarTranslucent />;
@@ -13,8 +20,36 @@ function KeyboardControllerViewTest() {
 function KeyboardProviderTest() {
   return (
     <KeyboardProvider statusBarTranslucent>
-      <View style={{ width: 20, height: 20, backgroundColor: "black" }} />
+      <EmptyView />
     </KeyboardProvider>
+  );
+}
+
+const style = { marginBottom: 20 };
+
+function KeyboardAvoidingViewTest() {
+  return (
+    <KeyboardAvoidingView behavior="height" style={style}>
+      <EmptyView />
+    </KeyboardAvoidingView>
+  );
+}
+
+function KeyboardAwareScrollViewTest() {
+  return (
+    <KeyboardAwareScrollView bottomOffset={20} style={style}>
+      <EmptyView />
+    </KeyboardAwareScrollView>
+  );
+}
+
+const offset = { closed: -20, opened: -40 };
+
+function KeyboardStickyViewTest() {
+  return (
+    <KeyboardStickyView offset={offset} style={style}>
+      <EmptyView />
+    </KeyboardStickyView>
   );
 }
 
@@ -25,5 +60,17 @@ describe("components rendering", () => {
 
   it("should render `KeyboardProvider`", () => {
     expect(render(<KeyboardProviderTest />)).toMatchSnapshot();
+  });
+
+  it("should render `KeyboardAvoidingView`", () => {
+    expect(render(<KeyboardAvoidingViewTest />)).toMatchSnapshot();
+  });
+
+  it("should render `KeyboardAwareScrollView`", () => {
+    expect(render(<KeyboardAwareScrollViewTest />)).toMatchSnapshot();
+  });
+
+  it("should render `KeyboardStickyView`", () => {
+    expect(render(<KeyboardStickyViewTest />)).toMatchSnapshot();
   });
 });

--- a/example/__tests__/module-hook.spec.tsx
+++ b/example/__tests__/module-hook.spec.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+import { Button } from "react-native";
+import { useKeyboardController } from "react-native-keyboard-controller";
+
+function SwitchModuleOnOff() {
+  const { setEnabled, enabled } = useKeyboardController();
+
+  return (
+    <Button
+      title="Toggle module"
+      testID="toggle_module"
+      onPress={() => setEnabled(!enabled)}
+    />
+  );
+}
+
+describe("switching module on/off", () => {
+  it("should call `setEnabled` with expected params", () => {
+    const setEnabled = jest.fn();
+    (useKeyboardController as jest.Mock).mockReturnValue({
+      setEnabled,
+      enabled: true,
+    });
+    const { getByTestId } = render(<SwitchModuleOnOff />);
+
+    fireEvent.press(getByTestId("toggle_module"));
+
+    expect(setEnabled).toHaveBeenCalledTimes(1);
+    expect(setEnabled).toHaveBeenCalledWith(false);
+  });
+});

--- a/jest/index.js
+++ b/jest/index.js
@@ -28,13 +28,19 @@ const focusedInput = {
 
 const mock = {
   // hooks
+  /// keyboard
   useKeyboardAnimation: jest.fn().mockReturnValue(values.animated),
   useReanimatedKeyboardAnimation: jest.fn().mockReturnValue(values.reanimated),
   useResizeMode: jest.fn(),
   useGenericKeyboardHandler: jest.fn(),
   useKeyboardHandler: jest.fn(),
+  /// input
   useReanimatedFocusedInput: jest.fn().mockReturnValue(focusedInput),
   useFocusedInputHandler: jest.fn(),
+  /// module
+  useKeyboardController: jest
+    .fn()
+    .mockReturnValue({ setEnabled: jest.fn(), enabled: true }),
   // modules
   KeyboardController: {
     setInputMode: jest.fn(),

--- a/jest/index.js
+++ b/jest/index.js
@@ -1,4 +1,4 @@
-import { Animated } from "react-native";
+import { Animated, ScrollView, View } from "react-native";
 
 const values = {
   animated: {
@@ -49,6 +49,10 @@ const mock = {
   KeyboardGestureArea: "KeyboardGestureArea",
   // providers
   KeyboardProvider: "KeyboardProvider",
+  // components
+  KeyboardStickyView: View,
+  KeyboardAvoidingView: View,
+  KeyboardAwareScrollView: ScrollView,
 };
 
 module.exports = mock;

--- a/src/components/KeyboardAvoidingView/hooks.ts
+++ b/src/components/KeyboardAvoidingView/hooks.ts
@@ -1,6 +1,6 @@
 import { useSharedValue } from "react-native-reanimated";
 
-import { useKeyboardHandler } from "../../hooks";
+import { useKeyboardHandler } from "react-native-keyboard-controller";
 
 export const useKeyboardAnimation = () => {
   const heightWhenOpened = useSharedValue(0);

--- a/src/components/KeyboardStickyView/index.tsx
+++ b/src/components/KeyboardStickyView/index.tsx
@@ -1,7 +1,8 @@
 import React, { forwardRef, useMemo } from "react";
 import Reanimated, { useAnimatedStyle } from "react-native-reanimated";
 
-import { useReanimatedKeyboardAnimation } from "../../hooks";
+import { useReanimatedKeyboardAnimation } from "react-native-keyboard-controller";
+
 import useKeyboardInterpolation from "../hooks/useKeyboardInterpolation";
 
 import type { View, ViewProps } from "react-native";

--- a/src/components/hooks/useKeyboardInterpolation.ts
+++ b/src/components/hooks/useKeyboardInterpolation.ts
@@ -3,7 +3,7 @@ import {
   useSharedValue,
 } from "react-native-reanimated";
 
-import { useKeyboardHandler } from "../../hooks";
+import { useKeyboardHandler } from "react-native-keyboard-controller";
 
 type KeyboardInterpolationOutput = [number, number];
 


### PR DESCRIPTION
## 📜 Description

Added mocks for exported components, such as `KeyboardAvoidingView`, `KeyboardAwareScrollView`, `KeyboardStickyView`.

## 💡 Motivation and Context

The library should support mocks for exported components out of the box.

In an ideal world I'd like to mock dependencies that depends on native implementation and use a real implementation for components. However since we mock entire module (`react-native-keyboard-controller`) it becomes impossible to mock it partially. 

Even with `jest.requireActual()` for components import from `react-native-keyboard-controller` produced `{}` and as a result `useKeyboardHandler` and other native dependencies were undefined and it causes errors during component rendering.

Also a controversial topic was how to mock these components - as `View`/`ScrollView` from RN or as strings. I had at implementation of other popular repositories and came to conclusion, that it should be mocked as RN components (as a reference I used `react-native-gesture-handler`).

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/319

## 📢 Changelog

### Docs
- added new checkbox for PR template (to verify mocks);

### CI
- use latest version of sponsor labeling, because old one uses deprecated Node 12;

### JS

- added mocks for `KeyboardAvoidingView`, `KeyboardAwareScrollView`, `KeyboardStickyView`;
- use imports from `react-native-keyboard-controller` in `components`;

## 🤔 How Has This Been Tested?

Added new snapshot tests to Fabric and paper examples.

## 📝 Checklist

- [x] CI successfully passed
