### PR TITLE
chore: release 1.11.7

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -964,7 +964,7 @@ PODS:
   - React-Mapbuffer (0.73.6):
     - glog
     - React-debug
-  - react-native-keyboard-controller (1.11.6):
+  - react-native-keyboard-controller (1.11.7):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -1558,7 +1558,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
+  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: f64d1e2ea739b4d8f7e4740cde18089cd97fe864
   Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
@@ -1597,7 +1597,7 @@ SPEC CHECKSUMS:
   React-jsitracing: 4fed160d939e93a39049481f47744af246a7ac2c
   React-logger: 3eb80a977f0d9669468ef641a5e1fabbc50a09ec
   React-Mapbuffer: 84ea43c6c6232049135b1550b8c60b2faac19fab
-  react-native-keyboard-controller: 444fcb1487bbeb38cbd2c112ac813be1d78ed26d
+  react-native-keyboard-controller: 7ac0083f3f16b3587d1d305e9ed75e4d759a84b8
   react-native-safe-area-context: 1e374c51edf537be56313b893b6e96b0e254ddfe
   React-nativeconfig: b4d4e9901d4cabb57be63053fd2aa6086eb3c85f
   React-NativeModulesApple: cd26e56d56350e123da0c1e3e4c76cb58a05e1ee

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputLayoutChangedEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputLayoutChangedEvent.kt
@@ -19,7 +19,7 @@ class FocusedInputLayoutChangedEvent(
   surfaceId: Int,
   viewId: Int,
   private val event: FocusedInputLayoutChangedEventData,
-) : Event<KeyboardTransitionEvent>(surfaceId, viewId) {
+) : Event<FocusedInputLayoutChangedEvent>(surfaceId, viewId) {
   override fun getEventName() = "topFocusedInputLayoutChanged"
 
   // All events for a given view can be coalesced

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputTextChangedEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputTextChangedEvent.kt
@@ -8,7 +8,7 @@ class FocusedInputTextChangedEvent(
   surfaceId: Int,
   viewId: Int,
   private val text: String,
-) : Event<KeyboardTransitionEvent>(surfaceId, viewId) {
+) : Event<FocusedInputTextChangedEvent>(surfaceId, viewId) {
   override fun getEventName() = "topFocusedInputTextChanged"
 
   // All events for a given view can be coalesced

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -951,7 +951,7 @@ PODS:
   - React-Mapbuffer (0.73.6):
     - glog
     - React-debug
-  - react-native-keyboard-controller (1.11.6):
+  - react-native-keyboard-controller (1.11.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1405,7 +1405,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 85583ef014ce53d731a98c66a0e24496f7a83066
   React-logger: 3eb80a977f0d9669468ef641a5e1fabbc50a09ec
   React-Mapbuffer: 84ea43c6c6232049135b1550b8c60b2faac19fab
-  react-native-keyboard-controller: d7eb6a5884e1b193c902e02f2ca298e53cad3a77
+  react-native-keyboard-controller: 43348036c16b2092851272a4cb4190f2a6b8f605
   react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
   react-native-text-input-mask: 22ca8eeef84d42a896f79428f7d175a5eb8b1c4e
   React-nativeconfig: b4d4e9901d4cabb57be63053fd2aa6086eb3c85f

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keyboard-controller",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "description": "Keyboard manager which works in identical way on both iOS and Android",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# Release

Version 1.11.7

Also in this PR I fixed incorrect event in generic params on Android.

Most likely last release for 1.11.x version.
