### PR TITLE
refactor: move `findKeyboardView` in separate file

### DIFF
--- a/ios/KeyboardController.xcodeproj/project.pbxproj
+++ b/ios/KeyboardController.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		084AEEC62ACF49A8001A3069 /* FocusedInputLayoutChangedEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 084AEEC52ACF49A8001A3069 /* FocusedInputLayoutChangedEvent.m */; };
 		084AEEC82ACF4AB2001A3069 /* FocusedInputObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084AEEC72ACF4AB2001A3069 /* FocusedInputObserver.swift */; };
 		089BA5DC2B3E0C9D000A9A90 /* ViewHierarchyNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089BA5DB2B3E0C9D000A9A90 /* ViewHierarchyNavigator.swift */; };
+		08C47AFC2BA9AF7100DB93BB /* KeyboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C47AFB2BA9AF7100DB93BB /* KeyboardView.swift */; };
 		F333F8D428996B8D0015B05F /* KeyboardControllerView.mm in Sources */ = {isa = PBXBuildFile; fileRef = F333F8D228996B8D0015B05F /* KeyboardControllerView.mm */; };
 		F359D34F28133C26000B6AFE /* KeyboardControllerModule.mm in Sources */ = {isa = PBXBuildFile; fileRef = F359D34E28133C26000B6AFE /* KeyboardControllerModule.mm */; };
 		F3626A0728B3FE760021B2D9 /* KeyboardMovementObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3626A0628B3FE760021B2D9 /* KeyboardMovementObserver.swift */; };
@@ -45,6 +46,7 @@
 		084AEEC52ACF49A8001A3069 /* FocusedInputLayoutChangedEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FocusedInputLayoutChangedEvent.m; sourceTree = "<group>"; };
 		084AEEC72ACF4AB2001A3069 /* FocusedInputObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedInputObserver.swift; sourceTree = "<group>"; };
 		089BA5DB2B3E0C9D000A9A90 /* ViewHierarchyNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHierarchyNavigator.swift; sourceTree = "<group>"; };
+		08C47AFB2BA9AF7100DB93BB /* KeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardView.swift; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libKeyboardController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libKeyboardController.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5891CC2AC0600A0062D /* KeyboardControllerViewManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = KeyboardControllerViewManager.mm; sourceTree = "<group>"; };
 		F333F8D128996B1C0015B05F /* KeyboardControllerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardControllerView.h; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 				089BA5DB2B3E0C9D000A9A90 /* ViewHierarchyNavigator.swift */,
 				0800511B2B65548600928E51 /* FocusedInputHolder.swift */,
 				0800511D2B65558800928E51 /* TextInput.swift */,
+				08C47AFB2BA9AF7100DB93BB /* KeyboardView.swift */,
 			);
 			path = traversal;
 			sourceTree = "<group>";
@@ -202,6 +205,7 @@
 				F4FF95D7245B92E800C19C63 /* KeyboardControllerViewManager.swift in Sources */,
 				F333F8D428996B8D0015B05F /* KeyboardControllerView.mm in Sources */,
 				0800511E2B65558800928E51 /* TextInput.swift in Sources */,
+				08C47AFC2BA9AF7100DB93BB /* KeyboardView.swift in Sources */,
 				F3F50669289E653B003091D6 /* KeyboardMoveEvent.m in Sources */,
 				083FB9852B15171600C0EFF0 /* TextChangeObserver.swift in Sources */,
 				089BA5DC2B3E0C9D000A9A90 /* ViewHierarchyNavigator.swift in Sources */,

--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -20,7 +20,7 @@ public class KeyboardMovementObserver: NSObject {
     let windowsCount = UIApplication.shared.windows.count
 
     if _keyboardView == nil || windowsCount != _windowsCount {
-      _keyboardView = findKeyboardView()
+      _keyboardView = KeyboardView.find()
       _windowsCount = windowsCount
     }
 
@@ -250,30 +250,6 @@ public class KeyboardMovementObserver: NSObject {
   @objc func removeKeyboardWatcher() {
     displayLink?.invalidate()
     displayLink = nil
-  }
-
-  // https://stackoverflow.com/questions/32598490/show-uiview-with-buttons-over-keyboard-like-in-skype-viber-messengers-swift-i
-  func findKeyboardView() -> UIView? {
-    var result: UIView?
-
-    let windows = UIApplication.shared.windows
-    for window in windows {
-      if window.description.hasPrefix("<UITextEffectsWindow") {
-        for subview in window.subviews {
-          if subview.description.hasPrefix("<UIInputSetContainerView") {
-            for hostView in subview.subviews {
-              if hostView.description.hasPrefix("<UIInputSetHostView") {
-                result = hostView
-                break
-              }
-            }
-            break
-          }
-        }
-        break
-      }
-    }
-    return result
   }
 
   @objc func updateKeyboardFrame() {

--- a/ios/traversal/KeyboardView.swift
+++ b/ios/traversal/KeyboardView.swift
@@ -1,0 +1,36 @@
+//
+//  KeyboardView.swift
+//  KeyboardController
+//
+//  Created by Kiryl Ziusko on 19/03/2024.
+//  Copyright © 2024 Facebook. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class KeyboardView {
+  // https://stackoverflow.com/questions/32598490/show-uiview-with-buttons-over-keyboard-like-in-skype-viber-messengers-swift-i
+  static func find() -> UIView? {
+    var result: UIView?
+
+    let windows = UIApplication.shared.windows
+    for window in windows {
+      if window.description.hasPrefix("<UITextEffectsWindow") {
+        for subview in window.subviews {
+          if subview.description.hasPrefix("<UIInputSetContainerView") {
+            for hostView in subview.subviews {
+              if hostView.description.hasPrefix("<UIInputSetHostView") {
+                result = hostView
+                break
+              }
+            }
+            break
+          }
+        }
+        break
+      }
+    }
+    return result
+  }
+}

--- a/ios/traversal/KeyboardView.swift
+++ b/ios/traversal/KeyboardView.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-class KeyboardView {
+enum KeyboardView {
   // https://stackoverflow.com/questions/32598490/show-uiview-with-buttons-over-keyboard-like-in-skype-viber-messengers-swift-i
   static func find() -> UIView? {
     var result: UIView?


### PR DESCRIPTION
## 📜 Description

Moved `findKeyboardView` in separate file.

## 💡 Motivation and Context

`KeyboardMovementObserver` is already pretty big file (250+ lines of the code). When we add new code then we get a lint warning telling, that files shouldn't be bigger than 250 lines of the code (excluding comments).

So in this PR I'm moving `findKeyboardView` function into separate file - this is a pure function with a clearly defined functionality, so it's an ideal candidate for splitting the code.

Initially I wanted to add it as extensions, but since we already have `traversal` folder - I decided to put it there, because in order to find a `keyboardView` we need to traverse through windows 🙂 

## 📢 Changelog

### iOS

- added new `KeyboardView` file in `traversal` folder;
- moved `findKeyboardView` function as static function of `KeyboardView` class;
- removed `findKeyboardView` from `KeyboardMovementObserver`;
- started to use `KeyboardView.find()` instead of `findKeyboardView`;

## 🤔 How Has This Been Tested?

Tested on iPhone 14 Pro (iOS 17.2, real device) + CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
