### PR TITLE
fix: export component props

### DIFF
--- a/src/components/KeyboardAvoidingView/index.tsx
+++ b/src/components/KeyboardAvoidingView/index.tsx
@@ -12,7 +12,7 @@ import { useKeyboardAnimation } from "./hooks";
 
 import type { LayoutRectangle, ViewProps } from "react-native";
 
-type Props = {
+export type KeyboardAvoidingViewProps = {
   /**
    * Specify how to react to the presence of the keyboard.
    */
@@ -47,7 +47,10 @@ const defaultLayout: LayoutRectangle = {
  * View that moves out of the way when the keyboard appears by automatically
  * adjusting its height, position, or bottom padding.
  */
-const KeyboardAvoidingView = forwardRef<View, React.PropsWithChildren<Props>>(
+const KeyboardAvoidingView = forwardRef<
+  View,
+  React.PropsWithChildren<KeyboardAvoidingViewProps>
+>(
   (
     {
       behavior,

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -24,7 +24,7 @@ import type {
 } from "react-native";
 import type { FocusedInputLayoutChangedEvent } from "react-native-keyboard-controller";
 
-type KeyboardAwareScrollViewProps = {
+export type KeyboardAwareScrollViewProps = {
   /** The distance between keyboard and focused `TextInput` when keyboard is shown. Default is `0`. */
   bottomOffset?: number;
   /** Prevents automatic scrolling of the `ScrollView` when the keyboard gets hidden, maintaining the current screen position. Default is `false`. */

--- a/src/components/KeyboardStickyView/index.tsx
+++ b/src/components/KeyboardStickyView/index.tsx
@@ -8,7 +8,7 @@ import { useReanimatedKeyboardAnimation } from "react-native-keyboard-controller
 
 import type { View, ViewProps } from "react-native";
 
-type KeyboardStickyViewProps = {
+export type KeyboardStickyViewProps = {
   /**
    * Specify additional offset to the view for given keyboard state.
    */

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,4 +5,7 @@ export {
   default as KeyboardToolbar,
   DefaultKeyboardToolbarTheme,
 } from "./KeyboardToolbar";
+export type { KeyboardAvoidingViewProps } from "./KeyboardAvoidingView";
+export type { KeyboardStickyViewProps } from "./KeyboardStickyView";
+export type { KeyboardAwareScrollViewProps } from "./KeyboardAwareScrollView";
 export type { KeyboardToolbarProps } from "./KeyboardToolbar";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,4 +13,9 @@ export {
   KeyboardToolbar,
   DefaultKeyboardToolbarTheme,
 } from "./components";
-export type { KeyboardToolbarProps } from "./components";
+export type {
+  KeyboardAvoidingViewProps,
+  KeyboardStickyViewProps,
+  KeyboardAwareScrollViewProps,
+  KeyboardToolbarProps,
+} from "./components";


### PR DESCRIPTION
## 📜 Description

Exported props for all components, including:
- `KeyboardAvoidingView`;
- `KeyboardStcikyView`;
- `KeyboardAwareScrollView`;
- `KeyboardToolbar`.

## 💡 Motivation and Context

Sometimes people need to wrap components into additional methods (for example `createBottomSheetScrollableComponent`) and it requires to know which props component is consuming.

Before devs had to copy/paste the props, but this is not a good from code duplication and consistency perspective.

So in this PR I'm exporting props for remaining components (`KeyboardToolbarProps` were already exported).

## 📢 Changelog

### JS

- export props for `KeyboardAvoidingView`;
- export props for `KeyboardStickyView`;
- export props for `KeyboardAwareScrollView`;

## 🤔 How Has This Been Tested?

Tested via CI 😁 

## 📸 Screenshots (if appropriate):

<img width="910" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/cb823852-6d41-484d-8afe-3dc8900f2172">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
