### PR TITLE
fix: incorrect selection coordinates when input grows

### DIFF
--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -96,7 +96,7 @@ public extension UIView {
 }
 
 public extension UITextInput {
-  var isSelectionFitIntoLayout: Bool {
+  var canSelectionFitIntoLayout: Bool {
     guard let selectedRange = selectedTextRange else { return false }
 
     guard let range = textRange(from: selectedRange.start, to: selectedRange.end) else { return false }

--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -94,3 +94,14 @@ public extension UIView {
     return superview?.convert(frame, to: rootView)
   }
 }
+
+public extension UITextInput {
+  var isSelectionFitIntoLayout: Bool {
+    guard let selectedRange = selectedTextRange else { return false }
+
+    guard let range = textRange(from: selectedRange.start, to: selectedRange.end) else { return false }
+    let rect = firstRect(for: range)
+
+    return rect.origin.x.isFinite && rect.origin.y.isFinite
+  }
+}

--- a/ios/delegates/KCTextInputCompositeDelegate.swift
+++ b/ios/delegates/KCTextInputCompositeDelegate.swift
@@ -79,7 +79,6 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
   // MARK: UITextViewDelegate
 
   func textViewDidChangeSelection(_ textView: UITextView) {
-    textView.layoutIfNeeded()
     textViewDelegate?.textViewDidChangeSelection?(textView)
     if textView.canSelectionFitIntoLayout {
       updateSelectionPosition(textInput: textView, sendEvent: onSelectionChange)

--- a/ios/delegates/KCTextInputCompositeDelegate.swift
+++ b/ios/delegates/KCTextInputCompositeDelegate.swift
@@ -81,7 +81,7 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
   func textViewDidChangeSelection(_ textView: UITextView) {
     textView.layoutIfNeeded()
     textViewDelegate?.textViewDidChangeSelection?(textView)
-    if textView.isSelectionFitIntoLayout {
+    if textView.canSelectionFitIntoLayout {
       updateSelectionPosition(textInput: textView, sendEvent: onSelectionChange)
     } else {
       // when multiline input grows we need to wait for layout to be updated

--- a/ios/delegates/KCTextInputCompositeDelegate.swift
+++ b/ios/delegates/KCTextInputCompositeDelegate.swift
@@ -79,8 +79,17 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
   // MARK: UITextViewDelegate
 
   func textViewDidChangeSelection(_ textView: UITextView) {
+    textView.layoutIfNeeded()
     textViewDelegate?.textViewDidChangeSelection?(textView)
-    updateSelectionPosition(textInput: textView, sendEvent: onSelectionChange)
+    if textView.isSelectionFitIntoLayout {
+      updateSelectionPosition(textInput: textView, sendEvent: onSelectionChange)
+    } else {
+      // when multiline input grows we need to wait for layout to be updated
+      // otherwise start/end positions will be incorrect (0/-1)
+      DispatchQueue.main.asyncAfter(deadline: .now() + UIUtils.nextFrame) {
+        updateSelectionPosition(textInput: textView, sendEvent: self.onSelectionChange)
+      }
+    }
   }
 
   func textViewDidChange(_ textView: UITextView) {


### PR DESCRIPTION
## 📜 Description

Fixed incorrect selection coordinates when text gets moved to a new line and text input grows.

## 💡 Motivation and Context

The problem happens because our text is bigger and can not fit into current layout. If we read coordinates we get `+Inf` and of course it's not reasonable to send such events to JS.

To fix this problem we need to wait for layout update (next frame) and send event only after that. This is exactly what i did in this PR:

```swift
if textView.canSelectionFitIntoLayout {
  updateSelectionPosition(textInput: textView, sendEvent: onSelectionChange)
} else {
  // when multiline input grows we need to wait for layout to be updated
  // otherwise start/end positions will be incorrect (0/-1)
  DispatchQueue.main.asyncAfter(deadline: .now() + UIUtils.nextFrame) {
    updateSelectionPosition(textInput: textView, sendEvent: self.onSelectionChange)
  }
}
```

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/489

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added `canSelectionFitIntoLayout` property extension to `UITextInput`;
- use `canSelectionFitIntoLayout` to detect whether we can send event immediately or need to wait for one frmae for layout to be updated and send event only after that;

## 🤔 How Has This Been Tested?

Tested manually using code sample provided in the issue.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/4a4cff0e-a478-491e-bdd9-7f2164658cf9)|![image](https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/4e4ed628-a811-42f6-bf6e-a6d349e50fde)|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
