### PR TITLE
chore: pin iOS/XCode versions to a local env

### DIFF
--- a/.github/workflows/build-ios-fabric.yml
+++ b/.github/workflows/build-ios-fabric.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.4"
+
       - name: Get yarn cache directory path
         id: fabric-yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.4"
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -39,7 +39,7 @@ jobs:
           cache: "yarn"
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "15.3"
+          xcode-version: "15.4"
       - name: Get Xcode version
         run: xcodebuild -version
       - name: Install AppleSimulatorUtils

--- a/.github/workflows/verify-ios.yml
+++ b/.github/workflows/verify-ios.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "15.3"
+          xcode-version: "15.4"
 
       - name: Install xcpretty
         run: gem install xcpretty

--- a/e2e/.detoxrc.js
+++ b/e2e/.detoxrc.js
@@ -45,6 +45,7 @@ module.exports = {
       type: "ios.simulator",
       device: {
         type: "iPhone 15 Pro",
+        os: "iOS 17.5"
       },
     },
     attached: {

--- a/e2e/.detoxrc.js
+++ b/e2e/.detoxrc.js
@@ -45,7 +45,7 @@ module.exports = {
       type: "ios.simulator",
       device: {
         type: "iPhone 15 Pro",
-        os: "iOS 17.5"
+        os: "iOS 17.5",
       },
     },
     attached: {

--- a/ios/KeyboardControllerNative/KeyboardControllerNativeUITests/KeyboardControllerNativeUITestsLaunchTests.swift
+++ b/ios/KeyboardControllerNative/KeyboardControllerNativeUITests/KeyboardControllerNativeUITestsLaunchTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 // swiftlint:disable:next type_name
 final class KeyboardControllerNativeUITestsLaunchTests: XCTestCase {
-  override class var runsForEachTargetApplicationUIConfiguration: Bool {
+  override static var runsForEachTargetApplicationUIConfiguration: Bool {
     true
   }
 


### PR DESCRIPTION
## 📜 Description

Pinned iOS to 17.5 and XCode to latest stable 15.4 for all iOS jobs.

## 💡 Motivation and Context

Recently GH updated images and now iOS e2e tests are running on iOS 18. iOS 18 is incompatible with current Detox (`typeText` crashes the app).

So in this PR I decided to lock everything to the same versions that I'm using locally (i. e. XCode 15.4 and iOS 17.5).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### E2E

- pin iOS simulator to iOS 17.5 to pass job on CI.

### CI

- pin XCode version to 15.4;

## 🤔 How Has This Been Tested?

Verified that CI is green.

## 📸 Screenshots (if appropriate):

<img width="861" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/65c8d0d8-7241-4721-86f9-13cf7e5ed92a">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
