### PR TITLE
fix: crash on web

### DIFF
--- a/src/components/KeyboardToolbar/Arrow.tsx
+++ b/src/components/KeyboardToolbar/Arrow.tsx
@@ -3,7 +3,7 @@ import { Animated, StyleSheet, View } from "react-native";
 
 import useColorScheme from "../hooks/useColorScheme";
 
-import type { KeyboardToolbarTheme } from "./colors";
+import type { KeyboardToolbarTheme } from "./types";
 import type { ViewStyle } from "react-native";
 
 type ArrowProps = {

--- a/src/components/KeyboardToolbar/Button.tsx
+++ b/src/components/KeyboardToolbar/Button.tsx
@@ -8,7 +8,7 @@ import {
 
 import useColorScheme from "../hooks/useColorScheme";
 
-import type { KeyboardToolbarTheme } from "./colors";
+import type { KeyboardToolbarTheme } from "./types";
 import type { PropsWithChildren } from "react";
 import type { ViewStyle } from "react-native";
 

--- a/src/components/KeyboardToolbar/colors.native.ts
+++ b/src/components/KeyboardToolbar/colors.native.ts
@@ -1,0 +1,16 @@
+import type { KeyboardToolbarTheme } from "./types";
+
+export const colors: KeyboardToolbarTheme = {
+  light: {
+    primary: "#2c2c2c",
+    disabled: "#B0BEC5",
+    background: "#f3f3f4",
+    ripple: "#bcbcbcbc",
+  },
+  dark: {
+    primary: "#fafafa",
+    disabled: "#707070",
+    background: "#2C2C2E",
+    ripple: "#F8F8F888",
+  },
+};

--- a/src/components/KeyboardToolbar/colors.native.ts
+++ b/src/components/KeyboardToolbar/colors.native.ts
@@ -1,16 +1,37 @@
+import { Platform, PlatformColor } from "react-native";
+
 import type { KeyboardToolbarTheme } from "./types";
+import type { ColorValue } from "react-native";
 
 export const colors: KeyboardToolbarTheme = {
   light: {
-    primary: "#2c2c2c",
-    disabled: "#B0BEC5",
-    background: "#f3f3f4",
+    primary: Platform.select<ColorValue>({
+      ios: PlatformColor("link"),
+      default: "#2c2c2c",
+    }),
+    disabled: Platform.select<ColorValue>({
+      ios: PlatformColor("systemGray4"),
+      default: "#B0BEC5",
+    }),
+    background: Platform.select({
+      ios: "#F8F8F8",
+      default: "#f3f3f4",
+    }),
     ripple: "#bcbcbcbc",
   },
   dark: {
-    primary: "#fafafa",
-    disabled: "#707070",
-    background: "#2C2C2E",
+    primary: Platform.select<ColorValue>({
+      ios: PlatformColor("label"),
+      default: "#fafafa",
+    }),
+    disabled: Platform.select<ColorValue>({
+      ios: PlatformColor("systemGray"),
+      default: "#707070",
+    }),
+    background: Platform.select({
+      ios: "#555756",
+      default: "#2C2C2E",
+    }),
     ripple: "#F8F8F888",
   },
 };

--- a/src/components/KeyboardToolbar/colors.ts
+++ b/src/components/KeyboardToolbar/colors.ts
@@ -1,21 +1,7 @@
 import { Platform, PlatformColor } from "react-native";
 
+import type { KeyboardToolbarTheme } from "./types";
 import type { ColorValue } from "react-native";
-
-type Theme = {
-  /** Color for arrow when it's enabled */
-  primary: ColorValue;
-  /** Color for arrow when it's disabled */
-  disabled: ColorValue;
-  /** Keyboard toolbar background color */
-  background: ColorValue;
-  /** Color for ripple effect (on button touch) on Android */
-  ripple: ColorValue;
-};
-export type KeyboardToolbarTheme = {
-  light: Theme;
-  dark: Theme;
-};
 
 export const colors: KeyboardToolbarTheme = {
   light: {

--- a/src/components/KeyboardToolbar/colors.ts
+++ b/src/components/KeyboardToolbar/colors.ts
@@ -1,37 +1,16 @@
-import { Platform, PlatformColor } from "react-native";
-
 import type { KeyboardToolbarTheme } from "./types";
-import type { ColorValue } from "react-native";
 
 export const colors: KeyboardToolbarTheme = {
   light: {
-    primary: Platform.select<ColorValue>({
-      ios: PlatformColor("link"),
-      default: "#2c2c2c",
-    }),
-    disabled: Platform.select<ColorValue>({
-      ios: PlatformColor("systemGray4"),
-      default: "#B0BEC5",
-    }),
-    background: Platform.select({
-      ios: "#F8F8F8",
-      default: "#f3f3f4",
-    }),
+    primary: "#2c2c2c",
+    disabled: "#B0BEC5",
+    background: "#f3f3f4",
     ripple: "#bcbcbcbc",
   },
   dark: {
-    primary: Platform.select<ColorValue>({
-      ios: PlatformColor("label"),
-      default: "#fafafa",
-    }),
-    disabled: Platform.select<ColorValue>({
-      ios: PlatformColor("systemGray"),
-      default: "#707070",
-    }),
-    background: Platform.select({
-      ios: "#555756",
-      default: "#2C2C2E",
-    }),
+    primary: "#fafafa",
+    disabled: "#707070",
+    background: "#2C2C2E",
     ripple: "#F8F8F888",
   },
 };

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -13,7 +13,7 @@ import Arrow from "./Arrow";
 import Button from "./Button";
 import { colors } from "./colors";
 
-import type { KeyboardToolbarTheme } from "./colors";
+import type { KeyboardToolbarTheme } from "./types";
 import type { ReactNode } from "react";
 
 export type KeyboardToolbarProps = {

--- a/src/components/KeyboardToolbar/types.ts
+++ b/src/components/KeyboardToolbar/types.ts
@@ -1,0 +1,16 @@
+import type { ColorValue } from "react-native";
+
+type Theme = {
+  /** Color for arrow when it's enabled */
+  primary: ColorValue;
+  /** Color for arrow when it's disabled */
+  disabled: ColorValue;
+  /** Keyboard toolbar background color */
+  background: ColorValue;
+  /** Color for ripple effect (on button touch) on Android */
+  ripple: ColorValue;
+};
+export type KeyboardToolbarTheme = {
+  light: Theme;
+  dark: Theme;
+};


### PR DESCRIPTION
## 📜 Description

Fixed a crash on web.

## 💡 Motivation and Context

It was a regression since `1.10.0` version. `PlatformColor` is not available on `web` and it will throw exception, because `KeyboardToolbar` is exported from `index` file and will be evaluated as soon as something gets imported from the package (i. e. `KeyboardProvider`).

To fix the problem I created two files: `colors.ts` (all platforms excluding mobile) and `colors.native.ts` (for mobile).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- created two files: `colors.ts` (all platforms excluding mobile) and `colors.native.ts` (for mobile)
- moved types to common `types` file;
- restructed imports to look into `types` file instead `colors`;

## 🤔 How Has This Been Tested?

Tested on web project.

## 📸 Screenshots (if appropriate):

<img width="1728" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/c1d12f79-0f40-4513-8bc4-f5dd8aaa89a4">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
