### PR TITLE
fix: prevent crash when no first responder

### DIFF
--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -95,7 +95,7 @@ public class FocusedInputObserver: NSObject {
   }
 
   @objc func keyboardWillShow(_: Notification) {
-    let responder = UIResponder.current as? UIView
+    guard let responder = UIResponder.current as? UIView else { return }
     removeObservers(newResponder: responder)
     currentResponder = responder
     currentInput = currentResponder?.superview as UIView?


### PR DESCRIPTION
## 📜 Description

Prevent crash when no first responder in `keyboardWillShow`.

## 💡 Motivation and Context

It happens because we can not find first responder when `keyboardWillShow` is triggerred:

<img width="587" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/f2281fc7-291c-4fec-8584-f7e871001e99">

Then we get NPE here (read `absoluteY` of `nil`):

<img width="592" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/6ce366e5-6a91-4291-9397-4a3d7632b189">

And finally app crashes:

<img width="622" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/25e10521-1112-4364-bac0-7defd2b94622">

To fix this problem I've decided to add `guard` statement - there is no sense to execute code further if we don't have a reference to `TextInput` - no sense to store it in holder, no sense to add listeners/observers, substitute delegates etc.

## 📢 Changelog

### iOS

- check that first responder is actually present before executing the code that relies on its presence;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15.

## 📸 Screenshots (if appropriate):


https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/83ecde49-69de-483e-8403-92c4dd41c4c7

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
