### PR TITLE
fix: use `dp` for selection events

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
@@ -121,10 +121,10 @@ class KeyboardControllerSelectionWatcher(
         return@FrameScheduler
       }
 
-      val cursorPositionStartX: Double
-      val cursorPositionStartY: Double
-      val cursorPositionEndX: Double
-      val cursorPositionEndY: Double
+      val cursorPositionStartX: Float
+      val cursorPositionStartY: Float
+      val cursorPositionEndX: Float
+      val cursorPositionEndY: Float
 
       val realStart = min(start, end)
       val realEnd = max(start, end)
@@ -133,8 +133,8 @@ class KeyboardControllerSelectionWatcher(
       val baselineStart = layout.getLineBaseline(lineStart)
       val ascentStart = layout.getLineAscent(lineStart)
 
-      cursorPositionStartX = layout.getPrimaryHorizontal(realStart).toDouble()
-      cursorPositionStartY = (baselineStart + ascentStart).toDouble()
+      cursorPositionStartX = layout.getPrimaryHorizontal(realStart)
+      cursorPositionStartY = (baselineStart + ascentStart).toFloat()
 
       val lineEnd = layout.getLineForOffset(realEnd)
 
@@ -146,10 +146,10 @@ class KeyboardControllerSelectionWatcher(
         0
       }
 
-      cursorPositionEndX = (right + cursorWidth).toDouble()
-      cursorPositionEndY = bottom.toDouble()
+      cursorPositionEndX = right + cursorWidth
+      cursorPositionEndY = bottom.toFloat()
 
-      action(start, end, cursorPositionStartX, cursorPositionStartY, cursorPositionEndX, cursorPositionEndY)
+      action(start, end, cursorPositionStartX.dp, cursorPositionStartY.dp, cursorPositionEndX.dp, cursorPositionEndY.dp)
     }
   }
 


### PR DESCRIPTION
## 📜 Description

Use `dp` for selection events.

## 💡 Motivation and Context

If we pass values directly, then we will have incorrect positioning, because we are passing `px` while RN relies on `dp`. So in this PR we are converting all selection coordinates in `dp` and only then pass them.

## 📢 Changelog

### Android

- convert all selection coordinates to `dp`;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 3a (API 33, emulator).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="436" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/de8890e6-ee18-4104-bb50-2c36c4be0d96">|<img width="432" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/65f6ebd6-444b-4fde-beba-119bfdd3ede6">|

> Pay an attention to `x` coordinates 👀 

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
