### PR TITLE
fix: consume context values as a default one

### DIFF
--- a/src/components/KeyboardAvoidingView/hooks.ts
+++ b/src/components/KeyboardAvoidingView/hooks.ts
@@ -1,12 +1,16 @@
 import { useSharedValue } from "react-native-reanimated";
 
-import { useKeyboardHandler } from "react-native-keyboard-controller";
+import {
+  useKeyboardContext,
+  useKeyboardHandler,
+} from "react-native-keyboard-controller";
 
 export const useKeyboardAnimation = () => {
-  const heightWhenOpened = useSharedValue(0);
-  const height = useSharedValue(0);
-  const progress = useSharedValue(0);
-  const isClosed = useSharedValue(true);
+  const { reanimated } = useKeyboardContext();
+  const heightWhenOpened = useSharedValue(-reanimated.height.value);
+  const height = useSharedValue(-reanimated.height.value);
+  const progress = useSharedValue(reanimated.progress.value);
+  const isClosed = useSharedValue(reanimated.progress.value === 0);
 
   useKeyboardHandler(
     {


### PR DESCRIPTION
## 📜 Description

Consume context values (as default values).

## 💡 Motivation and Context

When we navigate between screens, sometimes there can be a situation, where keyboard is not moving. If we initialize values as a default one - we'll have incorrect layout, because keyboard is actually shown (and wasn't moved) so we will continue to use default values (keyboard closed) while keyboard is actually open.

To fix this problem I specify default values from the context - context always holds a current values. It fixes the problem 🙂 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/398

## 📢 Changelog

### JS

- consume context values as a default one

## 🤔 How Has This Been Tested?

Tested on Android 10.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|----|
|<img width="346" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/a28befcd-c52b-4db8-9ea9-4227b4067028">|<img width="347" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/d40e38de-2dfb-4079-9675-51d014b6c027">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
