### PR TITLE
refactor: use `KeyboardAnimation` as common interface for an animation driver

### DIFF
--- a/ios/core/KeyboardAnimation.swift
+++ b/ios/core/KeyboardAnimation.swift
@@ -1,0 +1,77 @@
+//
+//  KeyboardAnimation.swift
+//  react-native-keyboard-controller
+//
+//  Created by Kiryl Ziusko on 04/05/2024.
+//
+
+import Foundation
+
+protocol KeyboardAnimationProtocol {
+  var startTime: CFTimeInterval { get }
+  var diff: Double { get }
+  var isIncreasing: Bool { get }
+
+  func valueAt(time: Double) -> Double
+  func timingAt(value: Double) -> Double
+}
+
+public class KeyboardAnimation: KeyboardAnimationProtocol {
+  private weak var animation: CAMediaTiming?
+
+  // constructor variables
+  let fromValue: Double
+  let toValue: Double
+  let speed: Float
+  let timestamp: CFTimeInterval
+
+  init(fromValue: Double, toValue: Double, animation: CAMediaTiming) {
+    self.fromValue = fromValue
+    self.toValue = toValue
+    self.animation = animation
+    speed = animation.speed
+    timestamp = CACurrentMediaTime()
+  }
+
+  // public getters
+  var startTime: CFTimeInterval {
+    // when concurrent animation happens, then `.beginTime` remains the same
+    return max(animation?.beginTime ?? timestamp, timestamp)
+  }
+
+  var diff: Double {
+    return ((animation?.beginTime ?? timestamp) - timestamp).truncatingRemainder(dividingBy: UIUtils.nextFrame)
+  }
+
+  var isIncreasing: Bool {
+    return fromValue < toValue
+  }
+
+  func valueAt(time _: Double) -> Double {
+    fatalError("Method is not implemented in abstract class!")
+  }
+
+  func timingAt(value: Double) -> Double {
+    var lowerBound = 0.0
+    var upperBound = 1.0 // Assuming 1 second is the max duration for simplicity
+    let tolerance = 0.00001 // Define how precise you want to be
+    var tGuess = 0.0
+
+    // Check the direction of the animation
+    let isIncreasing = isIncreasing
+
+    while (upperBound - lowerBound) > tolerance {
+      tGuess = (lowerBound + upperBound) / 2
+      let currentValue = valueAt(time: tGuess / Double(speed))
+
+      // Adjust the condition to account for the direction of animation
+      if (currentValue < value && isIncreasing) || (currentValue > value && !isIncreasing) {
+        lowerBound = tGuess
+      } else {
+        upperBound = tGuess
+      }
+    }
+
+    return tGuess / Double(speed)
+  }
+}

--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -39,7 +39,7 @@ public class KeyboardMovementObserver: NSObject {
   private var keyboardHeight: CGFloat = 0.0
   private var duration = 0
   private var tag: NSNumber = -1
-  private var animation: SpringAnimation?
+  private var animation: KeyboardAnimation?
 
   @objc public init(
     handler: @escaping (NSString, NSNumber, NSNumber, NSNumber, NSNumber) -> Void,


### PR DESCRIPTION
## 📜 Description

Added `KeyboardAnimation` class (as common interface) which drives an animation of the keyboard.

## 💡 Motivation and Context

Follow up for https://github.com/kirillzyusko/react-native-keyboard-controller/pull/412

Keyboard animation can be driven not only by `CASpringAnimation` class. What we want to achieve is to have a **single interface** that gives us all necessary properties (value for a particular timing, etc.), but will incapsulate calculations of these values internally.

So in this PR I added `KeyboardAnimation` abstract class that uses some common properties for all animations (from/to value, speed, init time), has universal method for finding a particular timing for a given value (since we use a binary search) and defines other publicly available functions.

And in this PR I also started to use this universal interface (`KeyboardAnimation`) in `KeyboardMovementObserver` (`SpringAnimation` inherits from `KeyboardAnimation`).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added `KeyboardAnimation` class and `KeyboardAnimationProtocol`;
- moved all shared logic in `KeyboardAnimation` class;
- started to use `KeyboardAnimation` as a common interface for `animation`.

## 🤔 How Has This Been Tested?

Tested on iPhone 11 (iOS 17.4), real device.

## 📸 Screenshots (if appropriate):

No visual changes.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
