### PR TITLE
docs: add `avoid keyboard` keyword, update SEO keywords, fix flaky docs e2e tests

### DIFF
--- a/docs/__tests__/screenshot.css
+++ b/docs/__tests__/screenshot.css
@@ -21,3 +21,7 @@ img[src$='.gif'],
 .lottie {
   display: none;
 }
+/* playwright - universal class that will hide element in e2e tests environment */
+.playwright {
+  display: none;
+}

--- a/docs/blog/2022-09-22-fabric/index.md
+++ b/docs/blog/2022-09-22-fabric/index.md
@@ -17,7 +17,9 @@ I'm glad to announce, that new upcoming release `1.2.0` brings a support for new
 
 Fortunately this library is backward compatible with old architecture and will be compiled conditionally depending on which architecture you are using. So don't be afraid of updating it to the latest version - it doesn't have any breaking changes!
 
-![react native logo](./react-native.png)
+<div class="playwright">
+  ![react native logo](./react-native.png#img-thumbnail)
+</div>
 
 <!--truncate-->
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -194,7 +194,8 @@ const config = {
       metadata: [
         {
           name: "keywords",
-          content: "react-native, keyboard, animation, ios, android",
+          content:
+            "react-native, keyboard, animation, ios, android, avoid keyboard, keyboard avoiding view, keyboard aware scroll view, sticky keyboard view, keyboard toolbar",
         },
       ],
       algolia: {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "focused input",
     "text changed",
     "avoiding view",
+    "avoid keyboard",
     "sticky view",
     "keyboard aware scroll view",
     "keyboard toolbar",


### PR DESCRIPTION
## 📜 Description

Added `avoid keyboard` to keywords + updated SEO keywords.

## 💡 Motivation and Context

When I do search for `avoid keyboard react native` on `npm` the `react-native-keyboard-controller` is not showing up in the search results:

<img width="1529" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e885b77e-b72f-4e2a-89b1-8544888ac900">

So this PR fixes this 🙃 

## 📢 Changelog

### Docs

- added `avoid keyboard` to `keywords` in `package.json`;
- updated SEO keywords;
- fixed flaky e2e test (exclude a picture from blogpost);

## 🤔 How Has This Been Tested?

There is no way to test these changes - can be verified only after merge + publishing.

## 📸 Screenshots (if appropriate):

🤷‍♂️ 

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
