### PR TITLE
fix: react on `enabled` property toggle when keyboard open (`KeyboardAwareScrollView`)

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -212,77 +212,74 @@ const KeyboardAwareScrollView = forwardRef<
     );
 
     useSmoothKeyboardHandler(
-      enabled
-        ? {
-            onStart: (e) => {
-              "worklet";
+      {
+        onStart: (e) => {
+          "worklet";
 
-              const keyboardWillChangeSize =
-                keyboardHeight.value !== e.height && e.height > 0;
-              keyboardWillAppear.value =
-                e.height > 0 && keyboardHeight.value === 0;
-              const keyboardWillHide = e.height === 0;
-              const focusWasChanged =
-                (tag.value !== e.target && e.target !== -1) ||
-                keyboardWillChangeSize;
+          const keyboardWillChangeSize =
+            keyboardHeight.value !== e.height && e.height > 0;
+          keyboardWillAppear.value = e.height > 0 && keyboardHeight.value === 0;
+          const keyboardWillHide = e.height === 0;
+          const focusWasChanged =
+            (tag.value !== e.target && e.target !== -1) ||
+            keyboardWillChangeSize;
 
-              if (keyboardWillChangeSize) {
-                initialKeyboardSize.value = keyboardHeight.value;
-              }
-
-              if (keyboardWillHide) {
-                // on back transition need to interpolate as [0, keyboardHeight]
-                initialKeyboardSize.value = 0;
-                scrollPosition.value = scrollBeforeKeyboardMovement.value;
-              }
-
-              if (
-                keyboardWillAppear.value ||
-                keyboardWillChangeSize ||
-                focusWasChanged
-              ) {
-                // persist scroll value
-                scrollPosition.value = position.value;
-                // just persist height - later will be used in interpolation
-                keyboardHeight.value = e.height;
-              }
-
-              // focus was changed
-              if (focusWasChanged) {
-                tag.value = e.target;
-
-                // save position of focused text input when keyboard starts to move
-                layout.value = input.value;
-                // save current scroll position - when keyboard will hide we'll reuse
-                // this value to achieve smooth hide effect
-                scrollBeforeKeyboardMovement.value = position.value;
-              }
-
-              if (focusWasChanged && !keyboardWillAppear.value) {
-                // update position on scroll value, so `onEnd` handler
-                // will pick up correct values
-                position.value += maybeScroll(e.height, true);
-              }
-            },
-            onMove: (e) => {
-              "worklet";
-
-              currentKeyboardFrameHeight.value = e.height;
-
-              // if the user has set disableScrollOnKeyboardHide, only auto-scroll when the keyboard opens
-              if (!disableScrollOnKeyboardHide || keyboardWillAppear.value) {
-                maybeScroll(e.height);
-              }
-            },
-            onEnd: (e) => {
-              "worklet";
-
-              keyboardHeight.value = e.height;
-              scrollPosition.value = position.value;
-            },
+          if (keyboardWillChangeSize) {
+            initialKeyboardSize.value = keyboardHeight.value;
           }
-        : {},
-      [height, maybeScroll, disableScrollOnKeyboardHide, enabled],
+
+          if (keyboardWillHide) {
+            // on back transition need to interpolate as [0, keyboardHeight]
+            initialKeyboardSize.value = 0;
+            scrollPosition.value = scrollBeforeKeyboardMovement.value;
+          }
+
+          if (
+            keyboardWillAppear.value ||
+            keyboardWillChangeSize ||
+            focusWasChanged
+          ) {
+            // persist scroll value
+            scrollPosition.value = position.value;
+            // just persist height - later will be used in interpolation
+            keyboardHeight.value = e.height;
+          }
+
+          // focus was changed
+          if (focusWasChanged) {
+            tag.value = e.target;
+
+            // save position of focused text input when keyboard starts to move
+            layout.value = input.value;
+            // save current scroll position - when keyboard will hide we'll reuse
+            // this value to achieve smooth hide effect
+            scrollBeforeKeyboardMovement.value = position.value;
+          }
+
+          if (focusWasChanged && !keyboardWillAppear.value) {
+            // update position on scroll value, so `onEnd` handler
+            // will pick up correct values
+            position.value += maybeScroll(e.height, true);
+          }
+        },
+        onMove: (e) => {
+          "worklet";
+
+          currentKeyboardFrameHeight.value = e.height;
+
+          // if the user has set disableScrollOnKeyboardHide, only auto-scroll when the keyboard opens
+          if (!disableScrollOnKeyboardHide || keyboardWillAppear.value) {
+            maybeScroll(e.height);
+          }
+        },
+        onEnd: (e) => {
+          "worklet";
+
+          keyboardHeight.value = e.height;
+          scrollPosition.value = position.value;
+        },
+      },
+      [height, maybeScroll, disableScrollOnKeyboardHide],
     );
 
     useAnimatedReaction(
@@ -303,16 +300,19 @@ const KeyboardAwareScrollView = forwardRef<
     );
 
     const view = useAnimatedStyle(
-      () => ({
-        // animations become laggy when scrolling to the end of the `ScrollView` (when the last input is focused)
-        // this happens because the layout recalculates on every frame. To avoid this we slightly increase padding
-        // by `+1`. In this way we assure, that `scrollTo` will never scroll to the end, because it uses interpolation
-        // from 0 to `keyboardHeight`, and here our padding is `keyboardHeight + 1`. It allows us not to re-run layout
-        // re-calculation on every animation frame and it helps to achieve smooth animation.
-        // see: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/342
-        paddingBottom: currentKeyboardFrameHeight.value + 1,
-      }),
-      [],
+      () =>
+        enabled
+          ? {
+              // animations become laggy when scrolling to the end of the `ScrollView` (when the last input is focused)
+              // this happens because the layout recalculates on every frame. To avoid this we slightly increase padding
+              // by `+1`. In this way we assure, that `scrollTo` will never scroll to the end, because it uses interpolation
+              // from 0 to `keyboardHeight`, and here our padding is `keyboardHeight + 1`. It allows us not to re-run layout
+              // re-calculation on every animation frame and it helps to achieve smooth animation.
+              // see: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/342
+              paddingBottom: currentKeyboardFrameHeight.value + 1,
+            }
+          : {},
+      [enabled],
     );
 
     return (


### PR DESCRIPTION
## 📜 Description

React on `enabled` property toggle when keyboard open in `KeyboardAwareScrollView` component.

## 💡 Motivation and Context

Initially me and @IvanIhnatsiuk were thinking that in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/350 it will be better to not handle keyboard appearance if `enabled=false`. But it turns out that it will produce issues like https://github.com/kirillzyusko/react-native-keyboard-controller/issues/414

So in this PR I'm always keeping a handler in `useKeyboardHandler` hook and instead I don't render additional padding if view is disabled (we are not making any scrolling because we already handle `enabled` property value in `maybeScroll`).

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/414

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- don't put keyboard handlers conditionally;
- make padding conditional depends on `enabled` property;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro (iOS 17.4, simulator).

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

|Before|After|
|-------|-----|
|![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e37f7dbc-b915-4f6c-993d-7b672672be66)|![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/44127abe-4353-4aff-abf3-aa69491e5383)|
|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/54de59f6-4f5e-45cd-ae4b-aa34cea6f56c">|<video src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/4e4fccf0-9c1e-4a94-a12e-17a8412b2244">|


## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
