### PR TITLE
fix: iOS 13 compilation issues

### DIFF
--- a/ios/delegates/KCTextInputCompositeDelegate.swift
+++ b/ios/delegates/KCTextInputCompositeDelegate.swift
@@ -92,6 +92,7 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
 
   // MARK: UITextFieldDelegate
 
+  @available(iOS 13.0, *)
   func textFieldDidChangeSelection(_ textField: UITextField) {
     textFieldDelegate?.textFieldDidChangeSelection?(textField)
     updateSelectionPosition(textInput: textField)


### PR DESCRIPTION
## 📜 Description

Fixed iOS 13 compatibility.

## 💡 Motivation and Context

For projects that are targeting iOS 12.4 (for example react-native 0.72) `textFieldDidChangeSelection` method doesn't exist for `UITextFieldDelegate`.

To fix it I added `@available` annotation that takes the method into compilation only for `iOS 13+`.

Technically it's not very correct solution, because `onSelectionChange` will not be fired from my handler on iOS 12 - if we want to have this event we have to capture events from setter and forward it, but without subclassing it's pretty hard to achieve (only method swizzling as a last resort). But I don't want to spend too much time right now - if I get request that this functionality must be implemented for iOS 12, then I'll add it (otherwise I don't see a lot of sense in that right now, because RN already dropped minimal supported version, so I expect more and more people will move away from iOS 12 soon).

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/459

## 📢 Changelog

### iOS

- added a guard for `textFieldDidChangeSelection` (iOS 13+);

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
