### PR TITLE
fix: ref deallocation with `FlatList` -> `KeyboardAwareScrollView` usage

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -90,6 +90,7 @@ const KeyboardAwareScrollView = forwardRef<
       disableScrollOnKeyboardHide = false,
       enabled = true,
       extraKeyboardSpace = 0,
+      snapToOffsets,
       ...rest
     },
     ref,
@@ -158,7 +159,7 @@ const KeyboardAwareScrollView = forwardRef<
               0,
               scrollDistanceWithRespectToSnapPoints(
                 relativeScrollTo + scrollPosition.value,
-                rest.snapToOffsets,
+                snapToOffsets,
               ) - scrollPosition.value,
             ],
           );
@@ -183,7 +184,7 @@ const KeyboardAwareScrollView = forwardRef<
 
         return 0;
       },
-      [bottomOffset, enabled, height, rest.snapToOffsets],
+      [bottomOffset, enabled, height, snapToOffsets],
     );
 
     const scrollFromCurrentPosition = useCallback(


### PR DESCRIPTION
## 📜 Description

Fixed `ref` deallocation when you assign ref to `FlatList` and render `KeyboardAwareScrollView` via `renderScrollComponent` prop.

## 💡 Motivation and Context

It looks like if we use `rest.snapToOffset`, then REA will try to copy all variables from `rest` properties to worklet runtime and then may fail to cleanup something.

Obviously we don't need to copy an entire object, because we only want to know one property, so in this PR I changed the approach and now we memoize only `snapToOffset` property (not entire `rest` object).

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/525

## 📢 Changelog

### JS

- capture only one variable (`snapToOffset`) instead of entire `rest` object into worklet closure;

## 🤔 How Has This Been Tested?

tested on Pixel 2 (API 30).

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/77e427b4-02ca-4775-81db-78450ae790aa

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
