### PR TITLE
feat: `KeyboardToolbar` callbacks

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1568,7 +1568,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: f64d1e2ea739b4d8f7e4740cde18089cd97fe864
   Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1273,6 +1273,13 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNReactNativeHapticFeedback (2.2.0):
+    - RCT-Folly
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - ReactCommon/turbomodule/core
   - RNReanimated (3.8.0):
     - glog
     - hermes-engine
@@ -1415,6 +1422,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -1548,6 +1556,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNReactNativeHapticFeedback:
+    :path: "../node_modules/react-native-haptic-feedback"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -1624,6 +1634,7 @@ SPEC CHECKSUMS:
   ReactCommon: 2aa35648354bd4c4665b9a5084a7d37097b89c10
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNGestureHandler: 0639a230f5bfdf0ffb2eae5dbc3c5f664d3f14ab
+  RNReactNativeHapticFeedback: 616c35bdec7d20d4c524a7949ca9829c09e35f37
   RNReanimated: 928a0e9d20b70bfc57ae741560ef3635937d3e9d
   RNScreens: 9cd50a78d3723dfa55252a2220a94a7188deb180
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -20,6 +20,7 @@
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-gesture-handler": "2.15.0",
+    "react-native-haptic-feedback": "^2.2.0",
     "react-native-keyboard-controller": "link:../",
     "react-native-reanimated": "3.8.0",
     "react-native-safe-area-context": "^4.9.0",

--- a/FabricExample/src/screens/Examples/Toolbar/index.tsx
+++ b/FabricExample/src/screens/Examples/Toolbar/index.tsx
@@ -3,7 +3,6 @@ import { Platform, StyleSheet, View } from "react-native";
 import { trigger } from "react-native-haptic-feedback";
 import {
   KeyboardAwareScrollView,
-  KeyboardController,
   KeyboardToolbar,
 } from "react-native-keyboard-controller";
 
@@ -20,19 +19,6 @@ const options = {
 };
 const haptic = () =>
   trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", options);
-
-const goToNextField = () => {
-  KeyboardController.setFocusTo("next");
-  haptic();
-};
-const goToPrevField = () => {
-  KeyboardController.setFocusTo("prev");
-  haptic();
-};
-const dismissKeyboard = () => {
-  KeyboardController.dismiss();
-  haptic();
-};
 
 export default function ToolbarExample() {
   const [showAutoFill, setShowAutoFill] = useState(false);
@@ -168,9 +154,9 @@ export default function ToolbarExample() {
             <AutoFillContacts onContactSelected={onContactSelected} />
           ) : null
         }
-        onPressNext={goToNextField}
-        onPressPrev={goToPrevField}
-        onPressDone={dismissKeyboard}
+        onDoneCallback={haptic}
+        onPrevCallback={haptic}
+        onNextCallback={haptic}
       />
     </>
   );

--- a/FabricExample/src/screens/Examples/Toolbar/index.tsx
+++ b/FabricExample/src/screens/Examples/Toolbar/index.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { Platform, StyleSheet, View } from "react-native";
+import { trigger } from "react-native-haptic-feedback";
 import {
   KeyboardAwareScrollView,
+  KeyboardController,
   KeyboardToolbar,
 } from "react-native-keyboard-controller";
 
@@ -10,6 +12,27 @@ import TextInput from "../../../components/TextInput";
 import AutoFillContacts from "./Contacts";
 
 import type { Contact } from "./Contacts";
+
+// Optional configuration
+const options = {
+  enableVibrateFallback: true,
+  ignoreAndroidSystemSettings: false,
+};
+const haptic = () =>
+  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", options);
+
+const goToNextField = () => {
+  KeyboardController.setFocusTo("next");
+  haptic();
+};
+const goToPrevField = () => {
+  KeyboardController.setFocusTo("prev");
+  haptic();
+};
+const dismissKeyboard = () => {
+  KeyboardController.dismiss();
+  haptic();
+};
 
 export default function ToolbarExample() {
   const [showAutoFill, setShowAutoFill] = useState(false);
@@ -145,6 +168,9 @@ export default function ToolbarExample() {
             <AutoFillContacts onContactSelected={onContactSelected} />
           ) : null
         }
+        onPressNext={goToNextField}
+        onPressPrev={goToPrevField}
+        onPressDone={dismissKeyboard}
       />
     </>
   );

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -4599,6 +4599,11 @@ react-native-gesture-handler@2.15.0:
     lodash "^4.17.21"
     prop-types "^15.7.2"
 
+react-native-haptic-feedback@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.2.0.tgz#bc46edd1f053265bfbe6c32487cbce074e099429"
+  integrity sha512-3tqJOjCguWhIrX0nkURn4yw6kXdsSDjjrvZCRjKXYGlL28hdQmoW2okAHduDTD9FWj9lA+lHgwFWgGs4aFNN7A==
+
 "react-native-keyboard-controller@link:..":
   version "0.0.0"
   uid ""

--- a/docs/docs/api/components/keyboard-toolbar/index.mdx
+++ b/docs/docs/api/components/keyboard-toolbar/index.mdx
@@ -102,88 +102,67 @@ const Icon: KeyboardToolbarProps["icon"] = ({ type }) => {
 <KeyboardToolbar icon={Icon} />;
 ```
 
-### `onPressDone`
+### `onDoneCallback`
 
-A callback that is called when the user presses the **done** button.
-
-:::warning Overriding default behavior
-If you specify this callback then default action is not called and it becomes your responsibility to define a behavior for the interaction with the button.
-:::
+A callback that is called when the user presses the **done** button along with the default action.
 
 ```tsx
-import {
-  KeyboardController,
-  KeyboardToolbar,
-} from "react-native-keyboard-controller";
+import { Platform } from "react-native";
+import { KeyboardToolbar } from "react-native-keyboard-controller";
 import { trigger } from "react-native-haptic-feedback";
 
-const onPressDone = () => {
-  KeyboardController.dismiss();
-  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", {
-    enableVibrateFallback: true,
-    ignoreAndroidSystemSettings: false,
-  });
+const options = {
+  enableVibrateFallback: true,
+  ignoreAndroidSystemSettings: false,
 };
+const haptic = () =>
+  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", options);
 
 // ...
 
-<KeyboardToolbar onPressDone={onPressDone} />;
+<KeyboardToolbar onDoneCallback={haptic} />;
 ```
 
-### `onPressNext`
+### `onNextCallback`
 
-A callback that is called when the user presses the **next** button.
-
-:::warning Overriding default behavior
-If you specify this callback then default action is not called and it becomes your responsibility to define a behavior for the interaction with the button.
-:::
+A callback that is called when the user presses the **next** button along with the default action.
 
 ```tsx
-import {
-  KeyboardController,
-  KeyboardToolbar,
-} from "react-native-keyboard-controller";
+import { Platform } from "react-native";
+import { KeyboardToolbar } from "react-native-keyboard-controller";
 import { trigger } from "react-native-haptic-feedback";
 
-const onPressNext = () => {
-  KeyboardController.setFocusTo("next");
-  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", {
-    enableVibrateFallback: true,
-    ignoreAndroidSystemSettings: false,
-  });
+const options = {
+  enableVibrateFallback: true,
+  ignoreAndroidSystemSettings: false,
 };
+const haptic = () =>
+  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", options);
 
 // ...
 
-<KeyboardToolbar onPressNext={onPressNext} />;
+<KeyboardToolbar onNextCallback={haptic} />;
 ```
 
-### `onPressPrev`
+### `onPrevCallback`
 
-A callback that is called when the user presses the **previous** button.
-
-:::warning Overriding default behavior
-If you specify this callback then default action is not called and it becomes your responsibility to define a behavior for the interaction with the button.
-:::
+A callback that is called when the user presses the **previous** button along with the default action.
 
 ```tsx
-import {
-  KeyboardController,
-  KeyboardToolbar,
-} from "react-native-keyboard-controller";
+import { Platform } from "react-native";
+import { KeyboardToolbar } from "react-native-keyboard-controller";
 import { trigger } from "react-native-haptic-feedback";
 
-const onPressPrev = () => {
-  KeyboardController.setFocusTo("prev");
-  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", {
-    enableVibrateFallback: true,
-    ignoreAndroidSystemSettings: false,
-  });
+const options = {
+  enableVibrateFallback: true,
+  ignoreAndroidSystemSettings: false,
 };
+const haptic = () =>
+  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", options);
 
 // ...
 
-<KeyboardToolbar onPressPrev={onPressPrev} />;
+<KeyboardToolbar onPrevCallback={haptic} />;
 ```
 
 ### `showArrows`

--- a/docs/docs/api/components/keyboard-toolbar/index.mdx
+++ b/docs/docs/api/components/keyboard-toolbar/index.mdx
@@ -102,6 +102,90 @@ const Icon: KeyboardToolbarProps["icon"] = ({ type }) => {
 <KeyboardToolbar icon={Icon} />;
 ```
 
+### `onPressDone`
+
+A callback that is called when the user presses the **done** button.
+
+:::warning Overriding default behavior
+If you specify this callback then default action is not called and it becomes your responsibility to define a behavior for the interaction with the button.
+:::
+
+```tsx
+import {
+  KeyboardController,
+  KeyboardToolbar,
+} from "react-native-keyboard-controller";
+import { trigger } from "react-native-haptic-feedback";
+
+const onPressDone = () => {
+  KeyboardController.dismiss();
+  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", {
+    enableVibrateFallback: true,
+    ignoreAndroidSystemSettings: false,
+  });
+};
+
+// ...
+
+<KeyboardToolbar onPressDone={onPressDone} />;
+```
+
+### `onPressNext`
+
+A callback that is called when the user presses the **next** button.
+
+:::warning Overriding default behavior
+If you specify this callback then default action is not called and it becomes your responsibility to define a behavior for the interaction with the button.
+:::
+
+```tsx
+import {
+  KeyboardController,
+  KeyboardToolbar,
+} from "react-native-keyboard-controller";
+import { trigger } from "react-native-haptic-feedback";
+
+const onPressNext = () => {
+  KeyboardController.setFocusTo("next");
+  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", {
+    enableVibrateFallback: true,
+    ignoreAndroidSystemSettings: false,
+  });
+};
+
+// ...
+
+<KeyboardToolbar onPressNext={onPressNext} />;
+```
+
+### `onPressPrev`
+
+A callback that is called when the user presses the **previous** button.
+
+:::warning Overriding default behavior
+If you specify this callback then default action is not called and it becomes your responsibility to define a behavior for the interaction with the button.
+:::
+
+```tsx
+import {
+  KeyboardController,
+  KeyboardToolbar,
+} from "react-native-keyboard-controller";
+import { trigger } from "react-native-haptic-feedback";
+
+const onPressPrev = () => {
+  KeyboardController.setFocusTo("prev");
+  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", {
+    enableVibrateFallback: true,
+    ignoreAndroidSystemSettings: false,
+  });
+};
+
+// ...
+
+<KeyboardToolbar onPressPrev={onPressPrev} />;
+```
+
 ### `showArrows`
 
 A boolean prop indicating whether to show `next` and `prev` buttons. Can be useful to set it to `false` if you have only one input and want to show only `Done` button. Default to `true`.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1134,6 +1134,8 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
+  - RNReactNativeHapticFeedback (2.2.0):
+    - React-Core
   - RNReanimated (3.8.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1225,6 +1227,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -1355,6 +1358,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNReactNativeHapticFeedback:
+    :path: "../node_modules/react-native-haptic-feedback"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -1430,6 +1435,7 @@ SPEC CHECKSUMS:
   ReactCommon: 2aa35648354bd4c4665b9a5084a7d37097b89c10
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNGestureHandler: 67fb54b3e6ca338a8044e85cd6f340265aa41091
+  RNReactNativeHapticFeedback: ec56a5f81c3941206fd85625fa669ffc7b4545f9
   RNReanimated: 00ee495a70897aa9d541e76debec14253133b812
   RNScreens: 17e2f657f1b09a71ec3c821368a04acbb7ebcb46
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17

--- a/example/package.json
+++ b/example/package.json
@@ -21,6 +21,7 @@
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-gesture-handler": "2.15.0",
+    "react-native-haptic-feedback": "^2.2.0",
     "react-native-keyboard-controller": "link:../",
     "react-native-reanimated": "3.8.0",
     "react-native-safe-area-context": "^4.9.0",

--- a/example/src/screens/Examples/Toolbar/index.tsx
+++ b/example/src/screens/Examples/Toolbar/index.tsx
@@ -3,7 +3,6 @@ import { Platform, StyleSheet, View } from "react-native";
 import { trigger } from "react-native-haptic-feedback";
 import {
   KeyboardAwareScrollView,
-  KeyboardController,
   KeyboardToolbar,
 } from "react-native-keyboard-controller";
 
@@ -20,19 +19,6 @@ const options = {
 };
 const haptic = () =>
   trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", options);
-
-const goToNextField = () => {
-  KeyboardController.setFocusTo("next");
-  haptic();
-};
-const goToPrevField = () => {
-  KeyboardController.setFocusTo("prev");
-  haptic();
-};
-const dismissKeyboard = () => {
-  KeyboardController.dismiss();
-  haptic();
-};
 
 export default function ToolbarExample() {
   const [showAutoFill, setShowAutoFill] = useState(false);
@@ -168,9 +154,9 @@ export default function ToolbarExample() {
             <AutoFillContacts onContactSelected={onContactSelected} />
           ) : null
         }
-        onPressNext={goToNextField}
-        onPressPrev={goToPrevField}
-        onPressDone={dismissKeyboard}
+        onDoneCallback={haptic}
+        onPrevCallback={haptic}
+        onNextCallback={haptic}
       />
     </>
   );

--- a/example/src/screens/Examples/Toolbar/index.tsx
+++ b/example/src/screens/Examples/Toolbar/index.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { Platform, StyleSheet, View } from "react-native";
+import { trigger } from "react-native-haptic-feedback";
 import {
   KeyboardAwareScrollView,
+  KeyboardController,
   KeyboardToolbar,
 } from "react-native-keyboard-controller";
 
@@ -10,6 +12,27 @@ import TextInput from "../../../components/TextInput";
 import AutoFillContacts from "./Contacts";
 
 import type { Contact } from "./Contacts";
+
+// Optional configuration
+const options = {
+  enableVibrateFallback: true,
+  ignoreAndroidSystemSettings: false,
+};
+const haptic = () =>
+  trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", options);
+
+const goToNextField = () => {
+  KeyboardController.setFocusTo("next");
+  haptic();
+};
+const goToPrevField = () => {
+  KeyboardController.setFocusTo("prev");
+  haptic();
+};
+const dismissKeyboard = () => {
+  KeyboardController.dismiss();
+  haptic();
+};
 
 export default function ToolbarExample() {
   const [showAutoFill, setShowAutoFill] = useState(false);
@@ -145,6 +168,9 @@ export default function ToolbarExample() {
             <AutoFillContacts onContactSelected={onContactSelected} />
           ) : null
         }
+        onPressNext={goToNextField}
+        onPressPrev={goToPrevField}
+        onPressDone={dismissKeyboard}
       />
     </>
   );

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4702,6 +4702,11 @@ react-native-gesture-handler@2.15.0:
     lodash "^4.17.21"
     prop-types "^15.7.2"
 
+react-native-haptic-feedback@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.2.0.tgz#bc46edd1f053265bfbe6c32487cbce074e099429"
+  integrity sha512-3tqJOjCguWhIrX0nkURn4yw6kXdsSDjjrvZCRjKXYGlL28hdQmoW2okAHduDTD9FWj9lA+lHgwFWgGs4aFNN7A==
+
 "react-native-keyboard-controller@link:..":
   version "0.0.0"
   uid ""

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import {
@@ -33,20 +33,17 @@ export type KeyboardToolbarProps = {
    */
   showArrows?: boolean;
   /**
-   * A callback that is called when the user presses the next button.
-   * If provided then default action is not called and you'll need to call it yourself.
+   * A callback that is called when the user presses the next button along with the default action.
    */
-  onPressNext?: () => void;
+  onNextCallback?: () => void;
   /**
-   * A callback that is called when the user presses the previous button.
-   * If provided then default action is not called and you'll need to call it yourself.
+   * A callback that is called when the user presses the previous button along with the default action.
    */
-  onPressPrev?: () => void;
+  onPrevCallback?: () => void;
   /**
-   * A callback that is called when the user presses the done button.
-   * If provided then default action is not called and you'll need to call it yourself.
+   * A callback that is called when the user presses the done button along with the default action.
    */
-  onPressDone?: () => void;
+  onDoneCallback?: () => void;
 };
 const TEST_ID_KEYBOARD_TOOLBAR = "keyboard.toolbar";
 const TEST_ID_KEYBOARD_TOOLBAR_PREVIOUS = `${TEST_ID_KEYBOARD_TOOLBAR}.previous`;
@@ -72,9 +69,9 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
   button,
   icon,
   showArrows = true,
-  onPressNext,
-  onPressPrev,
-  onPressDone,
+  onNextCallback,
+  onPrevCallback,
+  onDoneCallback,
 }) => {
   const colorScheme = useColorScheme();
   const [inputs, setInputs] = useState({
@@ -107,6 +104,19 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
   const ButtonContainer = button || Button;
   const IconContainer = icon || Arrow;
 
+  const onPressNext = useCallback(() => {
+    goToNextField();
+    onNextCallback?.();
+  }, [onNextCallback]);
+  const onPressPrev = useCallback(() => {
+    goToPrevField();
+    onPrevCallback?.();
+  }, [onPrevCallback]);
+  const onPressDone = useCallback(() => {
+    dismissKeyboard();
+    onDoneCallback?.();
+  }, [onDoneCallback]);
+
   return (
     <KeyboardStickyView offset={offset}>
       <View style={toolbarStyle} testID={TEST_ID_KEYBOARD_TOOLBAR}>
@@ -116,7 +126,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
               accessibilityLabel="Previous"
               accessibilityHint="Will move focus to previous field"
               disabled={isPrevDisabled}
-              onPress={onPressPrev ?? goToPrevField}
+              onPress={onPressPrev}
               testID={TEST_ID_KEYBOARD_TOOLBAR_PREVIOUS}
               theme={theme}
             >
@@ -130,7 +140,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
               accessibilityLabel="Next"
               accessibilityHint="Will move focus to next field"
               disabled={isNextDisabled}
-              onPress={onPressNext ?? goToNextField}
+              onPress={onPressNext}
               testID={TEST_ID_KEYBOARD_TOOLBAR_NEXT}
               theme={theme}
             >
@@ -149,7 +159,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
         <ButtonContainer
           accessibilityLabel="Done"
           accessibilityHint="Will close the keyboard"
-          onPress={onPressDone ?? dismissKeyboard}
+          onPress={onPressDone}
           testID={TEST_ID_KEYBOARD_TOOLBAR_DONE}
           rippleRadius={28}
           style={styles.doneButtonContainer}

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -32,6 +32,21 @@ export type KeyboardToolbarProps = {
    * and want to show only `Done` button. Default to `true`.
    */
   showArrows?: boolean;
+  /**
+   * A callback that is called when the user presses the next button.
+   * If provided then default action is not called and you'll need to call it yourself.
+   */
+  onPressNext?: () => void;
+  /**
+   * A callback that is called when the user presses the previous button.
+   * If provided then default action is not called and you'll need to call it yourself.
+   */
+  onPressPrev?: () => void;
+  /**
+   * A callback that is called when the user presses the done button.
+   * If provided then default action is not called and you'll need to call it yourself.
+   */
+  onPressDone?: () => void;
 };
 const TEST_ID_KEYBOARD_TOOLBAR = "keyboard.toolbar";
 const TEST_ID_KEYBOARD_TOOLBAR_PREVIOUS = `${TEST_ID_KEYBOARD_TOOLBAR}.previous`;
@@ -57,6 +72,9 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
   button,
   icon,
   showArrows = true,
+  onPressNext,
+  onPressPrev,
+  onPressDone,
 }) => {
   const colorScheme = useColorScheme();
   const [inputs, setInputs] = useState({
@@ -98,7 +116,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
               accessibilityLabel="Previous"
               accessibilityHint="Will move focus to previous field"
               disabled={isPrevDisabled}
-              onPress={goToPrevField}
+              onPress={onPressPrev ?? goToPrevField}
               testID={TEST_ID_KEYBOARD_TOOLBAR_PREVIOUS}
               theme={theme}
             >
@@ -112,7 +130,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
               accessibilityLabel="Next"
               accessibilityHint="Will move focus to next field"
               disabled={isNextDisabled}
-              onPress={goToNextField}
+              onPress={onPressNext ?? goToNextField}
               testID={TEST_ID_KEYBOARD_TOOLBAR_NEXT}
               theme={theme}
             >
@@ -131,7 +149,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
         <ButtonContainer
           accessibilityLabel="Done"
           accessibilityHint="Will close the keyboard"
-          onPress={dismissKeyboard}
+          onPress={onPressDone ?? dismissKeyboard}
           testID={TEST_ID_KEYBOARD_TOOLBAR_DONE}
           rippleRadius={28}
           style={styles.doneButtonContainer}


### PR DESCRIPTION
## 📜 Description

Added `onDoneCallback`/`onNextCallback`/`onPrevCallback` functions to `KeyboardToolbar`.

## 💡 Motivation and Context

It's often needed to customize behavior when buttons are pressed, for example do a haptic feedback or even play a sound.

Before this PR it wasn't possible to add an action that will be called whenever user presses a particular button along with the default action. But in this PR I added it.

Initially I wanted to provide `onNextPress` functions that would redefine an entire handler. But in this case users will have to go into source code and understand how `KeyboardToolbar` works under the hood. Even though it's not difficult it's better to keep such things internally (and in most cases users will rely on defult behavior - in case if we need to re-define a behavior I'll add new functions later).

## 📢 Changelog

### Docs

- added docs about new `onDoneCallback`/`onNextCallback`/`onPrevCallback` callbacks;

### JS

- added `onDoneCallback`/`onNextCallback`/`onPrevCallback`;

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro (android 14) and iPhone 11 (iOS 17.4).

## 📸 Screenshots (if appropriate):

There is no way to test haptic visually 😀 

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
