### PR TITLE
fix: use conditional import for supporting frameworks

### DIFF
--- a/ios/views/KeyboardControllerView.mm
+++ b/ios/views/KeyboardControllerView.mm
@@ -12,7 +12,12 @@
 #import "FocusedInputLayoutChangedEvent.h"
 #import "FocusedInputTextChangedEvent.h"
 #import "KeyboardMoveEvent.h"
+
+#if __has_include("react_native_keyboard_controller-Swift.h")
+#import "react_native_keyboard_controller-Swift.h"
+#else
 #import <react_native_keyboard_controller/react_native_keyboard_controller-Swift.h>
+#endif
 
 #import <react/renderer/components/reactnativekeyboardcontroller/ComponentDescriptors.h>
 #import <react/renderer/components/reactnativekeyboardcontroller/EventEmitters.h>

--- a/ios/views/KeyboardControllerView.mm
+++ b/ios/views/KeyboardControllerView.mm
@@ -12,7 +12,7 @@
 #import "FocusedInputLayoutChangedEvent.h"
 #import "FocusedInputTextChangedEvent.h"
 #import "KeyboardMoveEvent.h"
-#import "react_native_keyboard_controller-Swift.h"
+#import <react_native_keyboard_controller/react_native_keyboard_controller-Swift.h>
 
 #import <react/renderer/components/reactnativekeyboardcontroller/ComponentDescriptors.h>
 #import <react/renderer/components/reactnativekeyboardcontroller/EventEmitters.h>


### PR DESCRIPTION
## 📜 Description

Use library name as prefix and absolute import if static frameworks are enabled.

## 💡 Motivation and Context

I added conditional imports with `__has_include` check. When static frameworks are enabled we have to specify a prefix which is equivalent of library name. For more information you can see answer here: https://stackoverflow.com/a/47106911/9272042

So this import:

```objc
#import "react_native_keyboard_controller-Swift.h"
```

gets transformed into this one

```objc
#if __has_include("react_native_keyboard_controller-Swift.h")
#import "react_native_keyboard_controller-Swift.h"
#else
#import <react_native_keyboard_controller/react_native_keyboard_controller-Swift.h>
#endif
```

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/354

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- use conditional import;

## 🤔 How Has This Been Tested?

Tested manually in reproduction example.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
