### PR TITLE
fix: memory leak on iOS

### DIFF
--- a/ios/views/KeyboardControllerViewManager.swift
+++ b/ios/views/KeyboardControllerViewManager.swift
@@ -43,7 +43,6 @@ class KeyboardControllerView: UIView {
       onLayoutChangedHandler: { [weak self] event in self?.onLayoutChanged(event: event) },
       onTextChangedHandler: { [weak self] text in self?.onTextChanged(text: text) }
     )
-
     keyboardObserver = KeyboardMovementObserver(
       handler: { [weak self] event, height, progress, duration, target in
         self?.onEvent(event: event, height: height, progress: progress, duration: duration, target: target)

--- a/ios/views/KeyboardControllerViewManager.swift
+++ b/ios/views/KeyboardControllerViewManager.swift
@@ -39,8 +39,19 @@ class KeyboardControllerView: UIView {
     self.bridge = bridge
     eventDispatcher = bridge.eventDispatcher()
     super.init(frame: frame)
-    inputObserver = FocusedInputObserver(onLayoutChangedHandler: onLayoutChanged, onTextChangedHandler: onTextChanged)
-    keyboardObserver = KeyboardMovementObserver(handler: onEvent, onNotify: onNotify)
+    inputObserver = FocusedInputObserver(
+      onLayoutChangedHandler: { [weak self] event in self?.onLayoutChanged(event: event) },
+      onTextChangedHandler: { [weak self] text in self?.onTextChanged(text: text) }
+    )
+
+    keyboardObserver = KeyboardMovementObserver(
+      handler: { [weak self] event, height, progress, duration, target in
+        self?.onEvent(event: event, height: height, progress: progress, duration: duration, target: target)
+      },
+      onNotify: { [weak self] event, data in
+        self?.onNotify(event: event, data: data)
+      }
+    )
   }
 
   @available(*, unavailable)


### PR DESCRIPTION
## 📜 Description

Fixed memory leak on iOS in paper architecture.

## 💡 Motivation and Context

I used strong references when specified methods as callbacks. I had to use `[weak self]` in order to create a weak reference and object can be deallocated properly.

I also tested Fabric, but when I keep view as simple as possible - view still doesn't call `deinit`.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/317

## 📢 Changelog

### iOS

- added `[weak self]` for callbacks in `KeyboardMovementObserver` and `FocusedInputObserver`;

## 🤔 How Has This Been Tested?

Tested in XCode.

## 📸 Screenshots (if appropriate):

|Before|After|
|------|------|
|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/4e7bffa8-b226-4948-905d-cd5c8ab01a0f">|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/c29fec82-69ab-43b4-a87a-d3cf2fae4938">|
|<img width="658" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/c547f381-b057-41b3-8dec-9829844c80b5">|<img width="648" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/9c4045d5-1ec0-44e8-b901-a56142703f7a">|

## 📝 Checklist

- [x] CI successfully passed
- [x] added new mocks and corresponding unit-tests if library API was changed
