### PR TITLE
fix: android build fail with rnx kit & treeShaking enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ lib/
 
 # testing
 /coverage
+
+# yarn cache folder (v2+)
+.yarn

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,5 +4,5 @@ export { default as KeyboardAwareScrollView } from "./KeyboardAwareScrollView";
 export {
   default as KeyboardToolbar,
   DefaultKeyboardToolbarTheme,
-  type KeyboardToolbarProps,
 } from "./KeyboardToolbar";
+export type { KeyboardToolbarProps } from "./KeyboardToolbar"

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,4 +5,4 @@ export {
   default as KeyboardToolbar,
   DefaultKeyboardToolbarTheme,
 } from "./KeyboardToolbar";
-export type { KeyboardToolbarProps } from "./KeyboardToolbar"
+export type { KeyboardToolbarProps } from "./KeyboardToolbar";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,5 +4,5 @@ export { default as KeyboardAwareScrollView } from "./KeyboardAwareScrollView";
 export {
   default as KeyboardToolbar,
   DefaultKeyboardToolbarTheme,
-  KeyboardToolbarProps,
+  type KeyboardToolbarProps,
 } from "./KeyboardToolbar";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,5 @@ export {
   // keyboard toolbar
   KeyboardToolbar,
   DefaultKeyboardToolbarTheme,
-  KeyboardToolbarProps,
+  type KeyboardToolbarProps,
 } from "./components";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,6 @@ export {
   // keyboard toolbar
   KeyboardToolbar,
   DefaultKeyboardToolbarTheme,
-  type KeyboardToolbarProps,
 } from "./components";
+export type { KeyboardToolbarProps }  from "./components";
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,4 @@ export {
   KeyboardToolbar,
   DefaultKeyboardToolbarTheme,
 } from "./components";
-export type { KeyboardToolbarProps }  from "./components";
-
+export type { KeyboardToolbarProps } from "./components";

--- a/src/monkey-patch.android.ts
+++ b/src/monkey-patch.android.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error because there is no corresponding type definition
 import * as NativeAndroidManager from "react-native/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid";
 const RCTStatusBarManagerCompat = require("./specs/NativeStatusBarManagerCompat").default;
 

--- a/src/monkey-patch.android.ts
+++ b/src/monkey-patch.android.ts
@@ -1,39 +1,35 @@
-// @ts-expect-error because there is no corresponding type definition
 import * as NativeAndroidManager from "react-native/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid";
+const RCTStatusBarManagerCompat = require("./specs/NativeStatusBarManagerCompat").default;
 
-const DefaultNativeAndroidManager = NativeAndroidManager.default;
-const getConstants = NativeAndroidManager.default.getConstants;
-const RCTStatusBarManagerCompat =
-  require("./specs/NativeStatusBarManagerCompat").default;
+// Copy original default manager to keep its original state and methods
+const OriginalNativeAndroidManager = {...NativeAndroidManager.default};
 
+// Create a new object that modifies the necessary methods
 // On Android < 11 RN uses legacy API which breaks EdgeToEdge mode in RN, so
 // in order to use library on all available platforms we have to monkey patch
 // default RN implementation and use modern `WindowInsetsControllerCompat`.
-export const applyMonkeyPatch = () => {
-  NativeAndroidManager.default = {
-    getConstants,
-    setColor(color: number, animated: boolean): void {
-      RCTStatusBarManagerCompat.setColor(color, animated);
-    },
-
-    setTranslucent(translucent: boolean): void {
-      RCTStatusBarManagerCompat.setTranslucent(translucent);
-    },
-
-    /**
-     *  - statusBarStyles can be:
-     *    - 'default'
-     *    - 'dark-content'
-     */
-    setStyle(statusBarStyle?: string): void {
-      RCTStatusBarManagerCompat.setStyle(statusBarStyle);
-    },
-
-    setHidden(hidden: boolean): void {
-      RCTStatusBarManagerCompat.setHidden(hidden);
-    },
-  };
+const ModifiedNativeAndroidManager = {
+  ...NativeAndroidManager.default, // Spread original properties to keep existing functionality
+  setColor: (color: number, animated: boolean): void => {
+    RCTStatusBarManagerCompat.setColor(color, animated);
+  },
+  setTranslucent: (translucent: boolean): void => {
+    RCTStatusBarManagerCompat.setTranslucent(translucent);
+  },
+  setStyle: (statusBarStyle?: string): void => {
+    RCTStatusBarManagerCompat.setStyle(statusBarStyle);
+  },
+  setHidden: (hidden: boolean): void => {
+    RCTStatusBarManagerCompat.setHidden(hidden);
+  },
 };
+
+// Define a function to apply the monkey patch
+export const applyMonkeyPatch = () => {
+  Object.assign(NativeAndroidManager.default, ModifiedNativeAndroidManager);
+};
+
+// Define a function to revert changes back to the original state
 export const revertMonkeyPatch = () => {
-  NativeAndroidManager.default = DefaultNativeAndroidManager;
+  Object.assign(NativeAndroidManager.default, OriginalNativeAndroidManager);
 };

--- a/src/monkey-patch.android.ts
+++ b/src/monkey-patch.android.ts
@@ -16,6 +16,11 @@ const ModifiedNativeAndroidManager = {
   setTranslucent: (translucent: boolean): void => {
     RCTStatusBarManagerCompat.setTranslucent(translucent);
   },
+   /**
+     *  - statusBarStyles can be:
+     *    - 'default'
+     *    - 'dark-content'
+     */
   setStyle: (statusBarStyle?: string): void => {
     RCTStatusBarManagerCompat.setStyle(statusBarStyle);
   },

--- a/src/monkey-patch.android.ts
+++ b/src/monkey-patch.android.ts
@@ -1,9 +1,12 @@
 // @ts-expect-error because there is no corresponding type definition
 import * as NativeAndroidManager from "react-native/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid";
-const RCTStatusBarManagerCompat = require("./specs/NativeStatusBarManagerCompat").default;
+
+const RCTStatusBarManagerCompat =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("./specs/NativeStatusBarManagerCompat").default;
 
 // Copy original default manager to keep its original state and methods
-const OriginalNativeAndroidManager = {...NativeAndroidManager.default};
+const OriginalNativeAndroidManager = { ...NativeAndroidManager.default };
 
 // Create a new object that modifies the necessary methods
 // On Android < 11 RN uses legacy API which breaks EdgeToEdge mode in RN, so
@@ -17,11 +20,11 @@ const ModifiedNativeAndroidManager = {
   setTranslucent: (translucent: boolean): void => {
     RCTStatusBarManagerCompat.setTranslucent(translucent);
   },
-   /**
-     *  - statusBarStyles can be:
-     *    - 'default'
-     *    - 'dark-content'
-     */
+  /**
+   *  - statusBarStyles can be:
+   *    - 'default'
+   *    - 'dark-content'
+   */
   setStyle: (statusBarStyle?: string): void => {
     RCTStatusBarManagerCompat.setStyle(statusBarStyle);
   },


### PR DESCRIPTION
## 📜 Description

Fixed build issues when using `@rnx-kit`.

## 💡 Motivation and Context
When using tools like @rnx-kit from microsoft, which uses esbuild to handle bundling and also enables treeShaking, the build fails

## 📢 Changelog
- instead of direct export of type Ex: export { KeyboardToolbarProps } we export using "type": export { type KeyboardToolbarProps }


## 📸 Screenshots (if appropriate):



<img width="1249" alt="Screenshot 2024-03-07 at 23 01 07" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/10183866/6d2b5476-aadd-4736-98d2-22e5b53d68f3">
<img width="870" alt="Screenshot 2024-03-07 at 23 00 53" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/10183866/3c252693-a220-4ebb-bd77-e606b0139756">
