### PR TITLE
docs: mention `softwareKeyboardLayoutMode` in docs

### DIFF
--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application (in `Expo` often referred as `softwareKeyboardLayoutMode`). It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml` (in `Expo` referred as `softwareKeyboardLayoutMode`). It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` (`softwareKeyboardLayoutMode` in Expo terminology) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` (`softwareKeyboardLayoutMode` in Expo terminology) declared in the `AndroidManifest.xml` (or `app.json` in Expo case). It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application (in `Expo` often referred as `softwareKeyboardLayoutMode`). It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml` (in `Expo` referred as `softwareKeyboardLayoutMode`). It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/versioned_docs/version-1.10.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.10.0/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application (in `Expo` often referred as `softwareKeyboardLayoutMode`). It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml` (in `Expo` referred as `softwareKeyboardLayoutMode`). It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/versioned_docs/version-1.10.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.10.0/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` (`softwareKeyboardLayoutMode` in Expo terminology) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` (`softwareKeyboardLayoutMode` in Expo terminology) declared in the `AndroidManifest.xml` (or `app.json` in Expo case). It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/versioned_docs/version-1.10.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.10.0/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application (in `Expo` often referred as `softwareKeyboardLayoutMode`). It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml` (in `Expo` referred as `softwareKeyboardLayoutMode`). It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/versioned_docs/version-1.11.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.11.0/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application (in `Expo` referred as `softwareKeyboardLayoutMode`). It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml` (in `Expo` referred as `softwareKeyboardLayoutMode`). It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/versioned_docs/version-1.11.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.11.0/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` (in `Expo` referred as `softwareKeyboardLayoutMode`) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` (`softwareKeyboardLayoutMode` in Expo terminology) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` (in `Expo` referred as `softwareKeyboardLayoutMode`) declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` (`softwareKeyboardLayoutMode` in Expo terminology) declared in the `AndroidManifest.xml` (or `app.json` in Expo case). It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/versioned_docs/version-1.11.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.11.0/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application (in `Expo` referred as `softwareKeyboardLayoutMode`). It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` (in `Expo` referred as `softwareKeyboardLayoutMode`) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml` (in `Expo` referred as `softwareKeyboardLayoutMode`). It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` (in `Expo` referred as `softwareKeyboardLayoutMode`) declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/versioned_docs/version-1.12.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.12.0/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application (in `Expo` often referred as `softwareKeyboardLayoutMode`). It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml` (in `Expo` referred as `softwareKeyboardLayoutMode`). It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/versioned_docs/version-1.12.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.12.0/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` (`softwareKeyboardLayoutMode` in Expo terminology) during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` (in `Expo` often referred as `softwareKeyboardLayoutMode`) declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` (`softwareKeyboardLayoutMode` in Expo terminology) declared in the `AndroidManifest.xml` (or `app.json` in Expo case). It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();

--- a/docs/versioned_docs/version-1.12.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.12.0/api/keyboard-controller.md
@@ -22,7 +22,7 @@ The `KeyboardController` module in React Native provides a convenient set of met
 
 ### `setInputMode` <div class="label android"></div>
 
-This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application. It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
+This method is used to dynamically change the `windowSoftInputMode` during runtime in an Android application (in `Expo` often referred as `softwareKeyboardLayoutMode`). It takes an argument that specifies the desired input mode. The example provided sets the input mode to `SOFT_INPUT_ADJUST_RESIZE`:
 
 ```ts
 KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
@@ -38,7 +38,7 @@ A combination of `adjustResize` + `edge-to-edge` mode will result in behavior si
 
 ### `setDefaultMode` <div class="label android"></div>
 
-This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml`. It resets the input mode to the default value:
+This method is used to restore the default `windowSoftInputMode` declared in the `AndroidManifest.xml` (in `Expo` referred as `softwareKeyboardLayoutMode`). It resets the input mode to the default value:
 
 ```ts
 KeyboardController.setDefaultMode();


### PR DESCRIPTION
## 📜 Description

Added `softwareKeyboardLayoutMode` word to documentation.

## 💡 Motivation and Context

People are searching this keyword:

<img width="586" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/fa8ca98b-4729-43be-a83f-5e6e608354e1">

But turns out that it's an expo specific word (though functionality to control that property is present in this library).

So in this PR I updated some pages where `windowSoftInputMode` occurs and added corresponding Expo wording to make people aware about that + improve searching experience.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added `softwareKeyboardLayoutMode` mention;

## 🤔 How Has This Been Tested?

Tested on localhost + preview.

## 📸 Screenshots (if appropriate):

<img width="992" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/7c84bba4-0072-435b-b460-678995a32603">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
