### PR TITLE
ci: allow manual publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: 🌐 Publish Package to npmjs
 on:
   release:
     types: [created]
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
   workflow_dispatch:
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 📜 Description

Allow manual run for publishing to npm action.

## 💡 Motivation and Context

I wanted to have "verified" badge, but forgot to run proper permissions to the job. As a result the job failed and I can not publish a package with new permission (https://github.com/kirillzyusko/react-native-keyboard-controller/pull/520), because the job is heavily depends on the fact that **new** tag must be published. In oreder not to create a new tag I decided to allow manual run for the job (as a last resort) 🙃 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- allow manual runs for `publish.yml` job;
- rename `build` -> `publish` job;

## 🤔 How Has This Been Tested?

Can be tested only after merge 🙈 

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
