### PR TITLE
fix: ignore non-visible keyboard

### DIFF
--- a/ios/traversal/KeyboardView.swift
+++ b/ios/traversal/KeyboardView.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 enum KeyboardView {
-  // https://stackoverflow.com/questions/32598490/show-uiview-with-buttons-over-keyboard-like-in-skype-viber-messengers-swift-i
+  // inspired by https://stackoverflow.com/questions/32598490/show-uiview-with-buttons-over-keyboard-like-in-skype-viber-messengers-swift-i
   static func find() -> UIView? {
     let windows = UIApplication.shared.windows
     for window in windows {
@@ -18,7 +18,7 @@ enum KeyboardView {
         for subview in window.subviews {
           if subview.description.hasPrefix("<UIInputSetContainerView") {
             for hostView in subview.subviews {
-              if hostView.description.hasPrefix("<UIInputSetHostView") {
+              if hostView.description.hasPrefix("<UIInputSetHostView"), hostView.frame.height != 0 {
                 return hostView
               }
             }


### PR DESCRIPTION
## 📜 Description

Ignore non visible keyboard in `KeyboardView.find()` method.

## 💡 Motivation and Context

Sometimes we may have two keyboards:

![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/52456847-f1fd-4cd6-a21a-81a5afd8d6c8)

And the current algorithm for a search returns an invalid keyboard (not a one that is actually shown on the screen):

![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/fc22c83d-95c5-41de-9893-a4399330264b)

or

![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/c00f411e-d690-4f7a-bddf-a28c0a732381)

But when actual keyboard is tracked, then the frame of this keyboard has non-zero height:

![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/15c0ce28-f8c4-4c96-ad1f-35236a08e49e)

So to fix the problem with invalid keyboard view being found I decided to modify a condition and add additional condition to check that `frame.height != 0`.

Follow up for https://github.com/kirillzyusko/react-native-keyboard-controller/pull/471 and https://github.com/kirillzyusko/react-native-keyboard-controller/issues/338#issuecomment-2163904827

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- ignore keyboard view if its `height == 0`;

## 🤔 How Has This Been Tested?

Tested on CI (e2e tests).

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
