### PR TITLE
feat: modal example

### DIFF
--- a/FabricExample/src/components/KeyboardAnimation/index.tsx
+++ b/FabricExample/src/components/KeyboardAnimation/index.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Animated, TextInput, TouchableOpacity, View } from "react-native";
 import {
   KeyboardController,
+  useGenericKeyboardHandler,
   useKeyboardAnimation,
-  useKeyboardHandler,
 } from "react-native-keyboard-controller";
 import Reanimated, {
   useAnimatedStyle,
@@ -15,7 +15,7 @@ import styles from "./styles";
 const useGradualKeyboardAnimation = () => {
   const height = useSharedValue(0);
 
-  useKeyboardHandler(
+  useGenericKeyboardHandler(
     {
       onMove: (e) => {
         "worklet";
@@ -34,8 +34,14 @@ const useGradualKeyboardAnimation = () => {
   return height;
 };
 
-export default function KeyboardAnimation() {
-  const { height, progress } = useKeyboardAnimation();
+type Props = {
+  provider?: typeof useKeyboardAnimation;
+};
+
+export default function KeyboardAnimation({
+  provider = useKeyboardAnimation,
+}: Props) {
+  const { height, progress } = provider();
   const keyboard = useGradualKeyboardAnimation();
 
   const gradual = useAnimatedStyle(

--- a/FabricExample/src/constants/screenNames.ts
+++ b/FabricExample/src/constants/screenNames.ts
@@ -18,4 +18,5 @@ export enum ScreenNames {
   ENABLED_DISABLED = "ENABLED_DISABLED",
   CLOSE = "CLOSE",
   TOOLBAR = "TOOLBAR",
+  MODAL = "MODAL",
 }

--- a/FabricExample/src/navigation/ExamplesStack/index.tsx
+++ b/FabricExample/src/navigation/ExamplesStack/index.tsx
@@ -12,6 +12,7 @@ import InteractiveKeyboardIOS from "../../screens/Examples/InteractiveKeyboardIO
 import KeyboardAnimation from "../../screens/Examples/KeyboardAnimation";
 import KeyboardAvoidingViewExample from "../../screens/Examples/KeyboardAvoidingView";
 import LottieAnimation from "../../screens/Examples/Lottie";
+import ModalExample from "../../screens/Examples/Modal";
 import NonUIProps from "../../screens/Examples/NonUIProps";
 import ReanimatedChat from "../../screens/Examples/ReanimatedChat";
 import ReanimatedChatFlatList from "../../screens/Examples/ReanimatedChatFlatList";
@@ -36,6 +37,7 @@ export type ExamplesStackParamList = {
   [ScreenNames.ENABLED_DISABLED]: undefined;
   [ScreenNames.CLOSE]: undefined;
   [ScreenNames.TOOLBAR]: undefined;
+  [ScreenNames.MODAL]: undefined;
 };
 
 const Stack = createStackNavigator<ExamplesStackParamList>();
@@ -89,6 +91,9 @@ const options = {
   },
   [ScreenNames.TOOLBAR]: {
     title: "Toolbar",
+  },
+  [ScreenNames.MODAL]: {
+    title: "Modal",
   },
 };
 
@@ -173,6 +178,11 @@ const ExamplesStack = () => (
       name={ScreenNames.TOOLBAR}
       component={ToolbarExample}
       options={options[ScreenNames.TOOLBAR]}
+    />
+    <Stack.Screen
+      name={ScreenNames.MODAL}
+      component={ModalExample}
+      options={options[ScreenNames.MODAL]}
     />
   </Stack.Navigator>
 );

--- a/FabricExample/src/screens/Examples/Main/constants.ts
+++ b/FabricExample/src/screens/Examples/Main/constants.ts
@@ -99,4 +99,10 @@ export const examples: Example[] = [
     info: ScreenNames.TOOLBAR,
     icons: "🔥",
   },
+  {
+    title: "Modal",
+    testID: "modal",
+    info: ScreenNames.MODAL,
+    icons: "🔴 🌎",
+  },
 ];

--- a/FabricExample/src/screens/Examples/Modal/index.tsx
+++ b/FabricExample/src/screens/Examples/Modal/index.tsx
@@ -53,8 +53,8 @@ const styles = StyleSheet.create({
   },
   modalContainer: {
     flex: 1,
-    paddingLeft: 100,
-    backgroundColor: "rgba(0,0,0,0.5)",
+    paddingLeft: 220,
+    backgroundColor: "rgba(0,0,0,0.3)",
     justifyContent: "center",
     alignItems: "center",
   },

--- a/FabricExample/src/screens/Examples/Modal/index.tsx
+++ b/FabricExample/src/screens/Examples/Modal/index.tsx
@@ -32,12 +32,12 @@ export default function ModalExample() {
         onDismiss={() => setModalVisible(false)}
         onRequestClose={() => setModalVisible(false)}
       >
-        <Button
-          title={"Close Modal"}
-          onPress={() => setModalVisible(false)}
-          testID="close_button"
-        />
         <View style={styles.modalContainer}>
+          <Button
+            title={"Close Modal"}
+            onPress={() => setModalVisible(false)}
+            testID="close_button"
+          />
           <KeyboardAnimationTemplate provider={useKeyboardAnimation} />
         </View>
       </Modal>
@@ -53,6 +53,7 @@ const styles = StyleSheet.create({
   },
   modalContainer: {
     flex: 1,
+    paddingTop: 50,
     paddingLeft: 220,
     backgroundColor: "rgba(0,0,0,0.3)",
     justifyContent: "center",

--- a/FabricExample/src/screens/Examples/Modal/index.tsx
+++ b/FabricExample/src/screens/Examples/Modal/index.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import { Button, Modal, StyleSheet, View } from "react-native";
+import { useKeyboardContext } from "react-native-keyboard-controller";
+
+import KeyboardAnimationTemplate from "../../../components/KeyboardAnimation";
+
+// when modal is unmounted we don't want to reset `softInputMode` to default value
+const useKeyboardAnimation = () => {
+  const context = useKeyboardContext();
+
+  return context.animated;
+};
+
+export default function ModalExample() {
+  const [modalVisible, setModalVisible] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <Button
+        title={"Show Modal"}
+        onPress={() => setModalVisible(true)}
+        testID="show_button"
+      />
+
+      <View style={styles.animationContainer}>
+        <KeyboardAnimationTemplate />
+      </View>
+
+      <Modal
+        transparent
+        visible={modalVisible}
+        onDismiss={() => setModalVisible(false)}
+        onRequestClose={() => setModalVisible(false)}
+      >
+        <Button
+          title={"Close Modal"}
+          onPress={() => setModalVisible(false)}
+          testID="close_button"
+        />
+        <View style={styles.modalContainer}>
+          <KeyboardAnimationTemplate provider={useKeyboardAnimation} />
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "stretch",
+  },
+  modalContainer: {
+    flex: 1,
+    paddingLeft: 100,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  animationContainer: {
+    flex: 1,
+  },
+  textInput: {
+    width: 200,
+    marginTop: 50,
+    height: 50,
+    backgroundColor: "yellow",
+  },
+});

--- a/example/src/components/KeyboardAnimation/index.tsx
+++ b/example/src/components/KeyboardAnimation/index.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Animated, TextInput, TouchableOpacity, View } from "react-native";
 import {
   KeyboardController,
+  useGenericKeyboardHandler,
   useKeyboardAnimation,
-  useKeyboardHandler,
 } from "react-native-keyboard-controller";
 import Reanimated, {
   useAnimatedStyle,
@@ -15,7 +15,7 @@ import styles from "./styles";
 const useGradualKeyboardAnimation = () => {
   const height = useSharedValue(0);
 
-  useKeyboardHandler(
+  useGenericKeyboardHandler(
     {
       onMove: (e) => {
         "worklet";
@@ -34,8 +34,14 @@ const useGradualKeyboardAnimation = () => {
   return height;
 };
 
-export default function KeyboardAnimation() {
-  const { height, progress } = useKeyboardAnimation();
+type Props = {
+  provider?: typeof useKeyboardAnimation;
+};
+
+export default function KeyboardAnimation({
+  provider = useKeyboardAnimation,
+}: Props) {
+  const { height, progress } = provider();
   const keyboard = useGradualKeyboardAnimation();
 
   const gradual = useAnimatedStyle(

--- a/example/src/constants/screenNames.ts
+++ b/example/src/constants/screenNames.ts
@@ -19,4 +19,5 @@ export enum ScreenNames {
   CLOSE = "CLOSE",
   TEXT_INPUT_MASK = "TEXT_INPUT_MASK",
   TOOLBAR = "TOOLBAR",
+  MODAL = "MODAL",
 }

--- a/example/src/navigation/ExamplesStack/index.tsx
+++ b/example/src/navigation/ExamplesStack/index.tsx
@@ -12,6 +12,7 @@ import InteractiveKeyboardIOS from "../../screens/Examples/InteractiveKeyboardIO
 import KeyboardAnimation from "../../screens/Examples/KeyboardAnimation";
 import KeyboardAvoidingViewExample from "../../screens/Examples/KeyboardAvoidingView";
 import LottieAnimation from "../../screens/Examples/Lottie";
+import ModalExample from "../../screens/Examples/Modal";
 import NonUIProps from "../../screens/Examples/NonUIProps";
 import ReanimatedChat from "../../screens/Examples/ReanimatedChat";
 import ReanimatedChatFlatList from "../../screens/Examples/ReanimatedChatFlatList";
@@ -183,6 +184,11 @@ const ExamplesStack = () => (
       name={ScreenNames.TOOLBAR}
       component={ToolbarExample}
       options={options[ScreenNames.TOOLBAR]}
+    />
+    <Stack.Screen
+      name={ScreenNames.MODAL}
+      component={ModalExample}
+      options={options[ScreenNames.MODAL]}
     />
   </Stack.Navigator>
 );

--- a/example/src/navigation/ExamplesStack/index.tsx
+++ b/example/src/navigation/ExamplesStack/index.tsx
@@ -39,6 +39,7 @@ export type ExamplesStackParamList = {
   [ScreenNames.CLOSE]: undefined;
   [ScreenNames.TEXT_INPUT_MASK]: undefined;
   [ScreenNames.TOOLBAR]: undefined;
+  [ScreenNames.MODAL]: undefined;
 };
 
 const Stack = createStackNavigator<ExamplesStackParamList>();
@@ -95,6 +96,9 @@ const options = {
   },
   [ScreenNames.TOOLBAR]: {
     title: "Toolbar",
+  },
+  [ScreenNames.MODAL]: {
+    title: "Modal",
   },
 };
 

--- a/example/src/screens/Examples/Main/constants.ts
+++ b/example/src/screens/Examples/Main/constants.ts
@@ -105,4 +105,10 @@ export const examples: Example[] = [
     info: ScreenNames.TOOLBAR,
     icons: "🔥",
   },
+  {
+    title: "Modal",
+    testID: "modal",
+    info: ScreenNames.MODAL,
+    icons: "🔴 🌎",
+  },
 ];

--- a/example/src/screens/Examples/Modal/index.tsx
+++ b/example/src/screens/Examples/Modal/index.tsx
@@ -53,8 +53,8 @@ const styles = StyleSheet.create({
   },
   modalContainer: {
     flex: 1,
-    paddingLeft: 100,
-    backgroundColor: "rgba(0,0,0,0.5)",
+    paddingLeft: 220,
+    backgroundColor: "rgba(0,0,0,0.3)",
     justifyContent: "center",
     alignItems: "center",
   },

--- a/example/src/screens/Examples/Modal/index.tsx
+++ b/example/src/screens/Examples/Modal/index.tsx
@@ -32,12 +32,12 @@ export default function ModalExample() {
         onDismiss={() => setModalVisible(false)}
         onRequestClose={() => setModalVisible(false)}
       >
-        <Button
-          title={"Close Modal"}
-          onPress={() => setModalVisible(false)}
-          testID="close_button"
-        />
         <View style={styles.modalContainer}>
+          <Button
+            title={"Close Modal"}
+            onPress={() => setModalVisible(false)}
+            testID="close_button"
+          />
           <KeyboardAnimationTemplate provider={useKeyboardAnimation} />
         </View>
       </Modal>
@@ -53,6 +53,7 @@ const styles = StyleSheet.create({
   },
   modalContainer: {
     flex: 1,
+    paddingTop: 50,
     paddingLeft: 220,
     backgroundColor: "rgba(0,0,0,0.3)",
     justifyContent: "center",

--- a/example/src/screens/Examples/Modal/index.tsx
+++ b/example/src/screens/Examples/Modal/index.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import { Button, Modal, StyleSheet, View } from "react-native";
+import { useKeyboardContext } from "react-native-keyboard-controller";
+
+import KeyboardAnimationTemplate from "../../../components/KeyboardAnimation";
+
+// when modal is unmounted we don't want to reset `softInputMode` to default value
+const useKeyboardAnimation = () => {
+  const context = useKeyboardContext();
+
+  return context.animated;
+};
+
+export default function ModalExample() {
+  const [modalVisible, setModalVisible] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <Button
+        title={"Show Modal"}
+        onPress={() => setModalVisible(true)}
+        testID="show_button"
+      />
+
+      <View style={styles.animationContainer}>
+        <KeyboardAnimationTemplate />
+      </View>
+
+      <Modal
+        transparent
+        visible={modalVisible}
+        onDismiss={() => setModalVisible(false)}
+        onRequestClose={() => setModalVisible(false)}
+      >
+        <Button
+          title={"Close Modal"}
+          onPress={() => setModalVisible(false)}
+          testID="close_button"
+        />
+        <View style={styles.modalContainer}>
+          <KeyboardAnimationTemplate provider={useKeyboardAnimation} />
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "stretch",
+  },
+  modalContainer: {
+    flex: 1,
+    paddingLeft: 100,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  animationContainer: {
+    flex: 1,
+  },
+  textInput: {
+    width: 200,
+    marginTop: 50,
+    height: 50,
+    backgroundColor: "yellow",
+  },
+});


### PR DESCRIPTION
## 📜 Description

Added an example with `Modal` usage.

## 💡 Motivation and Context

Right now `Modal` usage will lead to default behavior on Android (i. e. window is automatically resized + keyboard movement is not tracked).

I'm planning to fix it later, but right now I just want to have a reproducible demo in example app (I used similar approach when fixed a native-stack integration).

## 📢 Changelog

### JS

- added an example with modal usage;

## 🤔 How Has This Been Tested?

Tested on iPhone 15 Pro and Pixel 3a.

## 📸 Screenshots (if appropriate):

<img width="407" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/7f704f26-614e-4570-8172-c37775bc6816">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
