### PR TITLE
fix: race condition between keyboardWillHide and KVO

### DIFF
--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -126,16 +126,18 @@ public class FocusedInputObserver: NSObject {
     let focusedInput = currentInput
     let globalFrame = focusedInput?.globalFrame
 
+    guard let frame = globalFrame, let input = focusedInput else { return }
+
     let data: [String: Any] = [
       "target": responder.reactViewTag,
       "parentScrollViewTarget": responder.parentScrollViewTarget,
       "layout": [
-        "absoluteX": globalFrame?.origin.x,
-        "absoluteY": globalFrame?.origin.y,
-        "width": focusedInput?.frame.width,
-        "height": focusedInput?.frame.height,
-        "x": focusedInput?.frame.origin.x,
-        "y": focusedInput?.frame.origin.y,
+        "absoluteX": frame.origin.x,
+        "absoluteY": frame.origin.y,
+        "width": input.frame.width,
+        "height": input.frame.height,
+        "x": input.frame.origin.x,
+        "y": input.frame.origin.y,
       ],
     ]
 


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

KVO dispatches event -> keyboardWillHide -> KVO triggers (asynchronously `syncUpLayout`) we try to send event on `nil` reference and get a crash.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

-
-

### iOS

-
-

### Android

-
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
