### PR TITLE
fix: race condition between js and worklet

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -119,7 +119,7 @@ const KeyboardAwareScrollView = forwardRef<
           }
         },
       },
-      [],
+      [onScrollProps],
     );
 
     const onRef = useCallback((assignedRef: Reanimated.ScrollView) => {

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -2,9 +2,11 @@ import React, { forwardRef, useCallback, useMemo } from "react";
 import { findNodeHandle } from "react-native";
 import Reanimated, {
   interpolate,
+  runOnJS,
   scrollTo,
   useAnimatedReaction,
   useAnimatedRef,
+  useAnimatedScrollHandler,
   useAnimatedStyle,
   useSharedValue,
 } from "react-native-reanimated";
@@ -106,13 +108,18 @@ const KeyboardAwareScrollView = forwardRef<
 
     const { height } = useWindowDimensions();
 
-    const onScroll = useCallback<NonNullable<ScrollViewProps["onScroll"]>>(
-      (event) => {
-        position.value = event.nativeEvent.contentOffset.y;
+    const onScroll = useAnimatedScrollHandler(
+      {
+        onScroll: (event) => {
+          position.value = event.contentOffset.y;
 
-        onScrollProps?.(event);
+          if (onScrollProps) {
+            // @ts-expect-error https://github.com/software-mansion/react-native-reanimated/issues/6204
+            runOnJS(onScrollProps)({ nativeEvent: event });
+          }
+        },
       },
-      [onScrollProps],
+      [],
     );
 
     const onRef = useCallback((assignedRef: Reanimated.ScrollView) => {


### PR DESCRIPTION
## 📜 Description

Fixed an issue where `scrollPosition.value` is updated with out-of-date value.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The problem happens, because without animation `onMove`/`onEnd` dispatched almost simultaneously. But js handler can not update `position.value` and in `onEnd` handler in `scrollPosition.value = position.value;` code we set `scrollPosition.value = 0`.

When text input grows:

```tsx
layout.value = input.value;
scrollPosition.value += maybeScroll(keyboardHeight.value, true);
```

We call `maybeScroll`, but `scrollPosition.value === 0` and because of that we scroll by 16px (though we had to scroll for `actualScroll (170) + 16` but we do `0 + 16`, and because of that position is incorrect.

To fix the problem `onEnd` should actually update `scrollPosition` to the expected value, and to achieve that we need to update a value from worklet.

Now it's slightly problematic, because current REA doesn't support both: js + worklet handlers (see https://github.com/software-mansion/react-native-reanimated/issues/6204), so I'm always re-dispatching `nativeEvent` manually via `runOnJS`.

The issue was caught originally in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/488

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- fix race condition between scroll position update and keyboard movement.

## 🤔 How Has This Been Tested?

- Set focus to `TextInput#3`
- press enter 2 times

Tested on Android 12 (Pixel 2) with disabled animations (detox).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="399" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/5511fb3e-54c3-4495-9955-13e933839941">|<img width="397" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/00d679ba-5986-4fb6-a41a-9c6a1944c98d">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
