### PR TITLE
fix: random scrolls of `KeyboardAwareScrollView` during re-render (when keyboard is open)

### DIFF
--- a/FabricExample/src/screens/Examples/AwareScrollView/index.tsx
+++ b/FabricExample/src/screens/Examples/AwareScrollView/index.tsx
@@ -15,6 +15,7 @@ const snapToOffsets = [125, 225, 325, 425, 525, 625];
 
 export default function AwareScrollView({ navigation }: Props) {
   const bottomSheetModalRef = useRef<BottomSheet>(null);
+  const [_, setText] = useState("");
 
   const handlePresentModalPress = useCallback(() => {
     bottomSheetModalRef.current?.expand();
@@ -76,6 +77,7 @@ export default function AwareScrollView({ navigation }: Props) {
             key={i}
             placeholder={`TextInput#${i}`}
             keyboardType={i % 2 === 0 ? "numeric" : "default"}
+            onChangeText={setText}
           />
         ))}
       </KeyboardAwareScrollView>

--- a/example/src/screens/Examples/AwareScrollView/index.tsx
+++ b/example/src/screens/Examples/AwareScrollView/index.tsx
@@ -15,6 +15,7 @@ const snapToOffsets = [125, 225, 325, 425, 525, 625];
 
 export default function AwareScrollView({ navigation }: Props) {
   const bottomSheetModalRef = useRef<BottomSheet>(null);
+  const [_, setText] = useState("");
 
   const handlePresentModalPress = useCallback(() => {
     bottomSheetModalRef.current?.expand();
@@ -76,6 +77,7 @@ export default function AwareScrollView({ navigation }: Props) {
             key={i}
             placeholder={`TextInput#${i}`}
             keyboardType={i % 2 === 0 ? "numeric" : "default"}
+            onChangeText={setText}
           />
         ))}
       </KeyboardAwareScrollView>

--- a/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
+++ b/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
@@ -68,7 +68,8 @@ export const useSmoothKeyboardHandler: typeof useKeyboardHandler = (
         persistedHeight.value = height.value;
       }
     },
-    [handler],
+    // REA uses own version of `DependencyList` and it's not compatible with the same type from React
+    deps as unknown[],
   );
 
   useKeyboardHandler(


### PR DESCRIPTION
## 📜 Description

Fixed random `KeyboardAwareScrollView` scrolls when user types a message on Android < 11.

## 💡 Motivation and Context

The problem happens when you update a state/props and `KeyboardAwareScrollView` gets re-rendered. In this case `handler` object gets re-created and `useAnimatedReaction` produce a new `onMove`/`onEnd` events.

Since we didn't call `onStart` -> we have out-of-date variables and because of that scroll happens to undesired position. The fix should be simple - `onMove` shouldn't be fired. So to fix that I changed `[handler] -> deps` (actually handler will be rebuild and new version will be used only when deps were updated -> otherwise new handler will not be used - this is how `useKeyboardHandler` hook works).

Additionally I cast `deps` to `unknown` to avoid types mismatches between `REA` and `React`.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/476 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/384

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- use `deps` instead of `[handler]` as an array of dependencies;

## 🤔 How Has This Been Tested?

Tested on CI.

### 📸 Screenshots (if appropriate):

|Before|After|
|------|------|
|![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e5736e1f-5503-4022-9a54-b5b11906a75c)|![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/40342eb9-878b-4012-8d6e-37f567a4c6a3)|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
