### PR TITLE
fix: size diff job

### DIFF
--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Pack
+        run: npm pack --json
       - name: Calculate size of package (current)
         id: new-size
         run: echo "NEW_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -24,6 +24,10 @@ jobs:
       #   id: old-size
       #   run: echo "OLD_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Pack

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -14,20 +14,20 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      # - name: Checkout to target branch
-      #  uses: actions/checkout@v4
-      #  with:
-      #    ref: ${{ github.event.pull_request.base.ref }}
-      # - name: Install dependencies
-      #  run: yarn install --frozen-lockfile
-      # - name: Calculate size of package (target)
-      #   id: old-size
-      #   run: echo "OLD_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - name: Checkout to target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 18.19.0
           cache: yarn
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Calculate size of package (target)
+        id: old-size
+        run: echo "OLD_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Pack
@@ -35,23 +35,23 @@ jobs:
       - name: Calculate size of package (current)
         id: new-size
         run: echo "NEW_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"
-      # - name: Calculate difference
-      #  id: diff
-      #  env:
-      #    NEW_SIZE: ${{ steps.new-size.outputs.NEW_SIZE }}
-      #    OLD_SIZE: ${{ steps.old-size.outputs.OLD_SIZE }}
-      #  run: |
-      #    echo "DIFF=$((NEW_SIZE - OLD_SIZE))" >> "$GITHUB_OUTPUT"
-      #    echo "SIGN=$([ $((NEW_SIZE - OLD_SIZE)) -gt 0 ] && echo "📈" || echo "📉")" >> "$GITHUB_OUTPUT"
-      # - uses: marocchino/sticky-pull-request-comment@v2
-      #  env:
-      #    NEW_SIZE: ${{ steps.new-size.outputs.NEW_SIZE }}
-      #    OLD_SIZE: ${{ steps.old-size.outputs.OLD_SIZE }}
-      #    DIFF: ${{ steps.diff.outputs.DIFF }}
-      #    SIGN: ${{ steps.diff.outputs.SIGN }}
-      #  with:
-      #    message: |
-      #      ### 📊 Package size report
-      #      | Current size  | Target Size   | Difference               |
-      #      | ------------- | ------------- | ------------------------ |
-      #      | ${{ env.NEW_SIZE }} bytes | ${{ env.OLD_SIZE }} bytes | ${{ env.DIFF }} bytes ${{ env.SIGN }} |
+      - name: Calculate difference
+        id: diff
+        env:
+          NEW_SIZE: ${{ steps.new-size.outputs.NEW_SIZE }}
+          OLD_SIZE: ${{ steps.old-size.outputs.OLD_SIZE }}
+        run: |
+          echo "DIFF=$((NEW_SIZE - OLD_SIZE))" >> "$GITHUB_OUTPUT"
+          echo "SIGN=$([ $((NEW_SIZE - OLD_SIZE)) -gt 0 ] && echo "📈" || echo "📉")" >> "$GITHUB_OUTPUT"
+      - uses: marocchino/sticky-pull-request-comment@v2
+        env:
+          NEW_SIZE: ${{ steps.new-size.outputs.NEW_SIZE }}
+          OLD_SIZE: ${{ steps.old-size.outputs.OLD_SIZE }}
+          DIFF: ${{ steps.diff.outputs.DIFF }}
+          SIGN: ${{ steps.diff.outputs.SIGN }}
+        with:
+          message: |
+            ### 📊 Package size report
+            | Current size  | Target Size   | Difference               |
+            | ------------- | ------------- | ------------------------ |
+            | ${{ env.NEW_SIZE }} bytes | ${{ env.OLD_SIZE }} bytes | ${{ env.DIFF }} bytes ${{ env.SIGN }} |

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 18.19.0
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -14,38 +14,38 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Checkout to target branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Calculate size of package (target)
-        id: old-size
-        run: echo "OLD_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"
+      # - name: Checkout to target branch
+      #  uses: actions/checkout@v4
+      #  with:
+      #    ref: ${{ github.event.pull_request.base.ref }}
+      # - name: Install dependencies
+      #  run: yarn install --frozen-lockfile
+      # - name: Calculate size of package (target)
+      #   id: old-size
+      #   run: echo "OLD_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Calculate size of package (current)
         id: new-size
         run: echo "NEW_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"
-      - name: Calculate difference
-        id: diff
-        env:
-          NEW_SIZE: ${{ steps.new-size.outputs.NEW_SIZE }}
-          OLD_SIZE: ${{ steps.old-size.outputs.OLD_SIZE }}
-        run: |
-          echo "DIFF=$((NEW_SIZE - OLD_SIZE))" >> "$GITHUB_OUTPUT"
-          echo "SIGN=$([ $((NEW_SIZE - OLD_SIZE)) -gt 0 ] && echo "📈" || echo "📉")" >> "$GITHUB_OUTPUT"
-      - uses: marocchino/sticky-pull-request-comment@v2
-        env:
-          NEW_SIZE: ${{ steps.new-size.outputs.NEW_SIZE }}
-          OLD_SIZE: ${{ steps.old-size.outputs.OLD_SIZE }}
-          DIFF: ${{ steps.diff.outputs.DIFF }}
-          SIGN: ${{ steps.diff.outputs.SIGN }}
-        with:
-          message: |
-            ### 📊 Package size report
-            | Current size  | Target Size   | Difference               |
-            | ------------- | ------------- | ------------------------ |
-            | ${{ env.NEW_SIZE }} bytes | ${{ env.OLD_SIZE }} bytes | ${{ env.DIFF }} bytes ${{ env.SIGN }} |
+      # - name: Calculate difference
+      #  id: diff
+      #  env:
+      #    NEW_SIZE: ${{ steps.new-size.outputs.NEW_SIZE }}
+      #    OLD_SIZE: ${{ steps.old-size.outputs.OLD_SIZE }}
+      #  run: |
+      #    echo "DIFF=$((NEW_SIZE - OLD_SIZE))" >> "$GITHUB_OUTPUT"
+      #    echo "SIGN=$([ $((NEW_SIZE - OLD_SIZE)) -gt 0 ] && echo "📈" || echo "📉")" >> "$GITHUB_OUTPUT"
+      # - uses: marocchino/sticky-pull-request-comment@v2
+      #  env:
+      #    NEW_SIZE: ${{ steps.new-size.outputs.NEW_SIZE }}
+      #    OLD_SIZE: ${{ steps.old-size.outputs.OLD_SIZE }}
+      #    DIFF: ${{ steps.diff.outputs.DIFF }}
+      #    SIGN: ${{ steps.diff.outputs.SIGN }}
+      #  with:
+      #    message: |
+      #      ### 📊 Package size report
+      #      | Current size  | Target Size   | Difference               |
+      #      | ------------- | ------------- | ------------------------ |
+      #      | ${{ env.NEW_SIZE }} bytes | ${{ env.OLD_SIZE }} bytes | ${{ env.DIFF }} bytes ${{ env.SIGN }} |

--- a/scripts/size.js
+++ b/scripts/size.js
@@ -1,6 +1,5 @@
 const { exec } = require("child_process");
 
 exec("npm pack --json", function (error, stdout, stderr) {
-  console.log(1, stdout, error, stderr);
-  // console.log(JSON.parse(stdout)[0].size);
+  console.log(JSON.parse(stdout)[0].size);
 });

--- a/scripts/size.js
+++ b/scripts/size.js
@@ -1,6 +1,6 @@
 const { exec } = require("child_process");
 
 exec("npm pack --json", function (error, stdout, stderr) {
-  console.log(stdout);
+  console.log(1, stdout, error, stderr);
   console.log(JSON.parse(stdout)[0].size);
 });

--- a/scripts/size.js
+++ b/scripts/size.js
@@ -1,5 +1,6 @@
 const { exec } = require("child_process");
 
 exec("npm pack --json", function (error, stdout, stderr) {
+  console.log(stdout);
   console.log(JSON.parse(stdout)[0].size);
 });

--- a/scripts/size.js
+++ b/scripts/size.js
@@ -2,5 +2,5 @@ const { exec } = require("child_process");
 
 exec("npm pack --json", function (error, stdout, stderr) {
   console.log(1, stdout, error, stderr);
-  console.log(JSON.parse(stdout)[0].size);
+  // console.log(JSON.parse(stdout)[0].size);
 });


### PR DESCRIPTION
## 📜 Description

Fixed "0 bytes" diff from size-diff job report.

## 💡 Motivation and Context

It was incorrect metric. Such metric is totally useless.

The original problem was the fact that in new node `18.20.1` prints output gathered from `react-native-builder-bob`:

```bash
> react-native-keyboard-controller@1.11.6 prepare
> bob build

ℹ Building target commonjs
ℹ Cleaning up previous build at lib/commonjs
ℹ Compiling 32 files in src with babel
✔ Wrote files to lib/commonjs
ℹ Building target module
ℹ Cleaning up previous build at lib/module
ℹ Compiling 32 files in src with babel
✔ Wrote files to lib/module
ℹ Building target typescript
ℹ Cleaning up previous build at lib/typescript
ℹ Generating type definitions with tsc
```

And such output can not be parsed.

The interesting thing is that `18.19.0` version produced expected result. So in this PR I locked node version for this particular job.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- lock node to `18.19.0` for `size-diff` job;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📸 Screenshots (if appropriate):

<img width="913" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e2dc190d-9d27-4e8e-b3df-cb60a954a9b4">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
