### PR TITLE
fix: set `currentInput` to `nil` to fix a memory leak

### DIFF
--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -79,6 +79,7 @@ public class FocusedInputObserver: NSObject {
 
   @objc func keyboardWillHide(_: Notification) {
     removeObservers()
+    currentInput = nil
     dispatchEventToJS(data: noFocusedInputEvent)
   }
 


### PR DESCRIPTION
## 📜 Description

Set `currentInput` to `nil` to fix a memory leak.

## 💡 Motivation and Context

If we store a reference as `currentInput = UIResponder.current`, then even if view is removed from the screen the view will not be deallocated (because we have a strong reference) and it'll be kind of memory leak (because view should be deallocated and free up a memory).

To fix this problem we need to remove a reference so ARC (automatic reference counter) will work properly and will deallocate view.

Actually it's not a very big problem, because users are switching between inputs frequently (and we overwrite a reference every time) so we have kind of have a constant memory allocation and it is not growing over time. Also we don't interact with this input anymore (don't call `becomeFirstResponder` and other methods), so it's kind of "safe".

## 📢 Changelog

### iOS

- set `currentInput` to `nil` in `keyboardWillHide` handler;

## 🤔 How Has This Been Tested?

Tested on iPhone 15 Pro (iOS 17.2) + e2e tests.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="656" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/c03c2ddd-e71f-460d-aa65-c32142d64dd6">|<img width="658" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/b27fd5f7-bafb-45cb-a14b-fede4f4b797c">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
