### PR TITLE
fix: missing `height` deps in `KeyboardAwareScrollView` component

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -196,7 +196,7 @@ const KeyboardAwareScrollView = forwardRef<
 
         return 0;
       },
-      [bottomOffset, enabled, rest.snapToOffsets],
+      [bottomOffset, enabled, height, rest.snapToOffsets],
     );
 
     const onChangeText = useCallback(() => {
@@ -303,7 +303,7 @@ const KeyboardAwareScrollView = forwardRef<
           scrollPosition.value = position.value;
         },
       },
-      [height, maybeScroll, disableScrollOnKeyboardHide, extraKeyboardSpace],
+      [maybeScroll, disableScrollOnKeyboardHide, extraKeyboardSpace],
     );
 
     useAnimatedReaction(


### PR DESCRIPTION
## 📜 Description

Added `height` to deps of `maybeScroll` function.

## 💡 Motivation and Context

When we mount component and height is updated later (`windowDidResize` is emitted after component mount), then we receive `height=0` in `maybeScroll`. This PR fixes this.

Also I removed `height` from `useSmoothKeyboardHandler` because we don't use this value in the hook and we have `maybeScroll` in dependencies. 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/499

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `height` to deps of `maybeScroll` function.

## 🤔 How Has This Been Tested?

Tested manually on Pixel 3A (API 33, emulator).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="384" alt="Screenshot 2024-07-09 at 10 51 38" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/d3d68393-b285-46bb-9900-0ae6b3b9475d">|<img width="379" alt="Screenshot 2024-07-09 at 10 50 47" src="https://github.com/kirillzyusko/react-native-keyboard-controller/assets/22820318/0e1a5b64-4ece-4120-8323-b1573ed3ea10">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
