### PR TITLE
e2e: update detox

### DIFF
--- a/e2e/kit/helpers/actions/index.ts
+++ b/e2e/kit/helpers/actions/index.ts
@@ -101,11 +101,8 @@ export const clearAndType = async (id: string, text: string): Promise<void> => {
 export const switchToEmojiKeyboard = async () => {
   const uiDevice = device.getUiDevice();
   // see https://github.com/wix/Detox/issues/4331
-  // @ts-expect-error this is not part of official detox API
   const height = await uiDevice.getDisplayHeight();
-  // @ts-expect-error this is not part of official detox API
   const width = await uiDevice.getDisplayWidth();
-  // @ts-expect-error this is not part of official detox API
   await uiDevice.click(width * 0.3, height * 0.95);
 };
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -32,7 +32,7 @@
     "@types/pngjs": "^6.0.1",
     "async-retry": "^1.3.3",
     "colors": "^1.4.0",
-    "detox": "^20.25.1",
+    "detox": "20.23.1",
     "jest": "^29",
     "patch-package": "^8.0.0",
     "pixelmatch": "^5.3.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -32,7 +32,7 @@
     "@types/pngjs": "^6.0.1",
     "async-retry": "^1.3.3",
     "colors": "^1.4.0",
-    "detox": "^20.19.3",
+    "detox": "^20.25.1",
     "jest": "^29",
     "patch-package": "^8.0.0",
     "pixelmatch": "^5.3.0",

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -1114,10 +1114,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detox@^20.19.3:
-  version "20.19.3"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-20.19.3.tgz#68c8c1d569fc98a69a1222fa3d56106953b46f31"
-  integrity sha512-5axCZVfVNB4SgKej4ONIAVXkPgvWXd5ULSTemmWGA8oLRmlZpELrhBXgAcTP4MEY/tArG1v0Cx4NWyoda/Lyiw==
+detox@^20.25.1:
+  version "20.25.1"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-20.25.1.tgz#72bfe34260388870ef4f7afd8171a475cf0c1146"
+  integrity sha512-l+VhhtwfIR8DR4Htvo3KUIx1VPQkYanwjxsKUlXrOM60e47GB45U87la3VYVpFEvUQ5liD46tWWDkY0fkhoOOw==
   dependencies:
     ajv "^8.6.3"
     bunyan "^1.8.12"
@@ -1131,7 +1131,7 @@ detox@^20.19.3:
     funpermaproxy "^1.1.0"
     glob "^8.0.3"
     ini "^1.3.4"
-    jest-environment-emit "^1.0.5"
+    jest-environment-emit "^1.0.8"
     json-cycle "^1.3.0"
     lodash "^4.17.11"
     multi-sort-stream "^1.0.3"
@@ -1747,10 +1747,10 @@ jest-each@^29.7.0:
     jest-util "^29.7.0"
     pretty-format "^29.7.0"
 
-jest-environment-emit@^1.0.5:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/jest-environment-emit/-/jest-environment-emit-1.0.7.tgz#14c2197e9fa48affa25b15fc5f4a74690aea7efd"
-  integrity sha512-/0AYqbL3zrfRTtGyzTZwgRxQZiDXEM8ZUfY7Uscla/XGs9vszx4f0XTSZqAk3CQaiwYAoKvFZkB2vSKm1Q08fQ==
+jest-environment-emit@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/jest-environment-emit/-/jest-environment-emit-1.0.8.tgz#ab0dad2c1dd04d3ca092762a99080607b0eef10b"
+  integrity sha512-WNqvxBLH0yNojHJQ99Y21963aT7UTavxV3PgiBQFi8zwrlnKU6HvkB6LOvQrbk5I8mI8JEKvcoOrQOvBVMLIXQ==
   dependencies:
     bunyamin "^1.5.2"
     bunyan "^2.0.5"

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -1114,10 +1114,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detox@^20.25.1:
-  version "20.25.1"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-20.25.1.tgz#72bfe34260388870ef4f7afd8171a475cf0c1146"
-  integrity sha512-l+VhhtwfIR8DR4Htvo3KUIx1VPQkYanwjxsKUlXrOM60e47GB45U87la3VYVpFEvUQ5liD46tWWDkY0fkhoOOw==
+detox@20.23.1:
+  version "20.23.1"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-20.23.1.tgz#57970c4bd7bdfc35f395c98106bbfb4be1c65150"
+  integrity sha512-K3UWCatYokzQStXxBTqrWzX0pLUBUCngNY3jGL61q6b1UH37vXPziGtOjWmKZ9zDQlxWC/HT7QWSiJqHn81DwA==
   dependencies:
     ajv "^8.6.3"
     bunyan "^1.8.12"


### PR DESCRIPTION
## 📜 Description

Updated detox.

## 💡 Motivation and Context

Mainly because I want to test iOS 18 compatibility + keed deps up-to-date.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### E2E

- update detox;
- remove unnecessary `@ts-expect-ignore` errors;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
