### PR TITLE
fix: slow back transitions on Android < 11 in `KeyboardAwareScrollView`

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -116,7 +116,7 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
         );
         const targetScrollY =
           Math.max(interpolatedScrollTo, 0) + scrollPosition.value;
-        scrollTo(scrollViewAnimatedRef, 0, targetScrollY - 0.5, animated);
+        scrollTo(scrollViewAnimatedRef, 0, targetScrollY, animated);
 
         return interpolatedScrollTo;
       }
@@ -257,7 +257,13 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
 
   const view = useAnimatedStyle(
     () => ({
-      paddingBottom: currentKeyboardFrameHeight.value,
+      // animations become laggy when scrolling to the end of the `ScrollView` (when the last input is focused)
+      // this happens because the layout recalculates on every frame. To avoid this we slightly increase padding
+      // by `+1`. In this way we assure, that `scrollTo` will never scroll to the end, because it uses interpolation
+      // from 0 to `keyboardHeight`, and here our padding is `keyboardHeight + 1`. It allows us not to re-run layout
+      // re-calculation on every animation frame and it helps to achieve smooth animation.
+      // see: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/342
+      paddingBottom: currentKeyboardFrameHeight.value + 1,
     }),
     [],
   );

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -90,6 +90,7 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
   const onScroll = useAnimatedScrollHandler(
     {
       onScroll: (e) => {
+        console.log("a", e.contentOffset.y);
         position.value = e.contentOffset.y;
       },
     },
@@ -114,9 +115,11 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
           [initialKeyboardSize.value, keyboardHeight.value],
           [0, keyboardHeight.value - (height - point) + bottomOffset],
         );
+        console.log({interpolatedScrollTo, e});
         const targetScrollY =
           Math.max(interpolatedScrollTo, 0) + scrollPosition.value;
-        scrollTo(scrollViewAnimatedRef, 0, targetScrollY, animated);
+        scrollTo(scrollViewAnimatedRef, 0, targetScrollY - 0.5, animated);
+        // console.log({targetScrollY, scroll: position.value});
 
         return interpolatedScrollTo;
       }
@@ -173,6 +176,8 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
       onStart: (e) => {
         "worklet";
 
+        // console.log("onStart", e, new Date().getTime());
+
         const keyboardWillChangeSize =
           keyboardHeight.value !== e.height && e.height > 0;
         keyboardWillAppear.value = e.height > 0 && keyboardHeight.value === 0;
@@ -221,6 +226,8 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
       onMove: (e) => {
         "worklet";
 
+        // console.log("onMove", e, new Date().getTime());
+
         currentKeyboardFrameHeight.value = e.height;
 
         // if the user has set disableScrollOnKeyboardHide, only auto-scroll when the keyboard opens
@@ -230,6 +237,8 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
       },
       onEnd: (e) => {
         "worklet";
+
+        // console.log("onEnd", e, new Date().getTime());
 
         keyboardHeight.value = e.height;
         scrollPosition.value = position.value;

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -90,7 +90,6 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
   const onScroll = useAnimatedScrollHandler(
     {
       onScroll: (e) => {
-        console.log("a", e.contentOffset.y);
         position.value = e.contentOffset.y;
       },
     },
@@ -115,11 +114,9 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
           [initialKeyboardSize.value, keyboardHeight.value],
           [0, keyboardHeight.value - (height - point) + bottomOffset],
         );
-        console.log({interpolatedScrollTo, e});
         const targetScrollY =
           Math.max(interpolatedScrollTo, 0) + scrollPosition.value;
         scrollTo(scrollViewAnimatedRef, 0, targetScrollY - 0.5, animated);
-        // console.log({targetScrollY, scroll: position.value});
 
         return interpolatedScrollTo;
       }
@@ -176,8 +173,6 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
       onStart: (e) => {
         "worklet";
 
-        // console.log("onStart", e, new Date().getTime());
-
         const keyboardWillChangeSize =
           keyboardHeight.value !== e.height && e.height > 0;
         keyboardWillAppear.value = e.height > 0 && keyboardHeight.value === 0;
@@ -226,8 +221,6 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
       onMove: (e) => {
         "worklet";
 
-        // console.log("onMove", e, new Date().getTime());
-
         currentKeyboardFrameHeight.value = e.height;
 
         // if the user has set disableScrollOnKeyboardHide, only auto-scroll when the keyboard opens
@@ -237,8 +230,6 @@ const KeyboardAwareScrollView: FC<KeyboardAwareScrollViewProps> = ({
       },
       onEnd: (e) => {
         "worklet";
-
-        // console.log("onEnd", e, new Date().getTime());
 
         keyboardHeight.value = e.height;
         scrollPosition.value = position.value;

--- a/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
+++ b/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
@@ -17,7 +17,7 @@ const IS_ANDROID_ELEVEN_OR_HIGHER_OR_IOS =
 // duration is taken from here: https://github.com/DrKLO/Telegram/blob/e9a35cea54c06277c69d41b8e25d94b5d7ede065/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/AdjustPanLayoutHelper.java#L39
 // and bezier is taken from: https://github.com/DrKLO/Telegram/blob/e9a35cea54c06277c69d41b8e25d94b5d7ede065/TMessagesProj/src/main/java/androidx/recyclerview/widget/ChatListItemAnimator.java#L40
 const TELEGRAM_ANDROID_TIMING_CONFIG = {
-  duration: 2500,
+  duration: 250,
   easing: Easing.bezier(
     0.19919472913616398,
     0.010644531250000006,

--- a/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
+++ b/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
@@ -26,10 +26,6 @@ const TELEGRAM_ANDROID_TIMING_CONFIG = {
   ),
 };
 
-// 1. Если сбрасывать persistedHeight в onEnd, то будут рейс кондишены, неправильный progress и т. д.
-// 2. Сбрасывать persistedHeight всё-таки нужно, чтобы правильно определять переключение между инпутами
-// 3. Если его сбрасывать в useAnimatedReaction, то получается 2 onEnd события
-
 /**
  * Hook that uses default transitions for iOS and Android > 11, and uses
  * custom interpolation on Android < 11 to achieve more smooth animation
@@ -67,12 +63,8 @@ export const useSmoothKeyboardHandler: typeof useKeyboardHandler = (
       handler.onMove?.(evt);
 
       // dispatch `onEnd`
-      // console.log(height.value, evt.height);
       if (evt.height === height.value) {
-        console.log("onENd2");
         handler.onEnd?.(evt);
-        // нужно для правильных запусков onMove если высота клавиатуры та же (с 7 до 9)
-        //
         persistedHeight.value = height.value;
       }
     },
@@ -91,7 +83,6 @@ export const useSmoothKeyboardHandler: typeof useKeyboardHandler = (
           e.height === persistedHeight.value
         ) {
           handler.onStart?.(e);
-          console.log("onEnd");
           handler.onEnd?.(e);
 
           return;
@@ -107,7 +98,6 @@ export const useSmoothKeyboardHandler: typeof useKeyboardHandler = (
         // to achieve smoother animation and use `animatedKeyboardHeight` as animation
         // driver
         if (!IS_ANDROID_ELEVEN_OR_HIGHER_OR_IOS) {
-          console.log("withTiming");
           animatedKeyboardHeight.value = withTiming(
             e.height,
             TELEGRAM_ANDROID_TIMING_CONFIG,
@@ -128,7 +118,6 @@ export const useSmoothKeyboardHandler: typeof useKeyboardHandler = (
         "worklet";
 
         if (IS_ANDROID_ELEVEN_OR_HIGHER_OR_IOS) {
-          console.log("onEnd1");
           handler.onEnd?.(e);
         }
       },

--- a/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
+++ b/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
@@ -104,8 +104,12 @@ export const useSmoothKeyboardHandler: typeof useKeyboardHandler = (
           );
         }
 
-        // TODO: incorrect duration property for `!IS_ANDROID_ELEVEN_OR_HIGHER_OR_IOS`
-        handler.onStart?.(e);
+        handler.onStart?.({
+          ...e,
+          duration: IS_ANDROID_ELEVEN_OR_HIGHER_OR_IOS
+            ? e.duration
+            : TELEGRAM_ANDROID_TIMING_CONFIG.duration,
+        });
       },
       onMove: (e) => {
         "worklet";


### PR DESCRIPTION
## 📜 Description

Improved FPS for `KeyboardAwareScrollView` when keyboard gets closed (and scroll position is the end of the scroll view).

## 💡 Motivation and Context

The fix consist of several stages. Below they are:

### 1️⃣ Incorrect `persistentHeight` update

When we reset `persistentHeight` in `onEnd` we:
- produce potential race condition (`persistentHeight` can be set to `0` after timing animation completion and because of that `onEnd` handler may not be fired at all)
- calculate `progress` incorrectly (it can be `Infinity` or `NaN` in last frames of animation

### 2️⃣ Avoid double `onMove`/`onEnd` events

If we reset `persistentHeight` to `0` in `useAnimatedReaction` (where we dispatch `onEnd`) -> we run animation effect again, and it may produce additional `onMove`/`onEnd` events after `onEnd` event. So I added `if (persistentHeight.value === 0)` check.

### 3️⃣ Don't re-calculate layout in every animation frame

When we scroll to the end of ScrollView and change padding, it seems like we do a heavy layout re-calculation. That's why I added `+1` padding.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/335

## 📢 Changelog

### JS

-  fixed `useSmoothKeyboardHandler` for Android < 10;

## 🤔 How Has This Been Tested?

Tested manually on Xiaomi Redmi Note 5 Pro. Also I use 2500ms instead of 250ms timing to see more detailed difference.

## 📸 Screenshots (if appropriate):

|Original performance|With corrected `useSmoothKeyboardHandler`|With `+1` fix|
|---------------------|----------------------------------------------|----------------|
|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e7f95f23-ed88-4d8c-80cb-1fca06d4697f">|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/fe9cc67f-61e8-40f2-8d17-b3fce4bd1c10">|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/1bb7f2b6-726b-47f6-b71e-c96c2086344f">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
