### PR TITLE
feat: scroll to at least the first snapToOffset value if any

### DIFF
--- a/example/src/screens/Examples/AwareScrollView/index.tsx
+++ b/example/src/screens/Examples/AwareScrollView/index.tsx
@@ -23,6 +23,8 @@ export default function AwareScrollView({ navigation }: Props) {
     useState(false);
   const [enabled, setEnabled] = useState(true);
 
+  const [snapToOffsetsEnabled, setSnapToOffsetsEnabled] = useState(false);
+
   useEffect(() => {
     navigation.setOptions({
       headerRight: () => (
@@ -37,16 +39,52 @@ export default function AwareScrollView({ navigation }: Props) {
     });
   }, []);
 
+  const snapToOffsets = [125, 225, 325, 425];
+
   return (
     <>
       <KeyboardAwareScrollView
         testID="aware_scroll_view_container"
         bottomOffset={50}
         enabled={enabled}
+        snapToOffsets={snapToOffsetsEnabled ? snapToOffsets : undefined}
         disableScrollOnKeyboardHide={disableScrollOnKeyboardHide}
         style={styles.container}
         contentContainerStyle={styles.content}
       >
+        {snapToOffsetsEnabled && (
+          <>
+            {snapToOffsets.map((offset) => (
+              <View
+                key={offset}
+                style={{
+                  width: "100%",
+                  position: "absolute",
+                  top: offset,
+                }}
+              >
+                <View
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 12,
+                  }}
+                >
+                  <Text>{offset}</Text>
+                  <View
+                    key={offset}
+                    style={{
+                      height: 2,
+                      flex: 1,
+                      backgroundColor: "black",
+                    }}
+                  ></View>
+                </View>
+              </View>
+            ))}
+          </>
+        )}
+
         {new Array(10).fill(0).map((_, i) => (
           <TextInput
             key={i}
@@ -78,6 +116,17 @@ export default function AwareScrollView({ navigation }: Props) {
             testID="bottom_sheet_toggle_enabled_state"
             onChange={() => {
               setEnabled(!enabled);
+            }}
+          />
+        </View>
+
+        <View style={styles.switchContainer}>
+          <Text>Toggle snapToOffsets</Text>
+          <Switch
+            value={snapToOffsetsEnabled}
+            testID="bottom_sheet_toggle_enabled_state"
+            onChange={() => {
+              setSnapToOffsetsEnabled(!snapToOffsetsEnabled);
             }}
           />
         </View>

--- a/example/src/screens/Examples/AwareScrollView/index.tsx
+++ b/example/src/screens/Examples/AwareScrollView/index.tsx
@@ -11,6 +11,7 @@ import type { ExamplesStackParamList } from "../../../navigation/ExamplesStack";
 import type { StackScreenProps } from "@react-navigation/stack";
 
 type Props = StackScreenProps<ExamplesStackParamList>;
+const snapToOffsets = [125, 225, 325, 425];
 
 export default function AwareScrollView({ navigation }: Props) {
   const bottomSheetModalRef = useRef<BottomSheet>(null);
@@ -39,8 +40,6 @@ export default function AwareScrollView({ navigation }: Props) {
     });
   }, []);
 
-  const snapToOffsets = [125, 225, 325, 425];
-
   return (
     <>
       <KeyboardAwareScrollView
@@ -57,28 +56,16 @@ export default function AwareScrollView({ navigation }: Props) {
             {snapToOffsets.map((offset) => (
               <View
                 key={offset}
-                style={{
-                  width: "100%",
-                  position: "absolute",
-                  top: offset,
-                }}
+                style={[
+                  styles.snapToOffsetsAbsoluteContainer,
+                  {
+                    top: offset,
+                  },
+                ]}
               >
-                <View
-                  style={{
-                    flexDirection: "row",
-                    alignItems: "center",
-                    gap: 12,
-                  }}
-                >
+                <View style={styles.snapToOffsetsInnerContainer}>
                   <Text>{offset}</Text>
-                  <View
-                    key={offset}
-                    style={{
-                      height: 2,
-                      flex: 1,
-                      backgroundColor: "black",
-                    }}
-                  ></View>
+                  <View style={styles.snapToOffsetsLine} />
                 </View>
               </View>
             ))}
@@ -124,7 +111,7 @@ export default function AwareScrollView({ navigation }: Props) {
           <Text>Toggle snapToOffsets</Text>
           <Switch
             value={snapToOffsetsEnabled}
-            testID="bottom_sheet_toggle_enabled_state"
+            testID="bottom_sheet_toggle_snap_to_offsets"
             onChange={() => {
               setSnapToOffsetsEnabled(!snapToOffsetsEnabled);
             }}

--- a/example/src/screens/Examples/AwareScrollView/styles.ts
+++ b/example/src/screens/Examples/AwareScrollView/styles.ts
@@ -17,4 +17,18 @@ export const styles = StyleSheet.create({
     alignItems: "center",
     margin: 16,
   },
+  snapToOffsetsAbsoluteContainer: {
+    width: "100%",
+    position: "absolute",
+  },
+  snapToOffsetsInnerContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  snapToOffsetsLine: {
+    height: 2,
+    flex: 1,
+    backgroundColor: "black",
+  },
 });

--- a/example/src/utils/index.ts
+++ b/example/src/utils/index.ts
@@ -1,12 +1,3 @@
 export function randomColor() {
   return "#" + Math.random().toString(16).slice(-6);
 }
-
-interface ClampLowerParams {
-  value: number;
-  lowerBound: number;
-}
-
-export function clampLower({ value, lowerBound }: ClampLowerParams) {
-  return Math.max(value, lowerBound);
-}

--- a/example/src/utils/index.ts
+++ b/example/src/utils/index.ts
@@ -1,3 +1,12 @@
 export function randomColor() {
   return "#" + Math.random().toString(16).slice(-6);
 }
+
+interface ClampLowerParams {
+  value: number;
+  lowerBound: number;
+}
+
+export function clampLower({ value, lowerBound }: ClampLowerParams) {
+  return Math.max(value, lowerBound);
+}

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-native-keyboard-controller";
 
 import { useSmoothKeyboardHandler } from "./useSmoothKeyboardHandler";
-import { clampLower, debounce } from "./utils";
+import { debounce } from "./utils";
 
 import type {
   LayoutChangeEvent,
@@ -153,16 +153,31 @@ const KeyboardAwareScrollView = forwardRef<
         const inputHeight = layout.value?.layout.height || 0;
         const point = absoluteY + inputHeight;
 
+        const scrollOutput = (
+          defaultScrollValue: number,
+          snapPoints?: number[],
+        ) => {
+          let snapPoint: number | undefined;
+
+          if (snapPoints) {
+            snapPoint = snapPoints.find(
+              (offset) => offset >= defaultScrollValue,
+            );
+          }
+
+          return snapPoint ? snapPoint : defaultScrollValue;
+        };
+
         if (visibleRect - point <= bottomOffset) {
           const interpolatedScrollTo = interpolate(
             e,
             [initialKeyboardSize.value, keyboardHeight.value],
             [
               0,
-              clampLower({
-                value: keyboardHeight.value - (height - point) + bottomOffset,
-                lowerBound: rest.snapToOffsets?.[0] || 0,
-              }),
+              scrollOutput(
+                keyboardHeight.value - (height - point) + bottomOffset,
+                rest.snapToOffsets,
+              ),
             ],
           );
           const targetScrollY =

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -9,6 +9,7 @@ import Reanimated, {
   useSharedValue,
 } from "react-native-reanimated";
 
+import { clampLower } from "example/src/utils";
 import {
   useFocusedInputHandler,
   useReanimatedFocusedInput,
@@ -154,7 +155,13 @@ const KeyboardAwareScrollView = forwardRef<
           const interpolatedScrollTo = interpolate(
             e,
             [initialKeyboardSize.value, keyboardHeight.value],
-            [0, keyboardHeight.value - (height - point) + bottomOffset],
+            [
+              0,
+              clampLower({
+                value: keyboardHeight.value - (height - point) + bottomOffset,
+                lowerBound: rest.snapToOffsets?.[0] || 0,
+              }),
+            ],
           );
           const targetScrollY =
             Math.max(interpolatedScrollTo, 0) + scrollPosition.value;

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-native-keyboard-controller";
 
 import { useSmoothKeyboardHandler } from "./useSmoothKeyboardHandler";
-import { debounce } from "./utils";
+import { debounce, scrollOutput } from "./utils";
 
 import type {
   LayoutChangeEvent,
@@ -152,21 +152,6 @@ const KeyboardAwareScrollView = forwardRef<
         const absoluteY = layout.value?.layout.absoluteY || 0;
         const inputHeight = layout.value?.layout.height || 0;
         const point = absoluteY + inputHeight;
-
-        const scrollOutput = (
-          defaultScrollValue: number,
-          snapPoints?: number[],
-        ) => {
-          let snapPoint: number | undefined;
-
-          if (snapPoints) {
-            snapPoint = snapPoints.find(
-              (offset) => offset >= defaultScrollValue,
-            );
-          }
-
-          return snapPoint ? snapPoint : defaultScrollValue;
-        };
 
         if (visibleRect - point <= bottomOffset) {
           const interpolatedScrollTo = interpolate(

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -9,14 +9,13 @@ import Reanimated, {
   useSharedValue,
 } from "react-native-reanimated";
 
-import { clampLower } from "example/src/utils";
 import {
   useFocusedInputHandler,
   useReanimatedFocusedInput,
 } from "react-native-keyboard-controller";
 
 import { useSmoothKeyboardHandler } from "./useSmoothKeyboardHandler";
-import { debounce } from "./utils";
+import { clampLower, debounce } from "./utils";
 
 import type {
   LayoutChangeEvent,

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -183,7 +183,7 @@ const KeyboardAwareScrollView = forwardRef<
 
         return 0;
       },
-      [bottomOffset, enabled],
+      [bottomOffset, enabled, rest.snapToOffsets],
     );
 
     const onChangeText = useCallback(() => {

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -161,6 +161,7 @@ const KeyboardAwareScrollView = forwardRef<
               0,
               scrollOutput(
                 keyboardHeight.value - (height - point) + bottomOffset,
+                scrollPosition.value,
                 rest.snapToOffsets,
               ),
             ],

--- a/src/components/KeyboardAwareScrollView/utils.ts
+++ b/src/components/KeyboardAwareScrollView/utils.ts
@@ -31,5 +31,6 @@ interface ClampLowerParams {
 }
 
 export function clampLower({ value, lowerBound }: ClampLowerParams) {
+  "worklet";
   return Math.max(value, lowerBound);
 }

--- a/src/components/KeyboardAwareScrollView/utils.ts
+++ b/src/components/KeyboardAwareScrollView/utils.ts
@@ -24,3 +24,17 @@ export const debounce = <F extends (...args: Parameters<F>) => ReturnType<F>>(
     return worklet(...args);
   };
 };
+
+export const scrollOutput = (
+  defaultScrollValue: number,
+  snapPoints?: number[],
+) => {
+  "worklet";
+  let snapPoint: number | undefined;
+
+  if (snapPoints) {
+    snapPoint = snapPoints.find((offset) => offset >= defaultScrollValue);
+  }
+
+  return snapPoint ? snapPoint : defaultScrollValue;
+};

--- a/src/components/KeyboardAwareScrollView/utils.ts
+++ b/src/components/KeyboardAwareScrollView/utils.ts
@@ -24,3 +24,12 @@ export const debounce = <F extends (...args: Parameters<F>) => ReturnType<F>>(
     return worklet(...args);
   };
 };
+
+interface ClampLowerParams {
+  value: number;
+  lowerBound: number;
+}
+
+export function clampLower({ value, lowerBound }: ClampLowerParams) {
+  return Math.max(value, lowerBound);
+}

--- a/src/components/KeyboardAwareScrollView/utils.ts
+++ b/src/components/KeyboardAwareScrollView/utils.ts
@@ -24,13 +24,3 @@ export const debounce = <F extends (...args: Parameters<F>) => ReturnType<F>>(
     return worklet(...args);
   };
 };
-
-interface ClampLowerParams {
-  value: number;
-  lowerBound: number;
-}
-
-export function clampLower({ value, lowerBound }: ClampLowerParams) {
-  "worklet";
-  return Math.max(value, lowerBound);
-}

--- a/src/components/KeyboardAwareScrollView/utils.ts
+++ b/src/components/KeyboardAwareScrollView/utils.ts
@@ -27,13 +27,16 @@ export const debounce = <F extends (...args: Parameters<F>) => ReturnType<F>>(
 
 export const scrollOutput = (
   defaultScrollValue: number,
+  scrollPosition: number,
   snapPoints?: number[],
 ) => {
   "worklet";
   let snapPoint: number | undefined;
 
   if (snapPoints) {
-    snapPoint = snapPoints.find((offset) => offset >= defaultScrollValue);
+    snapPoint = snapPoints.find(
+      (offset) => offset >= defaultScrollValue + scrollPosition,
+    );
   }
 
   return snapPoint ? snapPoint : defaultScrollValue;


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

When dealing with Scrollviews that are snapping to a specific point, if the keyboard is creating a scroll, we in some cases want the scrollview to scroll to at least the first snapToOffsets


<!-- Why is this change required? What problem does it solve? -->
It fixes layouts being stuck between 2 states, please see the following issue for more info: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/450
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/450

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS
- Added `clampLower` utility function
- Use this `clampLower` function to ensure a minimum scroll to the first snapToOffset if any

## 🤔 How Has This Been Tested?

Tested really briefly, going to point my own project to this PR for further testing

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

To be added

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
