### PR TITLE
feat: timing animation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -111,7 +111,10 @@
     "autoplayed",
     "bridgeless",
     "scrollview",
-    "AOSP"
+    "AOSP",
+    "bezier",
+    "bézier",
+    "Raphson"
   ],
   "ignorePaths": [
     "node_modules",

--- a/cspell.json
+++ b/cspell.json
@@ -114,7 +114,8 @@
     "AOSP",
     "bezier",
     "bézier",
-    "Raphson"
+    "Raphson",
+    "desmos"
   ],
   "ignorePaths": [
     "node_modules",

--- a/ios/core/KeyboardAnimation.swift
+++ b/ios/core/KeyboardAnimation.swift
@@ -17,7 +17,7 @@ protocol KeyboardAnimationProtocol {
 }
 
 public class KeyboardAnimation: KeyboardAnimationProtocol {
-  private weak var animation: CAMediaTiming?
+  weak var animation: CAMediaTiming?
 
   // constructor variables
   let fromValue: Double

--- a/ios/core/TimingAnimation.swift
+++ b/ios/core/TimingAnimation.swift
@@ -16,10 +16,8 @@ import QuartzCore
  * For more details on the Bézier curves, see [Desmos Graph](https://www.desmos.com/calculator/eynenh1aga?lang=en).
  */
 public class TimingAnimation: KeyboardAnimation {
-  private let p0: CGPoint
   private let p1: CGPoint
   private let p2: CGPoint
-  private let p3: CGPoint
 
   init(animation: CABasicAnimation, fromValue: Double, toValue: Double) {
     let timingFunction = animation.timingFunction
@@ -29,10 +27,8 @@ public class TimingAnimation: KeyboardAnimation {
     let p1 = CGPoint(x: CGFloat(controlPoints[0]), y: CGFloat(controlPoints[1]))
     let p2 = CGPoint(x: CGFloat(controlPoints[2]), y: CGFloat(controlPoints[3]))
 
-    p0 = CGPoint(x: 0.0, y: 0.0)
     self.p1 = p1
     self.p2 = p2
-    p3 = CGPoint(x: 1.0, y: 1.0)
 
     super.init(fromValue: fromValue, toValue: toValue, animation: animation)
   }
@@ -43,13 +39,14 @@ public class TimingAnimation: KeyboardAnimation {
     let uu = u * u
 
     // Calculate the terms for the Bézier curve
-    let term0 = uu * u * valueForPoint(p0) // P0
+    // term0 is evaluated as `0`, because P0(0, 0)
+    // let term0 = uu * u * valueForPoint(p0) // P0
     let term1 = 3 * uu * t * valueForPoint(p1) // P1
     let term2 = 3 * u * tt * valueForPoint(p2) // P2
-    let term3 = tt * t * valueForPoint(p3) // P3
+    let term3 = tt * t // * valueForPoint(p3), because P3(1, 1)
 
     // Sum all terms to get the Bézier value
-    return term0 + term1 + term2 + term3
+    return term1 + term2 + term3
   }
 
   func bezierY(t: CGFloat) -> CGFloat {
@@ -93,12 +90,14 @@ public class TimingAnimation: KeyboardAnimation {
     let tt = t * t
     let tu = t * u
 
-    let term0 = -3 * uu * valueForPoint(p0)
+    // term0 is evaluated as `0`, because P0(0, 0)
+    // let term0 = -3 * uu * valueForPoint(p0)
     let term1 = (3 * uu - 6 * tu) * valueForPoint(p1)
     let term2 = (6 * tu - 3 * tt) * valueForPoint(p2)
-    let term3 = 3 * tt * valueForPoint(p3)
+    let term3 = 3 * tt // * valueForPoint(p3), because P3(1, 1)
 
-    return term0 + term1 + term2 + term3
+    // Sum all terms to get the derivative
+    return term1 + term2 + term3
   }
 
   func bezierXDerivative(t: CGFloat) -> CGFloat {

--- a/ios/core/TimingAnimation.swift
+++ b/ios/core/TimingAnimation.swift
@@ -9,6 +9,12 @@ import Foundation
 import QuartzCore
 
 // swiftlint:disable identifier_name
+/**
+ * A class that handles timing animations using Bézier curves.
+ *
+ * This class calculates the progress of animations based on Bézier curve control points.
+ * For more details on the Bézier curves, see [Desmos Graph](https://www.desmos.com/calculator/eynenh1aga?lang=en).
+ */
 public class TimingAnimation: KeyboardAnimation {
   private let p0: CGPoint
   private let p1: CGPoint

--- a/ios/core/TimingAnimation.swift
+++ b/ios/core/TimingAnimation.swift
@@ -1,0 +1,134 @@
+//
+//  TimingAnimation.swift
+//  react-native-keyboard-controller
+//
+//  Created by Kiryl Ziusko on 02/05/2024.
+//
+
+import Foundation
+import QuartzCore
+
+public class TimingAnimation : KeyboardAnimation {
+  private weak var animation: CABasicAnimation?
+
+    private let p0: CGPoint
+    private let p1: CGPoint
+  private let fromValue: Double
+  private let toValue: Double
+  private let speed: Float
+  private let timestamp: CFTimeInterval
+
+  init(
+    p0: CGPoint,
+    p1: CGPoint,
+    speed: Float,
+    fromValue: Double,
+    toValue: Double
+  ) {
+      self.p0 = p0
+      self.p1 = p1
+    self.speed = speed
+    self.fromValue = fromValue
+    self.toValue = toValue
+    timestamp = CACurrentMediaTime()
+      print("\(self.toValue) \(self.p0) \(self.p1)")
+  }
+
+  convenience init(animation: CABasicAnimation, fromValue: Double, toValue: Double) {
+      let timingFunction = animation.timingFunction
+      var controlPoints: [Float] = [0, 0, 0, 0]
+      timingFunction?.getControlPoint(at: 1, values: &controlPoints[0])
+      timingFunction?.getControlPoint(at: 2, values: &controlPoints[2])
+      let p0 = CGPoint(x: CGFloat(controlPoints[0]), y: CGFloat(controlPoints[1]))
+      let p1 = CGPoint(x: CGFloat(controlPoints[2]), y: CGFloat(controlPoints[3]))
+    self.init(
+      p0: p0,
+      p1: p1,
+      speed: (animation as CABasicAnimation).speed,
+      fromValue: fromValue,
+      toValue: toValue
+    )
+    self.animation = animation
+  }
+
+    func bezier(t: CGFloat) -> CGFloat {
+        let u = 1 - t
+        let tt = t * t
+        let uu = u * u
+
+        // Calculate the terms for the Bézier curve
+        let term0 = uu * u * 0           // Since P0 = (0,0), term0 contributes 0
+        let term1 = 3 * uu * t * 0       // Since P1.y = 0
+        let term2 = 3 * u * tt * 1.0     // Since P2.y = 1.0
+        let term3 = tt * t * 1           // Since P3.y = 1, term3 = t^3
+
+        // Sum all terms to get the Bézier value
+        return term0 + term1 + term2 + term3
+    }
+
+  // public getters
+  var startTime: CFTimeInterval {
+    // when concurrent animation happens, then `.beginTime` remains the same
+    return max(animation?.beginTime ?? timestamp, timestamp)
+  }
+
+  var diff: Double {
+    return ((animation?.beginTime ?? timestamp) - timestamp).truncatingRemainder(dividingBy: UIUtils.nextFrame)
+  }
+
+  var isIncreasing: Bool {
+    return fromValue < toValue
+  }
+
+  // public functions
+  func valueAt(time: Double) -> Double {
+      let t = time * Double(speed)
+      let fraction = min(t / ((animation?.duration ?? 0.25) * Double(speed)), 1)
+      
+      let progress = bezier(t: fraction)
+      
+      print("ValueAt:: \(fraction) \(time) \(progress) \(animation?.duration). Bezier:: \(fromValue + (toValue - fromValue) * CGFloat(progress))")
+      // print("from: \(fromValue) to: \(toValue) \(progress)")
+      
+      return fromValue + (toValue - fromValue) * CGFloat(progress)
+  }
+    
+    // (346 - 160) * x = 112
+    // x (progress) = 0.60215053763
+    
+    func valueAt2(time: Double) -> Double {
+        let t = time * Double(speed)
+        let fraction = min(t / ((animation?.duration ?? 0.25) * Double(speed)), 1)
+        
+        let progress = bezier(t: fraction)
+        
+        // print("\(fromValue + (toValue - fromValue) * CGFloat(progress)) :: \(fraction) \(time) \(animation?.duration)")
+        // print("from: \(fromValue) to: \(toValue) \(progress)")
+        
+        return fromValue + (toValue - fromValue) * CGFloat(progress)
+    }
+
+  func timingAt(value y: Double) -> Double {
+    var lowerBound = 0.0
+    var upperBound = 1.0 // Assuming 1 second is the max duration for simplicity
+    let tolerance = 0.00001 // Define how precise you want to be
+    var tGuess = 0.0
+
+    // Check the direction of the animation
+    let isIncreasing = isIncreasing
+
+    while (upperBound - lowerBound) > tolerance {
+      tGuess = (lowerBound + upperBound) / 2
+      let currentValue = valueAt2(time: tGuess / Double(speed))
+
+      // Adjust the condition to account for the direction of animation
+      if (currentValue < y && isIncreasing) || (currentValue > y && !isIncreasing) {
+        lowerBound = tGuess
+      } else {
+        upperBound = tGuess
+      }
+    }
+
+    return tGuess / Double(speed)
+  }
+}

--- a/ios/core/TimingAnimation.swift
+++ b/ios/core/TimingAnimation.swift
@@ -13,25 +13,29 @@ public class TimingAnimation : KeyboardAnimation {
 
     private let p0: CGPoint
     private let p1: CGPoint
+    private let p2: CGPoint
+    private let p3: CGPoint
   private let fromValue: Double
   private let toValue: Double
   private let speed: Float
   private let timestamp: CFTimeInterval
 
   init(
-    p0: CGPoint,
     p1: CGPoint,
+    p2: CGPoint,
     speed: Float,
     fromValue: Double,
     toValue: Double
   ) {
-      self.p0 = p0
+      self.p0 = CGPoint(x: 0.0, y: 0.0)
       self.p1 = p1
+      self.p2 = p2
+      self.p3 = CGPoint(x: 1.0, y: 1.0)
     self.speed = speed
     self.fromValue = fromValue
     self.toValue = toValue
     timestamp = CACurrentMediaTime()
-      print("\(self.toValue) \(self.p0) \(self.p1)")
+      print("\(self.toValue) \(self.p1) \(self.p2)")
   }
 
   convenience init(animation: CABasicAnimation, fromValue: Double, toValue: Double) {
@@ -39,11 +43,11 @@ public class TimingAnimation : KeyboardAnimation {
       var controlPoints: [Float] = [0, 0, 0, 0]
       timingFunction?.getControlPoint(at: 1, values: &controlPoints[0])
       timingFunction?.getControlPoint(at: 2, values: &controlPoints[2])
-      let p0 = CGPoint(x: CGFloat(controlPoints[0]), y: CGFloat(controlPoints[1]))
-      let p1 = CGPoint(x: CGFloat(controlPoints[2]), y: CGFloat(controlPoints[3]))
+      let p1 = CGPoint(x: CGFloat(controlPoints[0]), y: CGFloat(controlPoints[1]))
+      let p2 = CGPoint(x: CGFloat(controlPoints[2]), y: CGFloat(controlPoints[3]))
     self.init(
-      p0: p0,
       p1: p1,
+      p2: p2,
       speed: (animation as CABasicAnimation).speed,
       fromValue: fromValue,
       toValue: toValue
@@ -57,10 +61,10 @@ public class TimingAnimation : KeyboardAnimation {
         let uu = u * u
 
         // Calculate the terms for the Bézier curve
-        let term0 = uu * u * 0           // Since P0 = (0,0), term0 contributes 0
-        let term1 = 3 * uu * t * 0       // Since P1.y = 0
-        let term2 = 3 * u * tt * 1.0     // Since P2.y = 1.0
-        let term3 = tt * t * 1           // Since P3.y = 1, term3 = t^3
+        let term0 = uu * u * p0.y           // Since P0 = (0,0), term0 contributes 0
+        let term1 = 3 * uu * t * p1.y       // Since P1.y = 0
+        let term2 = 3 * u * tt * p2.y     // Since P2.y = 1.0
+        let term3 = tt * t * p3.y           // Since P3.y = 1, term3 = t^3
 
         // Sum all terms to get the Bézier value
         return term0 + term1 + term2 + term3
@@ -82,31 +86,58 @@ public class TimingAnimation : KeyboardAnimation {
 
   // public functions
   func valueAt(time: Double) -> Double {
-      let t = time * Double(speed)
-      let fraction = min(t / ((animation?.duration ?? 0.25) * Double(speed)), 1)
+      let x = time * Double(speed)
+      let frames = ((animation?.duration ?? 0.0)) * Double(speed)
+      let fraction = min((x / frames), 1)
+      let t = findTForX(xTarget: fraction)
       
-      let progress = bezier(t: fraction)
+      let progress = bezier(t: t)
       
-      print("ValueAt:: \(fraction) \(time) \(progress) \(animation?.duration). Bezier:: \(fromValue + (toValue - fromValue) * CGFloat(progress))")
+      print("ValueAt:: \(fraction) \(t) \(time) \(progress) \(animation?.duration). Bezier:: \(fromValue + (toValue - fromValue) * CGFloat(progress))")
       // print("from: \(fromValue) to: \(toValue) \(progress)")
       
       return fromValue + (toValue - fromValue) * CGFloat(progress)
   }
     
-    // (346 - 160) * x = 112
-    // x (progress) = 0.60215053763
-    
     func valueAt2(time: Double) -> Double {
-        let t = time * Double(speed)
-        let fraction = min(t / ((animation?.duration ?? 0.25) * Double(speed)), 1)
+        let x = time * Double(speed)
+        let frames = ((animation?.duration ?? 0.0)) * Double(speed)
+        let fraction = min((x / frames), 1)
+        let t = findTForX(xTarget: fraction)
         
-        let progress = bezier(t: fraction)
+        let progress = bezier(t: t)
         
         // print("\(fromValue + (toValue - fromValue) * CGFloat(progress)) :: \(fraction) \(time) \(animation?.duration)")
         // print("from: \(fromValue) to: \(toValue) \(progress)")
         
         return fromValue + (toValue - fromValue) * CGFloat(progress)
     }
+    
+    func findTForX(xTarget: CGFloat, epsilon: CGFloat = 0.0001, maxIterations: Int = 100) -> CGFloat {
+        var t: CGFloat = 0.5  // Start with an initial guess of t = 0.5
+        for _ in 0..<maxIterations {
+            let currentX = bezierX(t: t)  // Compute the x-coordinate at t
+            let derivativeX = bezierXDerivative(t: t)  // Compute the derivative at t
+            let xError = currentX - xTarget
+            if abs(xError) < epsilon {
+                return t
+            }
+            t -= xError / derivativeX  // Newton-Raphson step
+            t = max(min(t, 1), 0)  // Ensure t stays within bounds
+        }
+        return t  // Return the approximation of t
+    }
+
+    func bezierX(t: CGFloat) -> CGFloat {
+        // Implement this to compute the x-coordinate of the Bezier curve at t
+        return (1 - t) * (1 - t) * (1 - t) * p0.x + 3 * (1 - t) * (1 - t) * t * p1.x + 3 * (1 - t) * t * t * p2.x + t * t * t * p3.x
+    }
+
+    func bezierXDerivative(t: CGFloat) -> CGFloat {
+        // Implement this to compute the derivative of the x-coordinate of the Bezier curve at t
+        return -3 * (1 - t) * (1 - t) * p0.x + (3 * (1 - t) * (1 - t) - 6 * t * (1 - t)) * p1.x + (6 * t * (1 - t) - 3 * t * t) * p2.x + 3 * t * t * p3.x
+    }
+
 
   func timingAt(value y: Double) -> Double {
     var lowerBound = 0.0

--- a/ios/core/TimingAnimation.swift
+++ b/ios/core/TimingAnimation.swift
@@ -81,14 +81,18 @@ public class TimingAnimation: KeyboardAnimation {
     return t // Return the approximation of t
   }
 
-  func bezierDerivative(t: CGFloat, valueForPoint _: (CGPoint) -> CGFloat) -> CGFloat {
+  func bezierDerivative(t: CGFloat, valueForPoint: (CGPoint) -> CGFloat) -> CGFloat {
     let u = 1 - t
     let uu = u * u
     let tt = t * t
     let tu = t * u
 
-    // computing the derivative of the (x/y)-coordinate of the Bezier curve at t
-    return -3 * uu * p0.x + (3 * uu - 6 * tu) * p1.x + (6 * tu - 3 * tt) * p2.x + 3 * tt * p3.x
+    let term0 = -3 * uu * valueForPoint(p0)
+    let term1 = (3 * uu - 6 * tu) * valueForPoint(p1)
+    let term2 = (6 * tu - 3 * tt) * valueForPoint(p2)
+    let term3 = 3 * tt * valueForPoint(p3)
+
+    return term0 + term1 + term2 + term3
   }
 
   func bezierXDerivative(t: CGFloat) -> CGFloat {

--- a/ios/core/TimingAnimation.swift
+++ b/ios/core/TimingAnimation.swift
@@ -8,120 +8,80 @@
 import Foundation
 import QuartzCore
 
-public class TimingAnimation : KeyboardAnimation {
-    private let p0: CGPoint
-    private let p1: CGPoint
-    private let p2: CGPoint
-    private let p3: CGPoint
-    
-    init(animation: CABasicAnimation, fromValue: Double, toValue: Double) {
-        let timingFunction = animation.timingFunction
-        var controlPoints: [Float] = [0, 0, 0, 0]
-        timingFunction?.getControlPoint(at: 1, values: &controlPoints[0])
-        timingFunction?.getControlPoint(at: 2, values: &controlPoints[2])
-        let p1 = CGPoint(x: CGFloat(controlPoints[0]), y: CGFloat(controlPoints[1]))
-        let p2 = CGPoint(x: CGFloat(controlPoints[2]), y: CGFloat(controlPoints[3]))
-        
-        self.p0 = CGPoint(x: 0.0, y: 0.0)
-        self.p1 = p1
-        self.p2 = p2
-        self.p3 = CGPoint(x: 1.0, y: 1.0)
+// swiftlint:disable identifier_name
+public class TimingAnimation: KeyboardAnimation {
+  private let p0: CGPoint
+  private let p1: CGPoint
+  private let p2: CGPoint
+  private let p3: CGPoint
 
-      super.init(fromValue: fromValue, toValue: toValue, animation: animation)
-    }
+  init(animation: CABasicAnimation, fromValue: Double, toValue: Double) {
+    let timingFunction = animation.timingFunction
+    var controlPoints: [Float] = [0, 0, 0, 0]
+    timingFunction?.getControlPoint(at: 1, values: &controlPoints[0])
+    timingFunction?.getControlPoint(at: 2, values: &controlPoints[2])
+    let p1 = CGPoint(x: CGFloat(controlPoints[0]), y: CGFloat(controlPoints[1]))
+    let p2 = CGPoint(x: CGFloat(controlPoints[2]), y: CGFloat(controlPoints[3]))
 
-    func bezier(t: CGFloat) -> CGFloat {
-        let u = 1 - t
-        let tt = t * t
-        let uu = u * u
+    p0 = CGPoint(x: 0.0, y: 0.0)
+    self.p1 = p1
+    self.p2 = p2
+    p3 = CGPoint(x: 1.0, y: 1.0)
 
-        // Calculate the terms for the Bézier curve
-        let term0 = uu * u * p0.y           // Since P0 = (0,0), term0 contributes 0
-        let term1 = 3 * uu * t * p1.y       // Since P1.y = 0
-        let term2 = 3 * u * tt * p2.y     // Since P2.y = 1.0
-        let term3 = tt * t * p3.y           // Since P3.y = 1, term3 = t^3
+    super.init(fromValue: fromValue, toValue: toValue, animation: animation)
+  }
 
-        // Sum all terms to get the Bézier value
-        return term0 + term1 + term2 + term3
-    }
+  func bezier(t: CGFloat) -> CGFloat {
+    let u = 1 - t
+    let tt = t * t
+    let uu = u * u
+
+    // Calculate the terms for the Bézier curve
+    let term0 = uu * u * p0.y // Since P0 = (0,0), term0 contributes 0
+    let term1 = 3 * uu * t * p1.y // Since P1.y = 0
+    let term2 = 3 * u * tt * p2.y // Since P2.y = 1.0
+    let term3 = tt * t * p3.y // Since P3.y = 1, term3 = t^3
+
+    // Sum all terms to get the Bézier value
+    return term0 + term1 + term2 + term3
+  }
 
   // public functions
   override func valueAt(time: Double) -> Double {
-      let x = time * Double(speed)
-      let frames = ((animation?.duration ?? 0.0)) * Double(speed)
-      let fraction = min((x / frames), 1)
-      let t = findTForX(xTarget: fraction)
-      
-      let progress = bezier(t: t)
-      
-      print("ValueAt:: \(fraction) \(t) \(time) \(progress) \(animation?.duration). Bezier:: \(fromValue + (toValue - fromValue) * CGFloat(progress))")
-      // print("from: \(fromValue) to: \(toValue) \(progress)")
-      
-      return fromValue + (toValue - fromValue) * CGFloat(progress)
+    let x = time * Double(speed)
+    let frames = (animation?.duration ?? 0.0) * Double(speed)
+    let fraction = min(x / frames, 1)
+    let t = findTForX(xTarget: fraction)
+
+    let progress = bezier(t: t)
+
+    return fromValue + (toValue - fromValue) * CGFloat(progress)
   }
-    
-    func valueAt2(time: Double) -> Double {
-        let x = time * Double(speed)
-        let frames = ((animation?.duration ?? 0.0)) * Double(speed)
-        let fraction = min((x / frames), 1)
-        let t = findTForX(xTarget: fraction)
-        
-        let progress = bezier(t: t)
-        
-        // print("\(fromValue + (toValue - fromValue) * CGFloat(progress)) :: \(fraction) \(time) \(animation?.duration)")
-        // print("from: \(fromValue) to: \(toValue) \(progress)")
-        
-        return fromValue + (toValue - fromValue) * CGFloat(progress)
-    }
-    
-    func findTForX(xTarget: CGFloat, epsilon: CGFloat = 0.0001, maxIterations: Int = 100) -> CGFloat {
-        var t: CGFloat = 0.5  // Start with an initial guess of t = 0.5
-        for _ in 0..<maxIterations {
-            let currentX = bezierX(t: t)  // Compute the x-coordinate at t
-            let derivativeX = bezierXDerivative(t: t)  // Compute the derivative at t
-            let xError = currentX - xTarget
-            if abs(xError) < epsilon {
-                return t
-            }
-            t -= xError / derivativeX  // Newton-Raphson step
-            t = max(min(t, 1), 0)  // Ensure t stays within bounds
-        }
-        return t  // Return the approximation of t
-    }
 
-    func bezierX(t: CGFloat) -> CGFloat {
-        // Implement this to compute the x-coordinate of the Bezier curve at t
-        return (1 - t) * (1 - t) * (1 - t) * p0.x + 3 * (1 - t) * (1 - t) * t * p1.x + 3 * (1 - t) * t * t * p2.x + t * t * t * p3.x
-    }
-
-    func bezierXDerivative(t: CGFloat) -> CGFloat {
-        // Implement this to compute the derivative of the x-coordinate of the Bezier curve at t
-        return -3 * (1 - t) * (1 - t) * p0.x + (3 * (1 - t) * (1 - t) - 6 * t * (1 - t)) * p1.x + (6 * t * (1 - t) - 3 * t * t) * p2.x + 3 * t * t * p3.x
-    }
-
-
-  // temporarily override it because of valueAt2 usage
-  override func timingAt(value y: Double) -> Double {
-    var lowerBound = 0.0
-    var upperBound = 1.0 // Assuming 1 second is the max duration for simplicity
-    let tolerance = 0.00001 // Define how precise you want to be
-    var tGuess = 0.0
-
-    // Check the direction of the animation
-    let isIncreasing = isIncreasing
-
-    while (upperBound - lowerBound) > tolerance {
-      tGuess = (lowerBound + upperBound) / 2
-      let currentValue = valueAt2(time: tGuess / Double(speed))
-
-      // Adjust the condition to account for the direction of animation
-      if (currentValue < y && isIncreasing) || (currentValue > y && !isIncreasing) {
-        lowerBound = tGuess
-      } else {
-        upperBound = tGuess
+  func findTForX(xTarget: CGFloat, epsilon: CGFloat = 0.0001, maxIterations: Int = 100) -> CGFloat {
+    var t: CGFloat = 0.5 // Start with an initial guess of t = 0.5
+    for _ in 0 ..< maxIterations {
+      let currentX = bezierX(t: t) // Compute the x-coordinate at t
+      let derivativeX = bezierXDerivative(t: t) // Compute the derivative at t
+      let xError = currentX - xTarget
+      if abs(xError) < epsilon {
+        return t
       }
+      t -= xError / derivativeX // Newton-Raphson step
+      t = max(min(t, 1), 0) // Ensure t stays within bounds
     }
+    return t // Return the approximation of t
+  }
 
-    return tGuess / Double(speed)
+  func bezierX(t: CGFloat) -> CGFloat {
+    // Implement this to compute the x-coordinate of the Bezier curve at t
+    return (1 - t) * (1 - t) * (1 - t) * p0.x + 3 * (1 - t) * (1 - t) * t * p1.x + 3 * (1 - t) * t * t * p2.x + t * t * t * p3.x
+  }
+
+  func bezierXDerivative(t: CGFloat) -> CGFloat {
+    // Implement this to compute the derivative of the x-coordinate of the Bezier curve at t
+    return -3 * (1 - t) * (1 - t) * p0.x + (3 * (1 - t) * (1 - t) - 6 * t * (1 - t)) * p1.x + (6 * t * (1 - t) - 3 * t * t) * p2.x + 3 * t * t * p3.x
   }
 }
+
+// swiftlint:enable identifier_name

--- a/ios/core/TimingAnimation.swift
+++ b/ios/core/TimingAnimation.swift
@@ -9,51 +9,26 @@ import Foundation
 import QuartzCore
 
 public class TimingAnimation : KeyboardAnimation {
-  private weak var animation: CABasicAnimation?
-
     private let p0: CGPoint
     private let p1: CGPoint
     private let p2: CGPoint
     private let p3: CGPoint
-  private let fromValue: Double
-  private let toValue: Double
-  private let speed: Float
-  private let timestamp: CFTimeInterval
+    
+    init(animation: CABasicAnimation, fromValue: Double, toValue: Double) {
+        let timingFunction = animation.timingFunction
+        var controlPoints: [Float] = [0, 0, 0, 0]
+        timingFunction?.getControlPoint(at: 1, values: &controlPoints[0])
+        timingFunction?.getControlPoint(at: 2, values: &controlPoints[2])
+        let p1 = CGPoint(x: CGFloat(controlPoints[0]), y: CGFloat(controlPoints[1]))
+        let p2 = CGPoint(x: CGFloat(controlPoints[2]), y: CGFloat(controlPoints[3]))
+        
+        self.p0 = CGPoint(x: 0.0, y: 0.0)
+        self.p1 = p1
+        self.p2 = p2
+        self.p3 = CGPoint(x: 1.0, y: 1.0)
 
-  init(
-    p1: CGPoint,
-    p2: CGPoint,
-    speed: Float,
-    fromValue: Double,
-    toValue: Double
-  ) {
-      self.p0 = CGPoint(x: 0.0, y: 0.0)
-      self.p1 = p1
-      self.p2 = p2
-      self.p3 = CGPoint(x: 1.0, y: 1.0)
-    self.speed = speed
-    self.fromValue = fromValue
-    self.toValue = toValue
-    timestamp = CACurrentMediaTime()
-      print("\(self.toValue) \(self.p1) \(self.p2)")
-  }
-
-  convenience init(animation: CABasicAnimation, fromValue: Double, toValue: Double) {
-      let timingFunction = animation.timingFunction
-      var controlPoints: [Float] = [0, 0, 0, 0]
-      timingFunction?.getControlPoint(at: 1, values: &controlPoints[0])
-      timingFunction?.getControlPoint(at: 2, values: &controlPoints[2])
-      let p1 = CGPoint(x: CGFloat(controlPoints[0]), y: CGFloat(controlPoints[1]))
-      let p2 = CGPoint(x: CGFloat(controlPoints[2]), y: CGFloat(controlPoints[3]))
-    self.init(
-      p1: p1,
-      p2: p2,
-      speed: (animation as CABasicAnimation).speed,
-      fromValue: fromValue,
-      toValue: toValue
-    )
-    self.animation = animation
-  }
+      super.init(fromValue: fromValue, toValue: toValue, animation: animation)
+    }
 
     func bezier(t: CGFloat) -> CGFloat {
         let u = 1 - t
@@ -70,22 +45,8 @@ public class TimingAnimation : KeyboardAnimation {
         return term0 + term1 + term2 + term3
     }
 
-  // public getters
-  var startTime: CFTimeInterval {
-    // when concurrent animation happens, then `.beginTime` remains the same
-    return max(animation?.beginTime ?? timestamp, timestamp)
-  }
-
-  var diff: Double {
-    return ((animation?.beginTime ?? timestamp) - timestamp).truncatingRemainder(dividingBy: UIUtils.nextFrame)
-  }
-
-  var isIncreasing: Bool {
-    return fromValue < toValue
-  }
-
   // public functions
-  func valueAt(time: Double) -> Double {
+  override func valueAt(time: Double) -> Double {
       let x = time * Double(speed)
       let frames = ((animation?.duration ?? 0.0)) * Double(speed)
       let fraction = min((x / frames), 1)
@@ -139,7 +100,8 @@ public class TimingAnimation : KeyboardAnimation {
     }
 
 
-  func timingAt(value y: Double) -> Double {
+  // temporarily override it because of valueAt2 usage
+  override func timingAt(value y: Double) -> Double {
     var lowerBound = 0.0
     var upperBound = 1.0 // Assuming 1 second is the max duration for simplicity
     let tolerance = 0.00001 // Define how precise you want to be

--- a/ios/core/TimingAnimation.swift
+++ b/ios/core/TimingAnimation.swift
@@ -91,7 +91,7 @@ public class TimingAnimation: KeyboardAnimation {
     return -3 * uu * p0.x + (3 * uu - 6 * tu) * p1.x + (6 * tu - 3 * tt) * p2.x + 3 * tt * p3.x
   }
 
-  func bezierXDerivative(t: CGFloat) {
+  func bezierXDerivative(t: CGFloat) -> CGFloat {
     return bezierDerivative(t: t) { $0.x }
   }
 }

--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -40,7 +40,6 @@ public class KeyboardMovementObserver: NSObject {
   private var duration = 0
   private var tag: NSNumber = -1
   private var animation: KeyboardAnimation?
-  var i = 0.0
 
   @objc public init(
     handler: @escaping (NSString, NSNumber, NSNumber, NSNumber, NSNumber) -> Void,
@@ -143,7 +142,7 @@ public class KeyboardMovementObserver: NSObject {
         // since it will be handled in `keyboardWillDisappear` function
         return
       }
-        
+
       prevKeyboardPosition = position
 
       onEvent(
@@ -272,19 +271,13 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   func initializeAnimation(fromValue: Double, toValue: Double) {
-    print(keyboardView?.layer.presentation()?.animation(forKey: "position"))
-      if let positionAnimation = keyboardView?.layer.presentation()?.animation(forKey: "position") {
-          if let springAnimation = positionAnimation as? CASpringAnimation {
-            animation = SpringAnimation(animation: springAnimation, fromValue: fromValue, toValue: toValue)
-              // Handle spring animation specifics here
-          } else if let basicAnimation = positionAnimation as? CABasicAnimation {
-              animation = TimingAnimation(animation: basicAnimation, fromValue: fromValue, toValue: toValue)
-          } else {
-              print("The animation is not a recognized type (not CASpringAnimation or CABasicAnimation).")
-          }
-      } else {
-          print("No animation found for key 'position'.")
-      }
+    guard let positionAnimation = keyboardView?.layer.presentation()?.animation(forKey: "position") else { return }
+
+    if let springAnimation = positionAnimation as? CASpringAnimation {
+      animation = SpringAnimation(animation: springAnimation, fromValue: fromValue, toValue: toValue)
+    } else if let basicAnimation = positionAnimation as? CABasicAnimation {
+      animation = TimingAnimation(animation: basicAnimation, fromValue: fromValue, toValue: toValue)
+    }
   }
 
   @objc func updateKeyboardFrame(link: CADisplayLink) {
@@ -300,15 +293,14 @@ public class KeyboardMovementObserver: NSObject {
       return
     }
 
-      if animation == nil {
-          initializeAnimation(fromValue: prevKeyboardPosition, toValue: keyboardHeight)
-          i = prevKeyboardPosition
-      }
-      
+    if animation == nil {
+      initializeAnimation(fromValue: prevKeyboardPosition, toValue: keyboardHeight)
+    }
+
     prevKeyboardPosition = keyboardPosition
 
     if let animation = animation {
-        let baseDuration = animation.timingAt(value: keyboardPosition)
+      let baseDuration = animation.timingAt(value: keyboardPosition)
 
       #if targetEnvironment(simulator)
         // on iOS simulator we can not use static interval
@@ -323,8 +315,6 @@ public class KeyboardMovementObserver: NSObject {
       #endif
 
       let position = CGFloat(animation.valueAt(time: duration))
-        print("At \(duration) Predicted: \(position).\n Base: \(baseDuration) -> \(animation.valueAt(time: baseDuration)) vs \(keyboardPosition). Timing: \(link.timestamp - animation.startTime)")
-        print("Diff: \((keyboardPosition - i) / (keyboardHeight - i))")
       // handles a case when final frame has final destination (i. e. 0 or 291)
       // but CASpringAnimation can never get to this final destination
       let race: (CGFloat, CGFloat) -> CGFloat = animation.isIncreasing ? max : min


### PR DESCRIPTION
## 📜 Description

A follow up PR for https://github.com/kirillzyusko/react-native-keyboard-controller/pull/412 - follow keyboard frame-in-frame if keyboard animation is **not** spring animation.

## 💡 Motivation and Context

On iOS keyboard animation can be not only spring animation. It can be also `CABasicAnimation` (when keyboard goes up after interactive dismissal, for example).

Before we were relying on `CADisplayLink` and coordinates pooling, but such approach doesn't give a good precision. Even after implementing custom `SpringAnimation` we still relied on this approach (we used this approach as a fallback if the animation is not `CASpringAnimation`).

In this PR I implemented custom `TimingAnimation` class and if the animation is `CABasicAnimation` then we also can assure frame precision. All these math calculations were based on this [Desmos playground](https://www.desmos.com/calculator/eynenh1aga?lang=en) - I used concrete params of a particular animation config and concrete values produced by iOS. And then I wrote a code 🙃 

> _As you can see some of points are not perfectly aligned to the curve - I think a similar behavior I also observed with `SpringAnimation` and later on I'll improve that as well_

For finding `t` for particular `x` (or `y`) I used [Newton-Raphson](https://en.wikipedia.org/wiki/Newton%27s_method) method. It has better convergence than a binary search and typically I can find a value with given precision within 6 iterations.

Last but not least - the animation (`CABaicAnimation`) is not available straight in `keyboardWillShow` callback (it's `nil` there) and it's available only in `CADisplayLink` callback (so I added an attempt of animation initialization there as well).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added `TimingAnimation` class;
- use `TimingAnimation` in `KeyboardMovementObserver`.

## 🤔 How Has This Been Tested?

Tested manually on:
- iPhone 6s (iOS 15.8)
- iPhone 11 (iOS 17.4);
- iPhone 14 Pro (iOS 17.4);
- iPhone 15 Pro (iOS 17.5, simulator);

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/1c1bba40-c76e-468f-87aa-7e9105715ab7">|<video src="https://github.com/user-attachments/assets/55de0c4d-9d0a-4775-a4dd-4983acc30283">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
