### PR TITLE
docs: badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,5 @@ lib/
 # yarn cache folder (v2+)
 .yarn
 
-# Docs
+# Web
 *.pem

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ lib/
 
 # yarn cache folder (v2+)
 .yarn
+
+# Docs
+*.pem

--- a/docs/.markdownlint.yaml
+++ b/docs/.markdownlint.yaml
@@ -2,3 +2,7 @@ default: true
 
 # Disable checks for line length
 MD013: false
+
+# Disable check for inline html (badges)
+MD033:
+  allowed_elements: ["div"]

--- a/docs/docs/api/keyboard-controller-view.md
+++ b/docs/docs/api/keyboard-controller-view.md
@@ -33,11 +33,11 @@ A callback function which is fired when layout of focused input gets changed.
 
 A callback function which is fired every time when user changes a text (types/deletes symbols).
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/docs/api/keyboard-controller-view.md
+++ b/docs/docs/api/keyboard-controller-view.md
@@ -33,11 +33,11 @@ A callback function which is fired when layout of focused input gets changed.
 
 A callback function which is fired every time when user changes a text (types/deletes symbols).
 
-### `statusBarTranslucent` <div class="label android"></div>
+### `statusBarTranslucent` <div class="badge android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent` <div class="label android"></div>
+### `navigationBarTranslucent` <div class="badge android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/docs/api/keyboard-controller-view.md
+++ b/docs/docs/api/keyboard-controller-view.md
@@ -33,11 +33,11 @@ A callback function which is fired when layout of focused input gets changed.
 
 A callback function which is fired every time when user changes a text (types/deletes symbols).
 
-### `statusBarTranslucent` <div class="badge android"></div>
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent` <div class="badge android"></div>
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -20,7 +20,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ## Methods
 
-### `setInputMode` <div class="label android"></div>
+### `setInputMode` <div class="badge android"></div>
 
 This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
@@ -36,7 +36,7 @@ To understand the difference between `adjustResize`/`adjustPan`/`adjustNothing` 
 A combination of `adjustResize` + `edge-to-edge` mode will result in behavior similar to `adjustNothing` - in this case window is not resized automatically and content is not moved along with the keyboard position. And it becomes a responsibility of developer to handle keyboard appearance (thus it'll match iOS behavior).
 :::
 
-### `setDefaultMode` <div class="label android"></div>
+### `setDefaultMode` <div class="badge android"></div>
 
 This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
 

--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -20,7 +20,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ## Methods
 
-### `setInputMode`
+### `setInputMode` <div class="label android"></div>
 
 This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
@@ -36,7 +36,7 @@ To understand the difference between `adjustResize`/`adjustPan`/`adjustNothing` 
 A combination of `adjustResize` + `edge-to-edge` mode will result in behavior similar to `adjustNothing` - in this case window is not resized automatically and content is not moved along with the keyboard position. And it becomes a responsibility of developer to handle keyboard appearance (thus it'll match iOS behavior).
 :::
 
-### `setDefaultMode`
+### `setDefaultMode` <div class="label android"></div>
 
 This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
 

--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -20,7 +20,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ## Methods
 
-### `setInputMode` <div class="badge android"></div>
+### `setInputMode` <div class="label android"></div>
 
 This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
@@ -36,7 +36,7 @@ To understand the difference between `adjustResize`/`adjustPan`/`adjustNothing` 
 A combination of `adjustResize` + `edge-to-edge` mode will result in behavior similar to `adjustNothing` - in this case window is not resized automatically and content is not moved along with the keyboard position. And it becomes a responsibility of developer to handle keyboard appearance (thus it'll match iOS behavior).
 :::
 
-### `setDefaultMode` <div class="badge android"></div>
+### `setDefaultMode` <div class="label android"></div>
 
 This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
 

--- a/docs/docs/api/keyboard-gesture-area.md
+++ b/docs/docs/api/keyboard-gesture-area.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -9,7 +10,7 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea
+# KeyboardGestureArea <div class="label android"></div>
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/docs/api/keyboard-gesture-area.md
+++ b/docs/docs/api/keyboard-gesture-area.md
@@ -10,7 +10,11 @@ keywords:
   ]
 ---
 
+<!-- prettier-ignore-start -->
+<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
+<!-- markdownlint-disable-next-line MD025 -->
 # KeyboardGestureArea <div class="badge android"></div>
+<!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/docs/api/keyboard-gesture-area.md
+++ b/docs/docs/api/keyboard-gesture-area.md
@@ -13,7 +13,7 @@ keywords:
 <!-- prettier-ignore-start -->
 <!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
 <!-- markdownlint-disable-next-line MD025 -->
-# KeyboardGestureArea <div class="badge android"></div>
+# KeyboardGestureArea <div class="label android"></div>
 <!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.

--- a/docs/docs/api/keyboard-gesture-area.md
+++ b/docs/docs/api/keyboard-gesture-area.md
@@ -10,7 +10,7 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea <div class="label android"></div>
+# KeyboardGestureArea <div class="badge android"></div>
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/docs/api/keyboard-provider.md
+++ b/docs/docs/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent` <div class="badge android"></div>
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent` <div class="badge android"></div>
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/docs/api/keyboard-provider.md
+++ b/docs/docs/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent` <div class="label android"></div>
+### `statusBarTranslucent` <div class="badge android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent` <div class="label android"></div>
+### `navigationBarTranslucent` <div class="badge android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/docs/api/keyboard-provider.md
+++ b/docs/docs/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
+    "https": "HTTPS=true SSL_CRT_FILE=localhost.pem SSL_KEY_FILE=localhost-key.pem docusaurus start",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc"

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -147,14 +147,14 @@
   border-radius: 20px;
   color: #fff;
   display: inline-block;
-  font-size: .85rem;
+  font-size: 0.85rem;
   font-weight: 500;
   padding: 2px 12px;
-  position: relative
+  position: relative;
 }
 
 .badge.android {
-  background: #3DDC84
+  background: #3ddc84;
 }
 
 .badge.android::before {
@@ -162,7 +162,7 @@
 }
 
 .badge.ios {
-  background: #616a70
+  background: #616a70;
 }
 
 .badge.ios::before {
@@ -178,7 +178,7 @@
 }
 
 .badge.new {
-  background: #40E0D0;
+  background: #40e0d0;
 }
 
 .badge.new::before {
@@ -186,7 +186,7 @@
 }
 
 .badge.web {
-  background: #007BFF;
+  background: #007bff;
 }
 
 .badge.web::before {
@@ -195,17 +195,17 @@
 
 h1 .badge {
   padding: 3px 12px;
-  top: -9px
+  top: -9px;
 }
 
 h2 .badge {
   padding: 3px 12px;
-  top: -5px
+  top: -5px;
 }
 
 h3 .badge {
   line-height: 20px;
-  top: -2px
+  top: -2px;
 }
 
 /* to become a circle in table of contents */

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -143,7 +143,7 @@
   }
 }
 
-.label {
+.badge {
   border-radius: 20px;
   color: #fff;
   display: inline-block;
@@ -153,63 +153,63 @@
   position: relative
 }
 
-.label.android {
+.badge.android {
   background: #3DDC84
 }
 
-.label.android::before {
+.badge.android::before {
   content: "Android";
 }
 
-.label.ios {
+.badge.ios {
   background: #616a70
 }
 
-.label.ios::before {
+.badge.ios::before {
   content: "iOS";
 }
 
-.label.required {
+.badge.required {
   background: #fa5035;
 }
 
-.label.required::before {
+.badge.required::before {
   content: "Required";
 }
 
-.label.new {
+.badge.new {
   background: #40E0D0;
 }
 
-.label.new::before {
+.badge.new::before {
   content: "New";
 }
 
-.label.web {
+.badge.web {
   background: #007BFF;
 }
 
-.label.web::before {
+.badge.web::before {
   content: "Web";
 }
 
-h1 .label {
+h1 .badge {
   padding: 3px 12px;
   top: -9px
 }
 
-h2 .label {
+h2 .badge {
   padding: 3px 12px;
   top: -5px
 }
 
-h3 .label {
+h3 .badge {
   line-height: 20px;
   top: -2px
 }
 
 /* to become a circle in table of contents */
-.table-of-contents .label {
+.table-of-contents .badge {
   border-radius: 100%;
   color: transparent;
   float: none;

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -142,3 +142,83 @@
     display: block;
   }
 }
+
+.label {
+  border-radius: 20px;
+  color: #fff;
+  display: inline-block;
+  font-size: .85rem;
+  font-weight: 500;
+  padding: 2px 12px;
+  position: relative
+}
+
+.label.android {
+  background: #3DDC84
+}
+
+.label.android::before {
+  content: "Android";
+}
+
+.label.ios {
+  background: #616a70
+}
+
+.label.ios::before {
+  content: "iOS";
+}
+
+.label.required {
+  background: #fa5035;
+}
+
+.label.required::before {
+  content: "Required";
+}
+
+.label.new {
+  background: #40E0D0;
+}
+
+.label.new::before {
+  content: "New";
+}
+
+.label.web {
+  background: #007BFF;
+}
+
+.label.web::before {
+  content: "Web";
+}
+
+h1 .label {
+  padding: 3px 12px;
+  top: -9px
+}
+
+h2 .label {
+  padding: 3px 12px;
+  top: -5px
+}
+
+h3 .label {
+  line-height: 20px;
+  top: -2px
+}
+
+/* to become a circle in table of contents */
+.table-of-contents .label {
+  border-radius: 100%;
+  color: transparent;
+  float: none;
+  height: 6px;
+  margin-left: 4px;
+  margin-top: 7px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 6px;
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -143,7 +143,7 @@
   }
 }
 
-.badge {
+.label {
   border-radius: 20px;
   color: #fff;
   display: inline-block;
@@ -153,63 +153,63 @@
   position: relative;
 }
 
-.badge.android {
+.label.android {
   background: #3ddc84;
 }
 
-.badge.android::before {
+.label.android::before {
   content: "Android";
 }
 
-.badge.ios {
+.label.ios {
   background: #616a70;
 }
 
-.badge.ios::before {
+.label.ios::before {
   content: "iOS";
 }
 
-.badge.required {
+.label.required {
   background: #fa5035;
 }
 
-.badge.required::before {
+.label.required::before {
   content: "Required";
 }
 
-.badge.new {
+.label.new {
   background: #40e0d0;
 }
 
-.badge.new::before {
+.label.new::before {
   content: "New";
 }
 
-.badge.web {
+.label.web {
   background: #007bff;
 }
 
-.badge.web::before {
+.label.web::before {
   content: "Web";
 }
 
-h1 .badge {
+h1 .label {
   padding: 3px 12px;
   top: -9px;
 }
 
-h2 .badge {
+h2 .label {
   padding: 3px 12px;
   top: -5px;
 }
 
-h3 .badge {
+h3 .label {
   line-height: 20px;
   top: -2px;
 }
 
 /* to become a circle in table of contents */
-.table-of-contents .badge {
+.table-of-contents .label {
   border-radius: 100%;
   color: transparent;
   float: none;

--- a/docs/versioned_docs/version-1.0.0/api/keyboard-controller-view.md
+++ b/docs/versioned_docs/version-1.0.0/api/keyboard-controller-view.md
@@ -8,6 +8,6 @@ A plain react-native `View` with some additional methods and props. Used interna
 
 A callback function which is fired every time, when keyboard changes its position on the screen.
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.

--- a/docs/versioned_docs/version-1.0.0/api/keyboard-provider.md
+++ b/docs/versioned_docs/version-1.0.0/api/keyboard-provider.md
@@ -4,7 +4,7 @@
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.10.0/api/keyboard-controller-view.md
+++ b/docs/versioned_docs/version-1.10.0/api/keyboard-controller-view.md
@@ -33,11 +33,11 @@ A callback function which is fired when layout of focused input gets changed.
 
 A callback function which is fired every time when user changes a text (types/deletes symbols).
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.10.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.10.0/api/keyboard-controller.md
@@ -20,7 +20,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ## Methods
 
-### `setInputMode`
+### `setInputMode` <div class="label android"></div>
 
 This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
@@ -36,7 +36,7 @@ To understand the difference between `adjustResize`/`adjustPan`/`adjustNothing` 
 A combination of `adjustResize` + `edge-to-edge` mode will result in behavior similar to `adjustNothing` - in this case window is not resized automatically and content is not moved along with the keyboard position. And it becomes a responsibility of developer to handle keyboard appearance (thus it'll match iOS behavior).
 :::
 
-### `setDefaultMode`
+### `setDefaultMode` <div class="label android"></div>
 
 This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
 

--- a/docs/versioned_docs/version-1.10.0/api/keyboard-gesture-area.md
+++ b/docs/versioned_docs/version-1.10.0/api/keyboard-gesture-area.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -9,7 +10,11 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea
+<!-- prettier-ignore-start -->
+<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
+<!-- markdownlint-disable-next-line MD025 -->
+# KeyboardGestureArea <div class="label android"></div>
+<!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/versioned_docs/version-1.10.0/api/keyboard-provider.md
+++ b/docs/versioned_docs/version-1.10.0/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.11.0/api/keyboard-controller-view.md
+++ b/docs/versioned_docs/version-1.11.0/api/keyboard-controller-view.md
@@ -33,11 +33,11 @@ A callback function which is fired when layout of focused input gets changed.
 
 A callback function which is fired every time when user changes a text (types/deletes symbols).
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.11.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.11.0/api/keyboard-controller.md
@@ -20,7 +20,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ## Methods
 
-### `setInputMode`
+### `setInputMode` <div class="label android"></div>
 
 This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
@@ -36,7 +36,7 @@ To understand the difference between `adjustResize`/`adjustPan`/`adjustNothing` 
 A combination of `adjustResize` + `edge-to-edge` mode will result in behavior similar to `adjustNothing` - in this case window is not resized automatically and content is not moved along with the keyboard position. And it becomes a responsibility of developer to handle keyboard appearance (thus it'll match iOS behavior).
 :::
 
-### `setDefaultMode`
+### `setDefaultMode` <div class="label android"></div>
 
 This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
 

--- a/docs/versioned_docs/version-1.11.0/api/keyboard-gesture-area.md
+++ b/docs/versioned_docs/version-1.11.0/api/keyboard-gesture-area.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -9,7 +10,11 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea
+<!-- prettier-ignore-start -->
+<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
+<!-- markdownlint-disable-next-line MD025 -->
+# KeyboardGestureArea <div class="label android"></div>
+<!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/versioned_docs/version-1.11.0/api/keyboard-provider.md
+++ b/docs/versioned_docs/version-1.11.0/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.4.0/api/keyboard-controller-view.md
+++ b/docs/versioned_docs/version-1.4.0/api/keyboard-controller-view.md
@@ -16,10 +16,10 @@ A callback function which is fired every time, when keyboard changes its positio
 
 A callback function which is fired when keyboard finished a transition from one to another state (from closed to open, for example).
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.

--- a/docs/versioned_docs/version-1.4.0/api/keyboard-provider.md
+++ b/docs/versioned_docs/version-1.4.0/api/keyboard-provider.md
@@ -4,7 +4,7 @@
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -12,7 +12,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.5.0/api/keyboard-controller-view.md
+++ b/docs/versioned_docs/version-1.5.0/api/keyboard-controller-view.md
@@ -25,10 +25,10 @@ A callback function which is fired every time, when user drags keyboard.
 
 A callback function which is fired when keyboard finished a transition from one to another state (from closed to open, for example).
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.

--- a/docs/versioned_docs/version-1.5.0/api/keyboard-gesture-area.md
+++ b/docs/versioned_docs/version-1.5.0/api/keyboard-gesture-area.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -9,7 +10,11 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea
+<!-- prettier-ignore-start -->
+<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
+<!-- markdownlint-disable-next-line MD025 -->
+# KeyboardGestureArea <div class="label android"></div>
+<!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/versioned_docs/version-1.5.0/api/keyboard-provider.md
+++ b/docs/versioned_docs/version-1.5.0/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.6.0/api/keyboard-controller-view.md
+++ b/docs/versioned_docs/version-1.6.0/api/keyboard-controller-view.md
@@ -25,10 +25,10 @@ A callback function which is fired every time, when user drags keyboard.
 
 A callback function which is fired when keyboard finished a transition from one to another state (from closed to open, for example).
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.

--- a/docs/versioned_docs/version-1.6.0/api/keyboard-gesture-area.md
+++ b/docs/versioned_docs/version-1.6.0/api/keyboard-gesture-area.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -9,7 +10,11 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea
+<!-- prettier-ignore-start -->
+<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
+<!-- markdownlint-disable-next-line MD025 -->
+# KeyboardGestureArea <div class="label android"></div>
+<!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/versioned_docs/version-1.6.0/api/keyboard-provider.md
+++ b/docs/versioned_docs/version-1.6.0/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.7.0/api/keyboard-controller-view.md
+++ b/docs/versioned_docs/version-1.7.0/api/keyboard-controller-view.md
@@ -25,10 +25,10 @@ A callback function which is fired every time, when user drags keyboard.
 
 A callback function which is fired when keyboard finished a transition from one to another state (from closed to open, for example).
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.

--- a/docs/versioned_docs/version-1.7.0/api/keyboard-gesture-area.md
+++ b/docs/versioned_docs/version-1.7.0/api/keyboard-gesture-area.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -9,7 +10,11 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea
+<!-- prettier-ignore-start -->
+<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
+<!-- markdownlint-disable-next-line MD025 -->
+# KeyboardGestureArea <div class="label android"></div>
+<!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/versioned_docs/version-1.7.0/api/keyboard-provider.md
+++ b/docs/versioned_docs/version-1.7.0/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.8.0/api/keyboard-controller-view.md
+++ b/docs/versioned_docs/version-1.8.0/api/keyboard-controller-view.md
@@ -25,11 +25,11 @@ A callback function which is fired every time, when user drags keyboard.
 
 A callback function which is fired when keyboard finished a transition from one to another state (from closed to open, for example).
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.8.0/api/keyboard-gesture-area.md
+++ b/docs/versioned_docs/version-1.8.0/api/keyboard-gesture-area.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -9,7 +10,11 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea
+<!-- prettier-ignore-start -->
+<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
+<!-- markdownlint-disable-next-line MD025 -->
+# KeyboardGestureArea <div class="label android"></div>
+<!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/versioned_docs/version-1.8.0/api/keyboard-provider.md
+++ b/docs/versioned_docs/version-1.8.0/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.9.0/api/keyboard-controller-view.md
+++ b/docs/versioned_docs/version-1.9.0/api/keyboard-controller-view.md
@@ -29,11 +29,11 @@ A callback function which is fired when keyboard finished a transition from one 
 
 A callback function which is fired when layout of focused input gets changed.
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 

--- a/docs/versioned_docs/version-1.9.0/api/keyboard-gesture-area.md
+++ b/docs/versioned_docs/version-1.9.0/api/keyboard-gesture-area.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -9,7 +10,11 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea
+<!-- prettier-ignore-start -->
+<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
+<!-- markdownlint-disable-next-line MD025 -->
+# KeyboardGestureArea <div class="label android"></div>
+<!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 

--- a/docs/versioned_docs/version-1.9.0/api/keyboard-provider.md
+++ b/docs/versioned_docs/version-1.9.0/api/keyboard-provider.md
@@ -9,7 +9,7 @@ keywords: [react-native-keyboard-controller, KeyboardProvider]
 
 ## Props
 
-### `statusBarTranslucent`
+### `statusBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether `StatusBar` should be translucent on `Android` or not.
 
@@ -17,7 +17,7 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 By default this library stretches to full screen (`edge-to-edge` mode) and status bar becomes translucent. But the library tries to use standard RN app behavior and automatically applies padding from top to look like a standard RN app. If you use `translucent` prop for `StatusBar` component - it will not work anymore. You'll need to specify it on provider level. For more info [see](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/30) this PR.
 :::
 
-### `navigationBarTranslucent`
+### `navigationBarTranslucent` <div class="label android"></div>
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 


### PR DESCRIPTION
## 📜 Description

Added badges for better clarity of what a particular prop/view.method does.

## 💡 Motivation and Context

I've seen this feature in `react-native` docs and in my opinion it's a very good feature of design in documentation - such short information allows user to process information faster because they have associative memory. Moreover it'll be easier for users who studied RN docs to understand my documentation (similar colors, similar approach).

Also in this PR I added an ability to run server on https (for some unknown reasons I can not open `http` websites in my Chrome anymore).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added an ability to run `https` server locally;
- added badges for Android, iOS, Web, New and Required types (though only android is used right now);

## 🤔 How Has This Been Tested?

Tested on localhost:3000

## 📸 Screenshots (if appropriate):

|Android|iOS|Web|New|Required|
|--------|---|-----|----|---------|
|<img width="86" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/23e85fb5-e9f0-4f42-81b8-ae674b447236">|<img width="57" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/b145aadc-ca0b-4a98-93be-1697b69776ca">|<img width="60" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/5874c704-433f-4f9b-81cf-1aaeb36d4708">|<img width="62" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/6fcfb8e1-4617-4f90-8765-f001bd26a332">|<img width="90" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/cfb47a30-a7b7-4f19-b4a0-193450843ca1">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
