### PR TITLE
fix: better horizontal `UIScrollView` detection

### DIFF
--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -71,7 +71,7 @@ public extension Optional where Wrapped: UIResponder {
       // If the current responder is a vertical UIScrollView (excluding UITextView), return its tag
       if let scrollView = currentView as? UIScrollView,
          !(currentView is UITextView),
-         scrollView.contentSize.height > scrollView.frame.size.height
+         scrollView.frame.width >= scrollView.contentSize.width
       // it was fixed in swiftlint https://github.com/realm/SwiftLint/issues/3756 but a new release is not available yet
       // swiftlint:disable all
       {


### PR DESCRIPTION
## 📜 Description

Improved conditions for detecting horizontal `ScrollView` on iOS.

## 💡 Motivation and Context

If we compare `height` properties, then we may have a false positive case if `ScrollView` is not big enough and can not be actually scrolled because of its small size:

![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/0d07e040-6f67-4a19-bc3e-1b3b103ae41e)

To fix the problem I decided to compare `width` property to properly detect horizontal `ScrollView`.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/453

## 📢 Changelog

### iOS

- compare `width` property to detect horizontal `ScrollView`s;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro (iOS 17.4).

## 📸 Screenshots (if appropriate):

https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/fde50481-b481-47ab-b23e-7417740ebed8

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
