### PR TITLE
fix: don't throw compilation errors for `emitEvent` function for RN < 0.72

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
@@ -29,7 +30,9 @@ fun ThemedReactContext?.dispatchEvent(viewId: Int, event: Event<*>) {
 }
 
 fun ThemedReactContext?.emitEvent(event: String, params: WritableMap) {
-  this?.reactApplicationContext?.emitDeviceEvent(event, params)
+  this?.reactApplicationContext
+    ?.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+    ?.emit(event, params)
 
   Log.i("ThemedReactContext", event)
 }


### PR DESCRIPTION
## 📜 Description

Fixed compilation errors on RN 0.71 and `keyboard-controller` 1.12.

## 💡 Motivation and Context

`emitDeviceEvent` is available only in RN 0.72 and we don't want to support RN 0.72 as the minimal version (because it's still quite new):

![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/61c229df-aabc-483a-8d36-db7c03a17e82)

The original change was introduced in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/410 - it was needed because old implementation threw errors (crashes) in bridgeless mode on Fabric.

In this Pr I made it compatible with bridgeless + it doesn't use newly introduced methods, so it should have a support until RN 0.65 again.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- don't use `emitDeviceEvent` as it's available only in RN 0.72;
- revert to previous code variant, but send an event from `ReactApplicationContext` class instance;

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro (Android 14), Fabric + RN 0.74

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
