### PR TITLE
fix: update selection on focus

### DIFF
--- a/e2e/kit/003-input-handlers.e2e.ts
+++ b/e2e/kit/003-input-handlers.e2e.ts
@@ -75,4 +75,18 @@ describe("input handlers functionality", () => {
       element(by.id("original_selection_text_start_end")),
     ).toHaveText("start: 5, end: 5");
   });
+
+  it("should fire `onSelectionChange` when we switch between inputs", async () => {
+    await expect(element(by.id("selection_text_start_end"))).toHaveText(
+      "start: 5, end: 5",
+    );
+    await waitAndTap("masked_input");
+    await expect(element(by.id("selection_text_start_end"))).toHaveText(
+      "start: 18, end: 18",
+    );
+    await waitAndType("multiline_input", ""); // just set focus back
+    await expect(element(by.id("selection_text_start_end"))).toHaveText(
+      "start: 5, end: 5",
+    );
+  });
 });

--- a/ios/delegates/KCTextInputCompositeDelegate.swift
+++ b/ios/delegates/KCTextInputCompositeDelegate.swift
@@ -7,30 +7,25 @@
 
 import Foundation
 
-struct Selection {
-  var start: Int
-  var startX: CGFloat
-  var startY: CGFloat
-  var end: Int
-  var endX: CGFloat
-  var endY: CGFloat
-}
-
-func textSelection(in textInput: UITextInput) -> Selection? {
+func textSelection(in textInput: UITextInput) -> NSDictionary? {
   if let selectedRange = textInput.selectedTextRange {
     let caretRectStart = textInput.caretRect(for: selectedRange.start)
     let caretRectEnd = textInput.caretRect(for: selectedRange.end)
 
-    let coordinates = Selection(
-      start: textInput.offset(from: textInput.beginningOfDocument, to: selectedRange.start),
-      startX: caretRectStart.origin.x,
-      startY: caretRectStart.origin.y,
-      end: textInput.offset(from: textInput.beginningOfDocument, to: selectedRange.end),
-      endX: caretRectEnd.origin.x + caretRectEnd.size.width,
-      endY: caretRectEnd.origin.y + caretRectEnd.size.height
-    )
-
-    return coordinates
+    return [
+      "selection": [
+        "start": [
+          "x": caretRectStart.origin.x,
+          "y": caretRectStart.origin.y,
+          "position": textInput.offset(from: textInput.beginningOfDocument, to: selectedRange.start),
+        ],
+        "end": [
+          "x": caretRectEnd.origin.x + caretRectEnd.size.width,
+          "y": caretRectEnd.origin.y + caretRectEnd.size.height,
+          "position": textInput.offset(from: textInput.beginningOfDocument, to: selectedRange.end),
+        ],
+      ],
+    ]
   }
 
   return nil
@@ -38,20 +33,7 @@ func textSelection(in textInput: UITextInput) -> Selection? {
 
 func updateSelectionPosition(textInput: UITextInput, sendEvent: (_ event: NSDictionary) -> Void) {
   if let selection = textSelection(in: textInput) {
-    sendEvent([
-      "selection": [
-        "start": [
-          "x": selection.startX,
-          "y": selection.startY,
-          "position": selection.start,
-        ],
-        "end": [
-          "x": selection.endX,
-          "y": selection.endY,
-          "position": selection.end,
-        ],
-      ],
-    ])
+    sendEvent(selection)
   }
 }
 

--- a/ios/delegates/KCTextInputCompositeDelegate.swift
+++ b/ios/delegates/KCTextInputCompositeDelegate.swift
@@ -36,6 +36,25 @@ func textSelection(in textInput: UITextInput) -> Selection? {
   return nil
 }
 
+func updateSelectionPosition(textInput: UITextInput, sendEvent: (_ event: NSDictionary) -> Void) {
+  if let selection = textSelection(in: textInput) {
+    sendEvent([
+      "selection": [
+        "start": [
+          "x": selection.startX,
+          "y": selection.startY,
+          "position": selection.start,
+        ],
+        "end": [
+          "x": selection.endX,
+          "y": selection.endY,
+          "position": selection.end,
+        ],
+      ],
+    ])
+  }
+}
+
 /**
  * A delegate that is being set to any focused input
  * and intercepts some specific events that needs to be handled
@@ -79,7 +98,7 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
 
   func textViewDidChangeSelection(_ textView: UITextView) {
     textViewDelegate?.textViewDidChangeSelection?(textView)
-    updateSelectionPosition(textInput: textView)
+    updateSelectionPosition(textInput: textView, sendEvent: onSelectionChange)
   }
 
   func textViewDidChange(_ textView: UITextView) {
@@ -95,7 +114,7 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
   @available(iOS 13.0, *)
   func textFieldDidChangeSelection(_ textField: UITextField) {
     textFieldDelegate?.textFieldDidChangeSelection?(textField)
-    updateSelectionPosition(textInput: textField)
+    updateSelectionPosition(textInput: textField, sendEvent: onSelectionChange)
   }
 
   func textField(
@@ -124,26 +143,5 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
       return activeDelegate
     }
     return super.forwardingTarget(for: aSelector)
-  }
-
-  // MARK: Private functions
-
-  private func updateSelectionPosition(textInput: UITextInput) {
-    if let selection = textSelection(in: textInput) {
-      onSelectionChange([
-        "selection": [
-          "start": [
-            "x": selection.startX,
-            "y": selection.startY,
-            "position": selection.start,
-          ],
-          "end": [
-            "x": selection.endX,
-            "y": selection.endY,
-            "position": selection.end,
-          ],
-        ],
-      ])
-    }
   }
 }

--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -197,6 +197,10 @@ public class FocusedInputObserver: NSObject {
         (textView as? RCTUITextView)?.setForceDelegate(delegate)
       }
     }
+    // dispatch onSelectionChange on focus
+    if let textInput = input as? UITextInput {
+      updateSelectionPosition(textInput: textInput, sendEvent: onSelectionChange)
+    }
   }
 
   private func substituteDelegateBack(_ input: UIResponder?) {


### PR DESCRIPTION
## 📜 Description

Update selection when focused has changed on iOS.

## 💡 Motivation and Context

That problem was present since the first version when the `onSelectionChange` handler was available (`1.12.0`). But I ignored it, since it wasn't so important 🙈 

In this PR I'm fixing the problem by manual event dispatching (when we add a delegate, i. e. focus was received). The problem is specific only for iOS (on Android it doesn't exist). But I had a plan to revisit Android implementation and make it more optimal, so keeping it in mind I decided to add e2e test to be sure such important functionality will not be broken in future releases.

Also in this PR I removed unnecessary class/structure instance creation and simplified code a little bit 👀 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/482

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### E2E

- added new test case (to verify we dispatch event on focus change);

### iOS

- manually dispatch `onSelectionChange` when we receive a focus;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro (iOS 17.5, simulator).

## 📸 Screenshots (if appropriate):


https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/e81ef947-8667-4acd-bf20-a3a837572317



## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
