### PR TITLE
fix: avoid deep workletization

### DIFF
--- a/FabricExample/src/screens/Examples/ReanimatedChat/hooks.ts
+++ b/FabricExample/src/screens/Examples/ReanimatedChat/hooks.ts
@@ -2,6 +2,8 @@ import { Platform } from "react-native";
 import { useKeyboardHandler } from "react-native-keyboard-controller";
 import { Easing, useSharedValue, withTiming } from "react-native-reanimated";
 
+const isAndroid = Platform.OS === "android";
+
 export const useTelegramTransitions = () => {
   const height = useSharedValue(0);
 
@@ -10,7 +12,7 @@ export const useTelegramTransitions = () => {
       onStart: (e) => {
         "worklet";
 
-        if (Platform.OS === "android") {
+        if (isAndroid) {
           // on Android Telegram is not using androidx.core values and uses custom interpolation
           // duration is taken from here: https://github.com/DrKLO/Telegram/blob/e9a35cea54c06277c69d41b8e25d94b5d7ede065/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/AdjustPanLayoutHelper.java#L39
           // and bezier is taken from: https://github.com/DrKLO/Telegram/blob/e9a35cea54c06277c69d41b8e25d94b5d7ede065/TMessagesProj/src/main/java/androidx/recyclerview/widget/ChatListItemAnimator.java#L40

--- a/example/src/screens/Examples/ReanimatedChat/hooks.ts
+++ b/example/src/screens/Examples/ReanimatedChat/hooks.ts
@@ -2,6 +2,8 @@ import { Platform } from "react-native";
 import { useKeyboardHandler } from "react-native-keyboard-controller";
 import { Easing, useSharedValue, withTiming } from "react-native-reanimated";
 
+const isAndroid = Platform.OS === "android";
+
 export const useTelegramTransitions = () => {
   const height = useSharedValue(0);
 
@@ -10,7 +12,7 @@ export const useTelegramTransitions = () => {
       onStart: (e) => {
         "worklet";
 
-        if (Platform.OS === "android") {
+        if (isAndroid) {
           // on Android Telegram is not using androidx.core values and uses custom interpolation
           // duration is taken from here: https://github.com/DrKLO/Telegram/blob/e9a35cea54c06277c69d41b8e25d94b5d7ede065/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/AdjustPanLayoutHelper.java#L39
           // and bezier is taken from: https://github.com/DrKLO/Telegram/blob/e9a35cea54c06277c69d41b8e25d94b5d7ede065/TMessagesProj/src/main/java/androidx/recyclerview/widget/ChatListItemAnimator.java#L40

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -72,6 +72,10 @@ type KeyboardProviderProps = {
   enabled?: boolean;
 };
 
+// capture `Platform.OS` in separate variable to avoid deep workletization of entire RN package
+// see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/393 and https://github.com/kirillzyusko/react-native-keyboard-controller/issues/294 for more details
+const OS = Platform.OS;
+
 export const KeyboardProvider = ({
   children,
   statusBarTranslucent,
@@ -130,7 +134,7 @@ export const KeyboardProvider = ({
   const updateSharedValues = (event: NativeEvent, platforms: string[]) => {
     "worklet";
 
-    if (platforms.includes(Platform.OS)) {
+    if (platforms.includes(OS)) {
       progressSV.value = event.progress;
       heightSV.value = -event.height;
     }
@@ -201,8 +205,8 @@ export const KeyboardProvider = ({
       <KeyboardControllerViewAnimated
         enabled={enabled}
         onKeyboardMoveReanimated={keyboardHandler}
-        onKeyboardMoveStart={Platform.OS === "ios" ? onKeyboardMove : undefined}
-        onKeyboardMove={Platform.OS === "android" ? onKeyboardMove : undefined}
+        onKeyboardMoveStart={OS === "ios" ? onKeyboardMove : undefined}
+        onKeyboardMove={OS === "android" ? onKeyboardMove : undefined}
         onKeyboardMoveInteractive={onKeyboardMove}
         onFocusedInputLayoutChangedReanimated={inputLayoutHandler}
         onFocusedInputTextChangedReanimated={inputTextHandler}


### PR DESCRIPTION
## 📜 Description

Avoid deep worletization of `react-native` package.

## 💡 Motivation and Context

It looks like in specific project setup babel plugin may try to serialize entire `react-native` package (see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/393 for more context).

To avoid that in this PR I'm extracting `Platform.OS` into separate `OS` variable, so that babel plugin will capture only value of `OS` (and not entire `Platform` object).

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/393 and https://github.com/kirillzyusko/react-native-keyboard-controller/issues/294 

## 📢 Changelog

### JS

- extract `Platform.OS` into separate `OS` variable

## 🤔 How Has This Been Tested?

Tested in the project where this error occurs.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
