### PR TITLE
ci: rename "Run Gradle Lint" -> "Run Gradle Assemble" for Android Build job

### DIFF
--- a/.github/workflows/verify-android.yml
+++ b/.github/workflows/verify-android.yml
@@ -56,7 +56,7 @@ jobs:
           java-version: "17"
       - name: Install dependencies
         run: yarn install --frozen-lockfile --cwd ..
-      - name: Run Gradle Lint
+      - name: Run Gradle Assemble
         run: ./gradlew assembleDebug
   detekt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📜 Description

Rename "Run Gradle Lint" -> "Run Gradle Assemble" for Android Build job.

## 💡 Motivation and Context

Looks like I copied/pasted "Gralde Lint" job and modified necessary lines in the code, but I forgot to rename one of the step 🙈 

In this PR I'm fixing this 😎 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- rename "Run Gradle Lint" -> "Run Gradle Assemble" for Android Build job

## 🤔 How Has This Been Tested?

Tested on CI.

## 📸 Screenshots (if appropriate):

<img width="345" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/0164be25-660f-4f66-9428-43a242a24dda">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
