### PR TITLE
chore: activate 120 FPS on ProMotion devices in example apps

### DIFF
--- a/FabricExample/ios/KeyboardControllerFabricExample/Info.plist
+++ b/FabricExample/ios/KeyboardControllerFabricExample/Info.plist
@@ -26,7 +26,6 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<!-- Do not change NSAllowsArbitraryLoads to true, or you will risk app rejection! -->
 		<key>NSAllowsArbitraryLoads</key>
 		<false/>
 		<key>NSAllowsLocalNetworking</key>
@@ -48,5 +47,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/example/ios/KeyboardControllerExample/Info.plist
+++ b/example/ios/KeyboardControllerExample/Info.plist
@@ -26,7 +26,6 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<!-- Do not change NSAllowsArbitraryLoads to true, or you will risk app rejection! -->
 		<key>NSAllowsArbitraryLoads</key>
 		<false/>
 		<key>NSAllowsLocalNetworking</key>
@@ -48,5 +47,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## 📜 Description

Activate 120 FPS on ProMotion devices in example apps.

## 💡 Motivation and Context

I have such tip in documentation, but in example app I didn't have it 🙈 

<img width="976" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/ad2faabd-0060-424a-a0ba-066134e81834">

So in this PR I'm enabling this flag and unlocking 120 FPS in both example apps (paper & fabric).

## 📢 Changelog

### iOS

- added `CADisableMinimumFrameDurationOnPhone` as `true`;
- XCode automatically removed a comment from `Info.plist`.

## 🤔 How Has This Been Tested?

Tested manually on iPhone 14 Pro (iOS 17.2).

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
