### PR TITLE
fix: fire `onScroll` from props in `KeyboardAwareScrollView`

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -26,7 +26,7 @@ type KeyboardAwareScrollViewProps = {
   bottomOffset?: number;
 } & ScrollViewProps;
 
-/**
+/*
  * Everything begins from `onStart` handler. This handler is called every time,
  * when keyboard changes its size or when focused `TextInput` was changed. In
  * this handler we are calculating/memoizing values which later will be used

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -254,7 +254,8 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
     <Reanimated.ScrollView
       ref={scrollViewAnimatedRef}
       {...rest}
-      onScroll={onScroll}
+      // @ts-expect-error `onScrollReanimated` is a fake prop needed for reanimated to intercept scroll events
+      onScrollReanimated={onScroll}
       scrollEventThrottle={16}
     >
       {children}


### PR DESCRIPTION
## 📜 Description

Fire `onScroll` from props in `KeyboardAwareScrollView`.

## 💡 Motivation and Context

Initially I wanted to achieve that as `runOnJS(props.onScroll)({ nativeEvent: e })`. But in this case I'm getting:

```bash
Argument of type '{ nativeEvent: ReanimatedScrollEvent; }' is not assignable to parameter of type 'NativeSyntheticEvent<NativeScrollEvent>'.
  Type '{ nativeEvent: ReanimatedScrollEvent; }' is missing the following properties from type 'NativeSyntheticEvent<NativeScrollEvent>': currentTarget, target, bubbles, cancelable, and 10 more.ts(2345)
```

And it's really incorrect, because several properties will be missing and js-based handler (not based on `Animated.event`) may not read expected properties (such as `target` etc.).

So I wanted to pass `onScroll` handler from reanimated as `onScrollReanimated` property. In this case `onScroll` will be passed from `rest` props and will be fired correctly.

## 📢 Changelog

### JS

- changed component documentation to multiline comment;
- pass `onScroll` (as `rest`) to `ScrollView`.

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
