### PR TITLE
docs: integration with `@gorhom/bottom-sheet`

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -109,7 +109,8 @@
     "objc",
     "QWERT",
     "autoplayed",
-    "bridgeless"
+    "bridgeless",
+    "scrollview"
   ],
   "ignorePaths": [
     "node_modules",

--- a/docs/docs/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/docs/api/components/keyboard-aware-scroll-view.mdx
@@ -77,7 +77,9 @@ Prevents automatic scrolling of the `ScrollView` when the keyboard gets hidden, 
 
 A boolean prop indicating whether `KeyboardAwareScrollView` is enabled or disabled. Default is `true`.
 
-## `FlatList`/`FlashList`/`SectionList` integrations
+## Integration with 3rd party components
+
+### `FlatList`/`FlashList`/`SectionList` etc.
 
 Unlike original [react-native-keyboard-aware-scroll-view](https://github.com/APSL/react-native-keyboard-aware-scroll-view) package I'm not exporting `KeyboardAwareFlatList`, `KeyboardAwareSectionList` and other components.
 
@@ -149,6 +151,56 @@ export default List;
 ```
 
 </details>
+
+### `@gorhom/bottom-sheet`
+
+To seamlessly work with [@gorhom/bottom-sheet](https://github.com/gorhom/react-native-bottom-sheet) you will need to wrap `KeyboardAwareScrollView` in some HOCs provided by `@gorhom/bottom-sheet`.
+
+```tsx title="BottomSheetKeyboardAwareScrollView.tsx"
+import {
+  KeyboardAwareScrollView,
+  KeyboardAwareScrollViewProps,
+} from "react-native-keyboard-controller";
+import {
+  SCROLLABLE_TYPE,
+  createBottomSheetScrollableComponent,
+  type BottomSheetScrollViewMethods,
+} from "@gorhom/bottom-sheet";
+import type { BottomSheetScrollViewProps } from "@gorhom/bottom-sheet/src/components/bottomSheetScrollable/types";
+import Reanimated from "react-native-reanimated";
+
+const AnimatedScrollView =
+  Reanimated.createAnimatedComponent<KeyboardAwareScrollViewProps>(
+    KeyboardAwareScrollView,
+  );
+const BottomSheetScrollViewComponent = createBottomSheetScrollableComponent<
+  BottomSheetScrollViewMethods,
+  BottomSheetScrollViewProps
+>(SCROLLABLE_TYPE.SCROLLVIEW, AnimatedScrollView);
+const BottomSheetKeyboardAwareScrollView = memo(BottomSheetScrollViewComponent);
+
+BottomSheetKeyboardAwareScrollView.displayName =
+  "BottomSheetKeyboardAwareScrollView";
+
+export default BottomSheetKeyboardAwareScrollView as (
+  props: BottomSheetScrollViewProps,
+) => ReturnType<typeof BottomSheetKeyboardAwareScrollView>;
+```
+
+```tsx title="index.tsx"
+import BottomSheet from "@gorhom/bottom-sheet";
+import BottomSheetKeyboardAwareScrollView from "./BottomSheetKeyboardAwareScrollView";
+
+export function Example() {
+  return (
+    <BottomSheet>
+      <BottomSheetKeyboardAwareScrollView>
+        {/* More content here */}
+      </BottomSheetKeyboardAwareScrollView>
+    </BottomSheet>
+  );
+}
+```
 
 ## Example
 

--- a/docs/versioned_docs/version-1.12.0/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/versioned_docs/version-1.12.0/api/components/keyboard-aware-scroll-view.mdx
@@ -77,7 +77,9 @@ Prevents automatic scrolling of the `ScrollView` when the keyboard gets hidden, 
 
 A boolean prop indicating whether `KeyboardAwareScrollView` is enabled or disabled. Default is `true`.
 
-## `FlatList`/`FlashList`/`SectionList` integrations
+## Integration with 3rd party components
+
+### `FlatList`/`FlashList`/`SectionList` etc.
 
 Unlike original [react-native-keyboard-aware-scroll-view](https://github.com/APSL/react-native-keyboard-aware-scroll-view) package I'm not exporting `KeyboardAwareFlatList`, `KeyboardAwareSectionList` and other components.
 
@@ -149,6 +151,56 @@ export default List;
 ```
 
 </details>
+
+### `@gorhom/bottom-sheet`
+
+To seamlessly work with [@gorhom/bottom-sheet](https://github.com/gorhom/react-native-bottom-sheet) you will need to wrap `KeyboardAwareScrollView` in some HOCs provided by `@gorhom/bottom-sheet`.
+
+```tsx title="BottomSheetKeyboardAwareScrollView.tsx"
+import {
+  KeyboardAwareScrollView,
+  KeyboardAwareScrollViewProps,
+} from "react-native-keyboard-controller";
+import {
+  SCROLLABLE_TYPE,
+  createBottomSheetScrollableComponent,
+  type BottomSheetScrollViewMethods,
+} from "@gorhom/bottom-sheet";
+import type { BottomSheetScrollViewProps } from "@gorhom/bottom-sheet/src/components/bottomSheetScrollable/types";
+import Reanimated from "react-native-reanimated";
+
+const AnimatedScrollView =
+  Reanimated.createAnimatedComponent<KeyboardAwareScrollViewProps>(
+    KeyboardAwareScrollView,
+  );
+const BottomSheetScrollViewComponent = createBottomSheetScrollableComponent<
+  BottomSheetScrollViewMethods,
+  BottomSheetScrollViewProps
+>(SCROLLABLE_TYPE.SCROLLVIEW, AnimatedScrollView);
+const BottomSheetKeyboardAwareScrollView = memo(BottomSheetScrollViewComponent);
+
+BottomSheetKeyboardAwareScrollView.displayName =
+  "BottomSheetKeyboardAwareScrollView";
+
+export default BottomSheetKeyboardAwareScrollView as (
+  props: BottomSheetScrollViewProps,
+) => ReturnType<typeof BottomSheetKeyboardAwareScrollView>;
+```
+
+```tsx title="index.tsx"
+import BottomSheet from "@gorhom/bottom-sheet";
+import BottomSheetKeyboardAwareScrollView from "./BottomSheetKeyboardAwareScrollView";
+
+export function Example() {
+  return (
+    <BottomSheet>
+      <BottomSheetKeyboardAwareScrollView>
+        {/* More content here */}
+      </BottomSheetKeyboardAwareScrollView>
+    </BottomSheet>
+  );
+}
+```
 
 ## Example
 


### PR DESCRIPTION
## 📜 Description

Added docs explaining how to integrate `KeyboardAwareScrollView` and `@gorhom/bottom-sheet`.

## 💡 Motivation and Context

It may be no very obvious that you'll need to wrap it in additional HOCs.

Inspired by https://github.com/kirillzyusko/react-native-keyboard-controller/discussions/309#discussioncomment-9215288

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/343

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added a section about integration `KeyboardAwareScrollView` with `@gorhom/bottom-sheet`;

## 🤔 How Has This Been Tested?

Tested via preview and `localhost:3000`.

## 📸 Screenshots (if appropriate):

<img width="1300" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e321a355-46fd-41ed-8f39-8a45a9f18c0d">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
