### PR TITLE
fix: memoize `WindowDimensionListener` on per context base (instead of global memoization)

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
@@ -14,11 +14,11 @@ class WindowDimensionListener(private val context: ThemedReactContext?) {
   private var lastDispatchedDimensions = Dimensions(0.0, 0.0)
 
   init {
-    // attach to content view only once
-    if (!isListenerAttached) {
-      isListenerAttached = true
+    // attach to content view only once per app instance
+    if (context != null && listenerID != context.hashCode()) {
+      listenerID = context.hashCode()
 
-      val content = context?.content
+      val content = context.content
 
       updateWindowDimensions(content)
 
@@ -52,6 +52,6 @@ class WindowDimensionListener(private val context: ThemedReactContext?) {
   }
 
   companion object {
-    private var isListenerAttached = false
+    private var listenerID = -1
   }
 }


### PR DESCRIPTION
## 📜 Description

Re-create `WindowDimensionListener` if context gets changed.

## 💡 Motivation and Context

We need to memoize `WindowDimensionListener` and have a single listener across the app to avoid potential and unnecessary multiple events (many listeners will produce many events at the same time and it will just hit performance and will consume more memory, resources etc. so it's highly undesirable).

However, when you reload the RN app (double `R` press) -> you will re-create all internal variables and you will not attach a new listener. And the problem is in the fact that old listener will be destroyed (and even if not destroyed -> then it will not propagate events because the context was destroyed). And we'll always have `height=0`.

Of course such behavior is not correct and the proper solution would be to re-attach listener when app is re-loaded. I handled it in this PR by caching listener using context hash as an identifier for an active listener.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/486

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- keep `context.hashCode` as identifier for attached listener (instead of global boolean variable);

## 🤔 How Has This Been Tested?

Tested manually on pixel 3a (API 33, Android 13, emulator).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/591d3692-d6b6-432c-b25a-33ddbdfbc32d" height="850">|<img src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/5663693e-b549-4b51-8313-f618b6dda653" height="850">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
