### PR TITLE
feat: allow js and reanimated scroll handlers for `KeyboardAwareScrollView`

### DIFF
--- a/docs/docs/guides/compatibility.md
+++ b/docs/docs/guides/compatibility.md
@@ -13,7 +13,7 @@ If you found an incompatibility or conflict with other open source libraries - d
 
 :::
 
-## React Native
+## `react-native`
 
 Below you can find an information about compatibility with `react-native` package per different architectures.
 
@@ -25,6 +25,10 @@ Below you can find a table with supported versions:
 
 | library version | react-native version |
 | --------------- | -------------------- |
+| 1.12.0+         | 0.74.0+              |
+| 1.10.0+         | 0.73.0+              |
+| 1.6.0+          | 0.72.0+              |
+| 1.5.0+          | 0.71.0+              |
 | 1.3.0+          | 0.70.0+              |
 | 1.2.0+          | 0.69.0+              |
 
@@ -36,6 +40,12 @@ This library supports as minimal `react-native` version as possible. However it 
 | --------------- | -------------------- |
 | 1.7.0+          | 0.65.0+              |
 | 1.0.0+          | 0.62.0+              |
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.11.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.0.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.0.0/guides/compatibility.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Compatibility
 
-## React Native
+## `react-native`
 
 Starting from `1.2.0` this library adds support for a new architecture called `Fabric`. Since a new architecture is still in adoption stage and it changes some APIs over time - it's highly recommended to use versions which are compatible and were intensively tested against specific `react-native` versions.
 
@@ -20,6 +20,12 @@ Below you can find a table with supported versions:
 For `Paper` (old) architecture there is no any restrictions. If you found an incompatibility - don't hesitate to open an [issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/new?assignees=kirillzyusko&labels=bug&template=bug_report.md&title=). It will help the project 🙏
 
 :::
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.3.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.10.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.10.0/guides/compatibility.md
@@ -13,7 +13,7 @@ If you found an incompatibility or conflict with other open source libraries - d
 
 :::
 
-## React Native
+## `react-native`
 
 Below you can find an information about compatibility with `react-native` package per different architectures.
 
@@ -39,6 +39,12 @@ This library supports as minimal `react-native` version as possible. However it 
 | --------------- | -------------------- |
 | 1.7.0+          | 0.65.0+              |
 | 1.0.0+          | 0.62.0+              |
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.3.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.11.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.11.0/guides/compatibility.md
@@ -13,7 +13,7 @@ If you found an incompatibility or conflict with other open source libraries - d
 
 :::
 
-## React Native
+## `react-native`
 
 Below you can find an information about compatibility with `react-native` package per different architectures.
 
@@ -39,6 +39,12 @@ This library supports as minimal `react-native` version as possible. However it 
 | --------------- | -------------------- |
 | 1.7.0+          | 0.65.0+              |
 | 1.0.0+          | 0.62.0+              |
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.3.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.12.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.12.0/guides/compatibility.md
@@ -13,7 +13,7 @@ If you found an incompatibility or conflict with other open source libraries - d
 
 :::
 
-## React Native
+## `react-native`
 
 Below you can find an information about compatibility with `react-native` package per different architectures.
 
@@ -40,6 +40,12 @@ This library supports as minimal `react-native` version as possible. However it 
 | --------------- | -------------------- |
 | 1.7.0+          | 0.65.0+              |
 | 1.0.0+          | 0.62.0+              |
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.11.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.4.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.4.0/guides/compatibility.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Compatibility
 
-## React Native
+## `react-native`
 
 Starting from `1.2.0` this library adds support for a new architecture called `Fabric`. Since a new architecture is still in adoption stage and it changes some APIs over time - it's highly recommended to use versions which are compatible and were intensively tested against specific `react-native` versions.
 
@@ -20,6 +20,12 @@ Below you can find a table with supported versions:
 For `Paper` (old) architecture there is no any restrictions. If you found an incompatibility - don't hesitate to open an [issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/new?assignees=kirillzyusko&labels=bug&template=bug_report.md&title=). It will help the project 🙏
 
 :::
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.3.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.5.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.5.0/guides/compatibility.md
@@ -7,7 +7,7 @@ keywords:
 
 # Compatibility
 
-## React Native
+## `react-native`
 
 Starting from `1.2.0` this library adds support for a new architecture called `Fabric`. Since a new architecture is still in adoption stage and it changes some APIs over time - it's highly recommended to use versions which are compatible and were intensively tested against specific `react-native` versions.
 
@@ -24,6 +24,12 @@ Below you can find a table with supported versions:
 For `Paper` (old) architecture there is no any restrictions. If you found an incompatibility - don't hesitate to open an [issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/new?assignees=kirillzyusko&labels=bug&template=bug_report.md&title=). It will help the project 🙏
 
 :::
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.3.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.6.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.6.0/guides/compatibility.md
@@ -7,7 +7,7 @@ keywords:
 
 # Compatibility
 
-## React Native
+## `react-native`
 
 Starting from `1.2.0` this library adds support for a new architecture called `Fabric`. Since a new architecture is still in adoption stage and it changes some APIs over time - it's highly recommended to use versions which are compatible and were intensively tested against specific `react-native` versions.
 
@@ -25,6 +25,12 @@ Below you can find a table with supported versions:
 For `Paper` (old) architecture there is no any restrictions. If you found an incompatibility - don't hesitate to open an [issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/new?assignees=kirillzyusko&labels=bug&template=bug_report.md&title=). It will help the project 🙏
 
 :::
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.3.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.7.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.7.0/guides/compatibility.md
@@ -13,7 +13,7 @@ If you found an incompatibility or conflict with other open source libraries - d
 
 :::
 
-## React Native
+## `react-native`
 
 Below you can find an information about compatibility with `react-native` package per different architectures.
 
@@ -38,6 +38,12 @@ This library supports as minimal `react-native` version as possible. However it 
 | --------------- | -------------------- |
 | 1.7.0+          | 0.65.0+              |
 | 1.0.0+          | 0.62.0+              |
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.3.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.8.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.8.0/guides/compatibility.md
@@ -13,7 +13,7 @@ If you found an incompatibility or conflict with other open source libraries - d
 
 :::
 
-## React Native
+## `react-native`
 
 Below you can find an information about compatibility with `react-native` package per different architectures.
 
@@ -38,6 +38,12 @@ This library supports as minimal `react-native` version as possible. However it 
 | --------------- | -------------------- |
 | 1.7.0+          | 0.65.0+              |
 | 1.0.0+          | 0.62.0+              |
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.3.0`.
 
 ## Third-party libraries compatibility
 

--- a/docs/versioned_docs/version-1.9.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.9.0/guides/compatibility.md
@@ -13,7 +13,7 @@ If you found an incompatibility or conflict with other open source libraries - d
 
 :::
 
-## React Native
+## `react-native`
 
 Below you can find an information about compatibility with `react-native` package per different architectures.
 
@@ -38,6 +38,12 @@ This library supports as minimal `react-native` version as possible. However it 
 | --------------- | -------------------- |
 | 1.7.0+          | 0.65.0+              |
 | 1.0.0+          | 0.62.0+              |
+
+## `react-native-reanimated`
+
+This library is heavily relies on `react-native-reanimated` primitives to bring advanced concepts for keyboard handling.
+
+The minimal supported version of `react-native-reanimated` is `2.3.0`.
 
 ## Third-party libraries compatibility
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-reanimated": ">=2.3.0"
+    "react-native-reanimated": ">=2.11.0"
   },
   "jest": {
     "preset": "react-native",

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -2,12 +2,11 @@ import React, { forwardRef, useCallback, useMemo } from "react";
 import { findNodeHandle } from "react-native";
 import Reanimated, {
   interpolate,
-  runOnJS,
   scrollTo,
   useAnimatedReaction,
   useAnimatedRef,
-  useAnimatedScrollHandler,
   useAnimatedStyle,
+  useScrollViewOffset,
   useSharedValue,
 } from "react-native-reanimated";
 
@@ -87,7 +86,6 @@ const KeyboardAwareScrollView = forwardRef<
       bottomOffset = 0,
       disableScrollOnKeyboardHide = false,
       enabled = true,
-      onScroll: onScrollProps,
       extraKeyboardSpace = 0,
       ...rest
     },
@@ -96,7 +94,7 @@ const KeyboardAwareScrollView = forwardRef<
     const scrollViewAnimatedRef = useAnimatedRef<Reanimated.ScrollView>();
     const scrollViewTarget = useSharedValue<number | null>(null);
     const scrollPosition = useSharedValue(0);
-    const position = useSharedValue(0);
+    const position = useScrollViewOffset(scrollViewAnimatedRef);
     const currentKeyboardFrameHeight = useSharedValue(0);
     const keyboardHeight = useSharedValue(0);
     const keyboardWillAppear = useSharedValue(false);
@@ -107,20 +105,6 @@ const KeyboardAwareScrollView = forwardRef<
     const layout = useSharedValue<FocusedInputLayoutChangedEvent | null>(null);
 
     const { height } = useWindowDimensions();
-
-    const onScroll = useAnimatedScrollHandler(
-      {
-        onScroll: (event) => {
-          position.value = event.contentOffset.y;
-
-          if (onScrollProps) {
-            // @ts-expect-error https://github.com/software-mansion/react-native-reanimated/issues/6204
-            runOnJS(onScrollProps)({ nativeEvent: event });
-          }
-        },
-      },
-      [onScrollProps],
-    );
 
     const onRef = useCallback((assignedRef: Reanimated.ScrollView) => {
       if (typeof ref === "function") {
@@ -344,7 +328,6 @@ const KeyboardAwareScrollView = forwardRef<
         ref={onRef}
         {...rest}
         onLayout={onScrollViewLayout}
-        onScroll={onScroll}
         scrollEventThrottle={16}
       >
         {children}


### PR DESCRIPTION
## 📜 Description

Use `useScrollViewOffset` hook to get a scrolled distance.

## 💡 Motivation and Context

`useScrollViewOffset` hook doesn't substitute `onScroll` handlers with `dummyListener` and thus it allows you to define your custom `onScroll` handler (and at the same time it can be plain js handler or reanimated one).

The new approach gives us next advantages:
- `position.value` is still calculating on UI;
- you can pass both worklet/js-handler as `onScroll` and it will work out of the box without additional manipulations 😎
- we don't use `@ts-expect-error` and don't ship the code with potential errors;
- we can support reanimated up to `2.11.0` (the first release that added `useScrollViewOffset`).

The disadvantage is that we need to bump REA from `2.3.0` to `2.11.0` (I described that in documentation). Theoretically we can create our own version of `useScrollViewOffset` and support REA from `2.3.0` again. But version `2.11.0` was released 2 years ago:

<img width="769" alt="image" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/fc819b2f-298d-497f-9fdd-d2feb06744ac">

And after math calculations I figured out that dropping support from `2.3.0` to `2.11.0` we'll loose only 2% of users (overall downloads for `2.3.0`-`2.10.0` are ~17k with 770k of overall downloads), so I don't think it's a breaking change.

And I think this 2% of users typically don't update deps at all in the project so I think it's not critical to bump minimal supported version for v1.12.x of this library.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- use `useScrollViewOffset` hook to get a scrolled distance;

## 🤔 How Has This Been Tested?

Tested manually + on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
