### PR TITLE
fix: missing `onScroll` event in `KeyboardAwareScrollView`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,5 @@ FabricExample/ios/build/
 FabricExample/src/**/Lottie/*.json
 
 android/build/
+
+tea.yaml

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useCallback, useMemo } from "react";
 import { findNodeHandle, useWindowDimensions } from "react-native";
 import Reanimated, {
   interpolate,
+  runOnJS,
   scrollTo,
   useAnimatedReaction,
   useAnimatedRef,
@@ -83,6 +84,7 @@ const KeyboardAwareScrollView = forwardRef<
       bottomOffset = 0,
       disableScrollOnKeyboardHide = false,
       enabled = true,
+      onScroll: onScrollProps,
       ...rest
     },
     ref,
@@ -106,6 +108,11 @@ const KeyboardAwareScrollView = forwardRef<
       {
         onScroll: (e) => {
           position.value = e.contentOffset.y;
+
+          if (onScrollProps) {
+            // @ts-expect-error we can not pass currentTarget, bubbles and other properties
+            runOnJS(onScrollProps)({ nativeEvent: e });
+          }
         },
       },
       [],
@@ -320,8 +327,7 @@ const KeyboardAwareScrollView = forwardRef<
         ref={onRef}
         {...rest}
         onLayout={onScrollViewLayout}
-        // @ts-expect-error `onScrollReanimated` is a fake prop needed for reanimated to intercept scroll events
-        onScrollReanimated={onScroll}
+        onScroll={onScroll}
         scrollEventThrottle={16}
       >
         {children}

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -2,11 +2,9 @@ import React, { forwardRef, useCallback, useMemo } from "react";
 import { findNodeHandle, useWindowDimensions } from "react-native";
 import Reanimated, {
   interpolate,
-  runOnJS,
   scrollTo,
   useAnimatedReaction,
   useAnimatedRef,
-  useAnimatedScrollHandler,
   useAnimatedStyle,
   useSharedValue,
 } from "react-native-reanimated";
@@ -104,16 +102,11 @@ const KeyboardAwareScrollView = forwardRef<
 
     const { height } = useWindowDimensions();
 
-    const onScroll = useAnimatedScrollHandler(
-      {
-        onScroll: (e) => {
-          position.value = e.contentOffset.y;
+    const onScroll = useCallback<NonNullable<ScrollViewProps["onScroll"]>>(
+      (event) => {
+        position.value = event.nativeEvent.contentOffset.y;
 
-          if (onScrollProps) {
-            // @ts-expect-error we can not pass currentTarget, bubbles and other properties
-            runOnJS(onScrollProps)({ nativeEvent: e });
-          }
-        },
+        onScrollProps?.(event);
       },
       [onScrollProps],
     );

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -115,7 +115,7 @@ const KeyboardAwareScrollView = forwardRef<
           }
         },
       },
-      [],
+      [onScrollProps],
     );
 
     const onRef = useCallback((assignedRef: Reanimated.ScrollView) => {

--- a/tea.yaml
+++ b/tea.yaml
@@ -2,5 +2,5 @@
 ---
 version: 1.0.0
 codeOwners:
-  - "0xeeF83F6BC5a2bC68A29F6e075e7780Aaa928FD5A"
+  - '0xeeF83F6BC5a2bC68A29F6e075e7780Aaa928FD5A'
 quorum: 1


### PR DESCRIPTION
## 📜 Description

Fixed firing of `onScroll` in `KeyboardAwareScrollView`

## 💡 Motivation and Context

Initially it was fixed in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/339 and I'm sure it was working 😅 

However it looks like in current setup (RN 0.73, REA 3.8.0) such way is not working and `onScroll` property still gets ignored 😔

So in this PR I followed a different path: initially I wanted to fire this handler via `runOnJS`, but we can not follow a full signature of the method, since REA has only `nativeEvent` property (and indeed in this case some properties would be simply missing).

The different path was to update a shared value from JS thread and call a callback as usually - it fixes a problem in old code and in a new, so for now this approach looks decent 👍

Let's see how it works in a wild life 👀

Also in this PR I'm changing content of `tea.yaml` - it should be done in separate PR, but I don't want to open another PR just to fix quotes, so decided to merge everything in a single one 🙈 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/337

## 📢 Changelog

### JS

- fire `onScroll` in callback;
- react on scroll position change in JS thread.

### FS (file system)

- added single quotes `'` for `tea.yaml`;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro.

## 📸 Screenshots (if appropriate):

<img width="474" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/11896adc-3fdd-4ab3-acf9-9f32f27e787c">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
