### PR TITLE
fix: snap points scroll calculations

### DIFF
--- a/FabricExample/src/screens/Examples/AwareScrollView/index.tsx
+++ b/FabricExample/src/screens/Examples/AwareScrollView/index.tsx
@@ -11,6 +11,7 @@ import type { ExamplesStackParamList } from "../../../navigation/ExamplesStack";
 import type { StackScreenProps } from "@react-navigation/stack";
 
 type Props = StackScreenProps<ExamplesStackParamList>;
+const snapToOffsets = [125, 225, 325, 425, 525, 625];
 
 export default function AwareScrollView({ navigation }: Props) {
   const bottomSheetModalRef = useRef<BottomSheet>(null);
@@ -22,6 +23,7 @@ export default function AwareScrollView({ navigation }: Props) {
   const [disableScrollOnKeyboardHide, setDisableScrollOnKeyboardHide] =
     useState(false);
   const [enabled, setEnabled] = useState(true);
+  const [snapToOffsetsEnabled, setSnapToOffsetsEnabled] = useState(false);
 
   useEffect(() => {
     navigation.setOptions({
@@ -43,10 +45,32 @@ export default function AwareScrollView({ navigation }: Props) {
         testID="aware_scroll_view_container"
         bottomOffset={50}
         enabled={enabled}
+        snapToOffsets={snapToOffsetsEnabled ? snapToOffsets : undefined}
         disableScrollOnKeyboardHide={disableScrollOnKeyboardHide}
         style={styles.container}
         contentContainerStyle={styles.content}
       >
+        {snapToOffsetsEnabled && (
+          <>
+            {snapToOffsets.map((offset) => (
+              <View
+                key={offset}
+                style={[
+                  styles.snapToOffsetsAbsoluteContainer,
+                  {
+                    top: offset,
+                  },
+                ]}
+              >
+                <View style={styles.snapToOffsetsInnerContainer}>
+                  <Text>{offset}</Text>
+                  <View style={styles.snapToOffsetsLine} />
+                </View>
+              </View>
+            ))}
+          </>
+        )}
+
         {new Array(10).fill(0).map((_, i) => (
           <TextInput
             key={i}
@@ -78,6 +102,17 @@ export default function AwareScrollView({ navigation }: Props) {
             testID="bottom_sheet_toggle_enabled_state"
             onChange={() => {
               setEnabled(!enabled);
+            }}
+          />
+        </View>
+
+        <View style={styles.switchContainer}>
+          <Text>Toggle snapToOffsets</Text>
+          <Switch
+            value={snapToOffsetsEnabled}
+            testID="bottom_sheet_toggle_snap_to_offsets"
+            onChange={() => {
+              setSnapToOffsetsEnabled(!snapToOffsetsEnabled);
             }}
           />
         </View>

--- a/FabricExample/src/screens/Examples/AwareScrollView/styles.ts
+++ b/FabricExample/src/screens/Examples/AwareScrollView/styles.ts
@@ -17,4 +17,18 @@ export const styles = StyleSheet.create({
     alignItems: "center",
     margin: 16,
   },
+  snapToOffsetsAbsoluteContainer: {
+    width: "100%",
+    position: "absolute",
+  },
+  snapToOffsetsInnerContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  snapToOffsetsLine: {
+    height: 2,
+    flex: 1,
+    backgroundColor: "black",
+  },
 });

--- a/docs/docs/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/docs/api/components/keyboard-aware-scroll-view.mdx
@@ -73,6 +73,10 @@ The distance between keyboard and focused `TextInput` when keyboard is shown. De
 This property is equivalent to [extraHeight](https://github.com/APSL/react-native-keyboard-aware-scroll-view/tree/9eee405f7b3e261faf86a0fc8e495288d91c853e?tab=readme-ov-file#props) from original [react-native-keyboard-aware-scroll-view](https://github.com/APSL/react-native-keyboard-aware-scroll-view) package.
 :::
 
+:::warning
+If you specified `snapToOffsets` to your `ScrollView` then `KeyboardAwareScrollView` will automatically respect to these values and an actual `bottomOffset` may be bigger (but focused input will be always above the keyboard anyway).
+:::
+
 ### `disableScrollOnKeyboardHide`
 
 Prevents automatic scrolling of the `ScrollView` when the keyboard gets hidden, maintaining the current screen position. Default is `false`.

--- a/docs/versioned_docs/version-1.12.0/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/versioned_docs/version-1.12.0/api/components/keyboard-aware-scroll-view.mdx
@@ -73,6 +73,10 @@ The distance between keyboard and focused `TextInput` when keyboard is shown. De
 This property is equivalent to [extraHeight](https://github.com/APSL/react-native-keyboard-aware-scroll-view/tree/9eee405f7b3e261faf86a0fc8e495288d91c853e?tab=readme-ov-file#props) from original [react-native-keyboard-aware-scroll-view](https://github.com/APSL/react-native-keyboard-aware-scroll-view) package.
 :::
 
+:::tip
+If you specified `snapOffsets` to your `ScrollView` then `KeyboardAwareScrollView` will automatically respect to this values and actual `bottomOffset` may be bigger (but focused input will be always above the keyboard anyway).
+:::
+
 ### `disableScrollOnKeyboardHide`
 
 Prevents automatic scrolling of the `ScrollView` when the keyboard gets hidden, maintaining the current screen position. Default is `false`.

--- a/docs/versioned_docs/version-1.12.0/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/versioned_docs/version-1.12.0/api/components/keyboard-aware-scroll-view.mdx
@@ -74,7 +74,7 @@ This property is equivalent to [extraHeight](https://github.com/APSL/react-nativ
 :::
 
 :::tip
-If you specified `snapOffsets` to your `ScrollView` then `KeyboardAwareScrollView` will automatically respect to this values and actual `bottomOffset` may be bigger (but focused input will be always above the keyboard anyway).
+If you specified `snapToOffsets` to your `ScrollView` then `KeyboardAwareScrollView` will automatically respect to these values and an actual `bottomOffset` may be bigger (but focused input will be always above the keyboard anyway).
 :::
 
 ### `disableScrollOnKeyboardHide`

--- a/docs/versioned_docs/version-1.12.0/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/versioned_docs/version-1.12.0/api/components/keyboard-aware-scroll-view.mdx
@@ -73,7 +73,7 @@ The distance between keyboard and focused `TextInput` when keyboard is shown. De
 This property is equivalent to [extraHeight](https://github.com/APSL/react-native-keyboard-aware-scroll-view/tree/9eee405f7b3e261faf86a0fc8e495288d91c853e?tab=readme-ov-file#props) from original [react-native-keyboard-aware-scroll-view](https://github.com/APSL/react-native-keyboard-aware-scroll-view) package.
 :::
 
-:::tip
+:::warning
 If you specified `snapToOffsets` to your `ScrollView` then `KeyboardAwareScrollView` will automatically respect to these values and an actual `bottomOffset` may be bigger (but focused input will be always above the keyboard anyway).
 :::
 

--- a/example/src/screens/Examples/AwareScrollView/index.tsx
+++ b/example/src/screens/Examples/AwareScrollView/index.tsx
@@ -23,7 +23,6 @@ export default function AwareScrollView({ navigation }: Props) {
   const [disableScrollOnKeyboardHide, setDisableScrollOnKeyboardHide] =
     useState(false);
   const [enabled, setEnabled] = useState(true);
-
   const [snapToOffsetsEnabled, setSnapToOffsetsEnabled] = useState(false);
 
   useEffect(() => {

--- a/example/src/screens/Examples/AwareScrollView/index.tsx
+++ b/example/src/screens/Examples/AwareScrollView/index.tsx
@@ -11,7 +11,7 @@ import type { ExamplesStackParamList } from "../../../navigation/ExamplesStack";
 import type { StackScreenProps } from "@react-navigation/stack";
 
 type Props = StackScreenProps<ExamplesStackParamList>;
-const snapToOffsets = [125, 225, 325, 425];
+const snapToOffsets = [125, 225, 325, 425, 525, 625];
 
 export default function AwareScrollView({ navigation }: Props) {
   const bottomSheetModalRef = useRef<BottomSheet>(null);

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,0 @@
-it.todo("write a test");

--- a/src/components/KeyboardAwareScrollView/__tests__/scrollDistanceWithRespectToSnapPoints.spec.ts
+++ b/src/components/KeyboardAwareScrollView/__tests__/scrollDistanceWithRespectToSnapPoints.spec.ts
@@ -1,0 +1,27 @@
+import { scrollDistanceWithRespectToSnapPoints } from "../utils";
+
+describe("scrollDistanceWithRespectToSnapPoints specification", () => {
+  it("should return relative scroll value if `snapPoints` array is not provided", () => {
+    expect(scrollDistanceWithRespectToSnapPoints(120, undefined)).toBe(120);
+  });
+
+  it("should return relative scroll value if `snapPoints=[]`", () => {
+    expect(scrollDistanceWithRespectToSnapPoints(130, [])).toBe(130);
+  });
+
+  it("should return relative scroll value if it's bigger than any value in `snapPoints`", () => {
+    expect(scrollDistanceWithRespectToSnapPoints(100, [50])).toBe(100);
+  });
+
+  it("should return relative scroll value if it's equal to one of `snapPoints`", () => {
+    expect(scrollDistanceWithRespectToSnapPoints(150, [50, 150, 200])).toBe(
+      150,
+    );
+  });
+
+  it("should return a value from `snapPoints` if it's bigger than a necessary scroll", () => {
+    expect(scrollDistanceWithRespectToSnapPoints(180, [50, 100, 200])).toBe(
+      200,
+    );
+  });
+});

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-native-keyboard-controller";
 
 import { useSmoothKeyboardHandler } from "./useSmoothKeyboardHandler";
-import { debounce, scrollOutput } from "./utils";
+import { debounce, scrollDistanceWithRespectToSnapPoints } from "./utils";
 
 import type {
   LayoutChangeEvent,
@@ -154,16 +154,17 @@ const KeyboardAwareScrollView = forwardRef<
         const point = absoluteY + inputHeight;
 
         if (visibleRect - point <= bottomOffset) {
+          const relativeScrollTo =
+            keyboardHeight.value - (height - point) + bottomOffset;
           const interpolatedScrollTo = interpolate(
             e,
             [initialKeyboardSize.value, keyboardHeight.value],
             [
               0,
-              scrollOutput(
-                keyboardHeight.value - (height - point) + bottomOffset,
-                scrollPosition.value,
+              scrollDistanceWithRespectToSnapPoints(
+                relativeScrollTo + scrollPosition.value,
                 rest.snapToOffsets,
-              ),
+              ) - scrollPosition.value,
             ],
           );
           const targetScrollY =

--- a/src/components/KeyboardAwareScrollView/utils.ts
+++ b/src/components/KeyboardAwareScrollView/utils.ts
@@ -25,19 +25,17 @@ export const debounce = <F extends (...args: Parameters<F>) => ReturnType<F>>(
   };
 };
 
-export const scrollOutput = (
+export const scrollDistanceWithRespectToSnapPoints = (
   defaultScrollValue: number,
-  scrollPosition: number,
   snapPoints?: number[],
 ) => {
   "worklet";
+
   let snapPoint: number | undefined;
 
   if (snapPoints) {
-    snapPoint = snapPoints.find(
-      (offset) => offset >= defaultScrollValue + scrollPosition,
-    );
+    snapPoint = snapPoints.find((offset) => offset >= defaultScrollValue);
   }
 
-  return snapPoint ? snapPoint : defaultScrollValue;
+  return snapPoint ?? defaultScrollValue;
 };


### PR DESCRIPTION
## 📜 Description

Fixed corner cases for `scrollOutput` function, added tests, updated docs and example apps.

## 💡 Motivation and Context

This is a slight revision of https://github.com/kirillzyusko/react-native-keyboard-controller/pull/452

In this PR I fixed some bugs, unified some functions, updated docs, etc.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- fixed an issue with returning absolute value from `scrollOutput` from `snapPoints`;
- renamed `scrollOutput` -> `scrollDistanceWithRespectToSnapPoints`;
- refactored function `scrollDistanceWithRespectToSnapPoints` to make less computations in cycle and make a signature of function simpler (now this function always returns absolute scroll position);
- added unit-tests;
- ported example to FabricExample;

### Docs

- added info about `snapToOffsets` and how `KeyboardAwareScrollView` handles that;

## 🤔 How Has This Been Tested?

Tested locally on iPhone 15 Pro.

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
