### PR TITLE
fix: RN 0.75 compilation error

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
@@ -3,6 +3,7 @@ package com.reactnativekeyboardcontroller.extensions
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.facebook.react.uimanager.ThemedReactContext
@@ -25,7 +26,7 @@ fun ThemedReactContext.setupWindowDimensionsListener() {
 
 fun ThemedReactContext?.dispatchEvent(viewId: Int, event: Event<*>) {
   val eventDispatcher: EventDispatcher? =
-    UIManagerHelper.getEventDispatcherForReactTag(this, viewId)
+    UIManagerHelper.getEventDispatcherForReactTag(this as ReactContext, viewId)
   eventDispatcher?.dispatchEvent(event)
 }
 


### PR DESCRIPTION
## 📜 Description

Fixed compilation error:

```bash
> Task :compileReleaseKotlin FAILED
e: file:///Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt:28:51 Type mismatch: inferred type is ThemedReactContext? but ReactContext was expected
```

## 💡 Motivation and Context

Before we passed `ThemedReactContext` directly to `UIManagerHelper.getEventDispatcherForReactTag` method. It actually works, because `ThemedReactContext extends ReactContext` and kotlin could cast types automatically.

But it looks like in RN 0.75 something has changed and CI jobs such as `gradlew lint` and `gradlew build` (which consumes latest artifacts from maven) started to fail. I've tried to cast it to `ReactContext` using `as ReactContext` construction (which is safe, because I'm not using `!` or `?` symbols) and it started to work again.

So I think we'll go with this fix 👀 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- pass `ReactContext` instead of `ThemedReactContext` to `UIManagerHelper.getEventDispatcherForReactTag`;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📸 Screenshots (if appropriate):

<img width="1074" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/95b38dfd-522f-46c7-a251-842250ebbf5c">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
