### PR TITLE
docs: mention that `react-native-reanimated` is a mandatory dependency right now

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -40,6 +40,11 @@ npm install react-native-keyboard-controller --save
 </TabItem>
 </Tabs>
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/versioned_docs/version-1.0.0/installation.md
+++ b/docs/versioned_docs/version-1.0.0/installation.md
@@ -14,6 +14,11 @@ yarn add react-native-keyboard-controller
 # npm install react-native-keyboard-controller --save
 ```
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/versioned_docs/version-1.10.0/installation.mdx
+++ b/docs/versioned_docs/version-1.10.0/installation.mdx
@@ -40,6 +40,11 @@ npm install react-native-keyboard-controller --save
 </TabItem>
 </Tabs>
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/versioned_docs/version-1.11.0/installation.mdx
+++ b/docs/versioned_docs/version-1.11.0/installation.mdx
@@ -40,6 +40,11 @@ npm install react-native-keyboard-controller --save
 </TabItem>
 </Tabs>
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/versioned_docs/version-1.4.0/installation.md
+++ b/docs/versioned_docs/version-1.4.0/installation.md
@@ -14,6 +14,11 @@ yarn add react-native-keyboard-controller
 # npm install react-native-keyboard-controller --save
 ```
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/versioned_docs/version-1.5.0/installation.md
+++ b/docs/versioned_docs/version-1.5.0/installation.md
@@ -26,6 +26,11 @@ yarn add react-native-keyboard-controller
 # npm install react-native-keyboard-controller --save
 ```
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/versioned_docs/version-1.6.0/installation.md
+++ b/docs/versioned_docs/version-1.6.0/installation.md
@@ -26,6 +26,11 @@ yarn add react-native-keyboard-controller
 # npm install react-native-keyboard-controller --save
 ```
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/versioned_docs/version-1.7.0/installation.md
+++ b/docs/versioned_docs/version-1.7.0/installation.md
@@ -26,6 +26,11 @@ yarn add react-native-keyboard-controller
 # npm install react-native-keyboard-controller --save
 ```
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/versioned_docs/version-1.8.0/installation.md
+++ b/docs/versioned_docs/version-1.8.0/installation.md
@@ -26,6 +26,11 @@ yarn add react-native-keyboard-controller
 # npm install react-native-keyboard-controller --save
 ```
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

--- a/docs/versioned_docs/version-1.9.0/installation.mdx
+++ b/docs/versioned_docs/version-1.9.0/installation.mdx
@@ -40,6 +40,11 @@ npm install react-native-keyboard-controller --save
 </TabItem>
 </Tabs>
 
+:::warning Mandatory `react-native-reanimated` dependency
+
+This library requires `react-native-reanimated` to work properly. If you don't have it in your project, you need to follow [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and install it in your project before using this library.
+:::
+
 ### Linking
 
 This package supports [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).


### PR DESCRIPTION
## 📜 Description

Added warning on installation page that `reanimated` is a mandatory dependency right now.

## 💡 Motivation and Context

People who are not aware about adding `reanimated` dependency may get "failed to create a worklet" error, so I want to make it explicit that `reanimated` is a mandatory dependency right now (maybe later I'll make it optional).

Partially resovles https://github.com/kirillzyusko/react-native-keyboard-controller/issues/301

## 📢 Changelog

### Docs

- added a warning about mandatory `reanimated` installation

## 🤔 How Has This Been Tested?

Tested manually on `localhost:3000`.

## 📸 Screenshots (if appropriate):

<img width="1007" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/98d00954-0425-4688-b10d-42f00a29e318">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
