### PR TITLE
fix: missing `navigationBar` height in keyboard size if `navigationBar` is `translucent`

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -32,6 +32,7 @@ class KeyboardAnimationCallback(
   val deferredInsetTypes: Int,
   dispatchMode: Int = DISPATCH_MODE_STOP,
   val context: ThemedReactContext?,
+  val hasTranslucentNavigationBar: Boolean = false,
 ) : WindowInsetsAnimationCompat.Callback(dispatchMode), OnApplyWindowInsetsListener {
   private val surfaceId = UIManagerHelper.getSurfaceId(view)
 
@@ -205,10 +206,13 @@ class KeyboardAnimationCallback(
     // First we get the insets which are potentially deferred
     val typesInset = insets.getInsets(deferredInsetTypes)
     // Then we get the persistent inset types which are applied as padding during layout
-    val otherInset = insets.getInsets(persistentInsetTypes)
+    var otherInset = insets.getInsets(persistentInsetTypes)
 
     // Now that we subtract the two insets, to calculate the difference. We also coerce
     // the insets to be >= 0, to make sure we don't use negative insets.
+    if (hasTranslucentNavigationBar) {
+      otherInset = Insets.NONE
+    }
     val diff = Insets.subtract(typesInset, otherInset).let {
       Insets.max(it, Insets.NONE)
     }
@@ -358,7 +362,7 @@ class KeyboardAnimationCallback(
   private fun getCurrentKeyboardHeight(): Double {
     val insets = ViewCompat.getRootWindowInsets(view)
     val keyboardHeight = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
-    val navigationBar = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
+    val navigationBar = if (hasTranslucentNavigationBar) 0 else insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
 
     // on hide it will be negative value, so we are using max function
     return (keyboardHeight - navigationBar).toFloat().dp.coerceAtLeast(0.0)

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -362,7 +362,12 @@ class KeyboardAnimationCallback(
   private fun getCurrentKeyboardHeight(): Double {
     val insets = ViewCompat.getRootWindowInsets(view)
     val keyboardHeight = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
-    val navigationBar = if (hasTranslucentNavigationBar) 0 else insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
+    val navigationBar =
+      if (hasTranslucentNavigationBar) {
+        0
+      } else {
+        insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
+      }
 
     // on hide it will be negative value, so we are using max function
     return (keyboardHeight - navigationBar).toFloat().dp.coerceAtLeast(0.0)

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -121,6 +121,7 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
         deferredInsetTypes = WindowInsetsCompat.Type.ime(),
         dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
         context = reactContext,
+        hasTranslucentNavigationBar = isNavigationBarTranslucent
       )
 
       eventView?.let {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -121,7 +121,7 @@ class EdgeToEdgeReactViewGroup(private val reactContext: ThemedReactContext) : R
         deferredInsetTypes = WindowInsetsCompat.Type.ime(),
         dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
         context = reactContext,
-        hasTranslucentNavigationBar = isNavigationBarTranslucent
+        hasTranslucentNavigationBar = isNavigationBarTranslucent,
       )
 
       eventView?.let {


### PR DESCRIPTION
## 📜 Description

Keyboard size is incorrectly reported if we draw behind navigation status bar (i. e. it's translucent). This PR fixes this by omitting the `-navigationBarHeight` if `navigationBar` is translucent.

## 💡 Motivation and Context

It's incorrect behavior in the core of the library and should be fixed 👀 

Originally discussed in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/259#issuecomment-1848966075

Maybe there is better solution which don't directly depends on `navigationBarTrasnlucent` property, but to fix this bug right now let's use this code. Later on we can always improve/refactor the code.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added `hasTranslucentNavigationBar` to `KeyboardAnimationCallback`;
- conditionally subtract `navigationBar` insets;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro and on CI (via e2e tests).

## 📸 Screenshots (if appropriate):

Tested on Pixel 7 Pro (Android 14):

|Before|After|
|-------|-----|
|![telegram-cloud-photo-size-2-5427266154814104062-y](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/58f14456-5aee-4e32-9181-0238dc82ac85)|![telegram-cloud-photo-size-2-5427266154814104063-y](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/cbbf0460-af76-42aa-b5b3-ef52db1ebfc7)|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
