### PR TITLE
ci: missing permissions for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       # Setup .npmrc file to publish to npm


### PR DESCRIPTION
## 📜 Description

Fixing:

```bash
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2024-07-24T10_31_43_348Z-debug-0.log
```

## 💡 Motivation and Context

According to documentation and tutorials these permissions are necessary: https://tsmx.net/npmjs-built-and-signed-on-github-actions/

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- grant `contents` and `id-token` corresponding permission for publishing npm package;

## 🤔 How Has This Been Tested?

Can be tested only after merge 🤷‍♂️ 

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
