### PR TITLE
feat: new `offset` prop for `KeyboardGestureArea` on Android

### DIFF
--- a/FabricExample/src/screens/Examples/InteractiveKeyboard/index.tsx
+++ b/FabricExample/src/screens/Examples/InteractiveKeyboard/index.tsx
@@ -87,10 +87,11 @@ function InteractiveKeyboard({ navigation }: Props) {
   return (
     <View style={styles.container}>
       <KeyboardGestureArea
-        testID="chat.gesture"
         style={styles.content}
+        testID="chat.gesture"
         interpolator={interpolator}
         showOnSwipeUp
+        offset={50}
       >
         <Reanimated.ScrollView
           testID="chat.scroll"

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
@@ -27,6 +27,11 @@ class KeyboardGestureAreaViewManager(mReactContext: ReactApplicationContext) :
     return manager.createViewInstance(context)
   }
 
+  @ReactProp(name = "offset")
+  override fun setOffset(view: ReactViewGroup, value: Double?) {
+    manager.setOffset(view as KeyboardGestureAreaReactViewGroup, value ?: 0.0)
+  }
+
   @ReactProp(name = "interpolator")
   override fun setInterpolator(view: ReactViewGroup, value: String?) {
     manager.setInterpolator(view as KeyboardGestureAreaReactViewGroup, value ?: "linear")

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
@@ -28,8 +28,8 @@ class KeyboardGestureAreaViewManager(mReactContext: ReactApplicationContext) :
   }
 
   @ReactProp(name = "offset")
-  override fun setOffset(view: ReactViewGroup, value: Double?) {
-    manager.setOffset(view as KeyboardGestureAreaReactViewGroup, value ?: 0.0)
+  override fun setOffset(view: ReactViewGroup, value: Double) {
+    manager.setOffset(view as KeyboardGestureAreaReactViewGroup, value)
   }
 
   @ReactProp(name = "interpolator")

--- a/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/Interpolator.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/Interpolator.kt
@@ -8,7 +8,8 @@ interface Interpolator {
    * @param dy the distance that the finger has moved relative to the previous location.
    * @param absoluteFingerPosition current position of the finger.
    * @param keyboardPosition current keyboard position.
+   * @param offset extra space to the keyboard to activate a gesture
    * @return the distance the keyboard should be moved from its current location.
    */
-  fun interpolate(dy: Int, absoluteFingerPosition: Int, keyboardPosition: Int): Int
+  fun interpolate(dy: Int, absoluteFingerPosition: Int, keyboardPosition: Int, offset: Int): Int
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/IosInterpolator.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/IosInterpolator.kt
@@ -5,9 +5,10 @@ class IosInterpolator : Interpolator {
     dy: Int,
     absoluteFingerPosition: Int,
     keyboardPosition: Int,
+    offset: Int
   ): Int {
     if (
-      absoluteFingerPosition <= keyboardPosition || // user over scrolled keyboard
+      absoluteFingerPosition <= keyboardPosition + offset || // user over scrolled keyboard
       dy <= 0 // user scrolls up
     ) {
       return dy

--- a/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/IosInterpolator.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/IosInterpolator.kt
@@ -5,7 +5,7 @@ class IosInterpolator : Interpolator {
     dy: Int,
     absoluteFingerPosition: Int,
     keyboardPosition: Int,
-    offset: Int
+    offset: Int,
   ): Int {
     if (
       absoluteFingerPosition <= keyboardPosition + offset || // user over scrolled keyboard

--- a/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/LinearInterpolator.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/LinearInterpolator.kt
@@ -5,7 +5,9 @@ class LinearInterpolator : Interpolator {
     dy: Int,
     absoluteFingerPosition: Int,
     keyboardPosition: Int,
+    offset: Int
   ): Int {
+    // TODO: do we need to take offset into consideration?
     return dy
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/LinearInterpolator.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/LinearInterpolator.kt
@@ -7,7 +7,6 @@ class LinearInterpolator : Interpolator {
     keyboardPosition: Int,
     offset: Int,
   ): Int {
-    // TODO: do we need to take offset into consideration?
     return dy
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/LinearInterpolator.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/interactive/interpolators/LinearInterpolator.kt
@@ -5,7 +5,7 @@ class LinearInterpolator : Interpolator {
     dy: Int,
     absoluteFingerPosition: Int,
     keyboardPosition: Int,
-    offset: Int
+    offset: Int,
   ): Int {
     // TODO: do we need to take offset into consideration?
     return dy

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardGestureAreaViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardGestureAreaViewManagerImpl.kt
@@ -10,6 +10,10 @@ class KeyboardGestureAreaViewManagerImpl(mReactContext: ReactApplicationContext)
     return KeyboardGestureAreaReactViewGroup(reactContext)
   }
 
+  fun setOffset(view: KeyboardGestureAreaReactViewGroup, offset: Double) {
+    view.setOffset(offset)
+  }
+
   fun setInterpolator(view: KeyboardGestureAreaReactViewGroup, interpolator: String) {
     view.setInterpolator(interpolator)
   }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
@@ -12,6 +12,7 @@ import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.extensions.copyBoundsInWindow
+import com.reactnativekeyboardcontroller.extensions.px
 import com.reactnativekeyboardcontroller.interactive.KeyboardAnimationController
 import com.reactnativekeyboardcontroller.interactive.interpolators.Interpolator
 import com.reactnativekeyboardcontroller.interactive.interpolators.IosInterpolator
@@ -35,6 +36,7 @@ class KeyboardGestureAreaReactViewGroup(private val reactContext: ThemedReactCon
   private var keyboardHeight = 0
 
   // react props
+  private var offset = 0
   private var interpolator: Interpolator = LinearInterpolator()
   private var scrollKeyboardOnScreenWhenNotVisible = false
   private var scrollKeyboardOffScreenWhenVisible = true
@@ -63,6 +65,10 @@ class KeyboardGestureAreaReactViewGroup(private val reactContext: ThemedReactCon
   }
 
   // region Props setters
+  fun setOffset(offset: Double) {
+    this.offset = offset.toFloat().px.toInt()
+  }
+
   fun setInterpolator(interpolator: String) {
     this.interpolator = interpolators[interpolator] ?: LinearInterpolator()
   }
@@ -125,6 +131,7 @@ class KeyboardGestureAreaReactViewGroup(private val reactContext: ThemedReactCon
           dy.roundToInt(),
           this.getWindowHeight() - event.rawY.toInt(),
           controller.getCurrentKeyboardHeight(),
+          offset
         )
 
         if (moveBy != 0) {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
@@ -131,7 +131,7 @@ class KeyboardGestureAreaReactViewGroup(private val reactContext: ThemedReactCon
           dy.roundToInt(),
           this.getWindowHeight() - event.rawY.toInt(),
           controller.getCurrentKeyboardHeight(),
-          offset
+          offset,
         )
 
         if (moveBy != 0) {

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
@@ -16,6 +16,11 @@ class KeyboardGestureAreaViewManager(mReactContext: ReactApplicationContext) : R
     return manager.createViewInstance(reactContext)
   }
 
+  @ReactProp(name = "offset")
+  fun setInterpolator(view: KeyboardGestureAreaReactViewGroup, offset: Double) {
+    manager.setOffset(view, offset)
+  }
+
   @ReactProp(name = "interpolator")
   fun setInterpolator(view: KeyboardGestureAreaReactViewGroup, interpolator: String) {
     manager.setInterpolator(view, interpolator)

--- a/docs/docs/api/keyboard-gesture-area.md
+++ b/docs/docs/api/keyboard-gesture-area.md
@@ -1,6 +1,5 @@
 ---
 sidebar_position: 4
-title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -10,19 +9,19 @@ keywords:
   ]
 ---
 
-<!-- prettier-ignore-start -->
-<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
-<!-- markdownlint-disable-next-line MD025 -->
-# KeyboardGestureArea <div class="label android"></div>
-<!-- prettier-ignore-end -->
+# KeyboardGestureArea
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 
 :::info Platform availability
-This component is available only for Android >= 11. For iOS and Android < 11 it will render `React.Fragment`.
+This component is available only for Android >= 11. For Android < 11 it will render `React.Fragment`.
 :::
 
 ## Props
+
+### `offset`
+
+Extra distance to the keyboard. Default is `0`.
 
 ### `interpolator`
 
@@ -31,11 +30,15 @@ String with possible values `linear` and `ios`:
 - **ios** - interactive keyboard dismissing will work as in iOS: swipes in non-keyboard area will not affect keyboard positioning, but if your swipe touches keyboard - keyboard will follow finger position.
 - **linear** - gestures inside the component will linearly affect the position of the keyboard, i.e. if the user swipes down by 20 pixels, then the keyboard will also be moved down by 20 pixels, even if the gesture was not made over the keyboard area.
 
-### `showOnSwipeUp`
+:::info Platform availability
+This property does the difference only on `Android`. On `iOS` the behavior will be always `ios` since it's not possible to make any customizations there.
+:::
+
+### `showOnSwipeUp` <div class="label android"></div>
 
 A boolean prop which allows to customize interactive keyboard behavior. If set to `true` then it allows to show keyboard (if it's already closed) by swipe up gesture. `false` by default.
 
-### `enableSwipeToDismiss`
+### `enableSwipeToDismiss` <div class="label android"></div>
 
 A boolean prop which allows to customize interactive keyboard behavior. If set to `false`, then any gesture will not affect keyboard position if the keyboard is shown. `true` by default.
 

--- a/docs/docs/api/keyboard-gesture-area.md
+++ b/docs/docs/api/keyboard-gesture-area.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: KeyboardGestureArea
 keywords:
   [
     react-native-keyboard-controller,
@@ -9,12 +10,16 @@ keywords:
   ]
 ---
 
-# KeyboardGestureArea
+<!-- prettier-ignore-start -->
+<!-- we explicitly specify title and h1 because we add badge to h1 and we don't want this element to go to table of contents -->
+<!-- markdownlint-disable-next-line MD025 -->
+# KeyboardGestureArea <div class="label android"></div>
+<!-- prettier-ignore-end -->
 
 `KeyboardGestureArea` allows you to define a region on the screen, where gestures will control the keyboard position.
 
 :::info Platform availability
-This component is available only for Android >= 11. For Android < 11 it will render `React.Fragment`.
+This component is available only for Android >= 11. For iOS and Android < 11 it will render `React.Fragment`.
 :::
 
 ## Props
@@ -30,22 +35,18 @@ String with possible values `linear` and `ios`:
 - **ios** - interactive keyboard dismissing will work as in iOS: swipes in non-keyboard area will not affect keyboard positioning, but if your swipe touches keyboard - keyboard will follow finger position.
 - **linear** - gestures inside the component will linearly affect the position of the keyboard, i.e. if the user swipes down by 20 pixels, then the keyboard will also be moved down by 20 pixels, even if the gesture was not made over the keyboard area.
 
-:::info Platform availability
-This property does the difference only on `Android`. On `iOS` the behavior will be always `ios` since it's not possible to make any customizations there.
-:::
-
-### `showOnSwipeUp` <div class="label android"></div>
+### `showOnSwipeUp`
 
 A boolean prop which allows to customize interactive keyboard behavior. If set to `true` then it allows to show keyboard (if it's already closed) by swipe up gesture. `false` by default.
 
-### `enableSwipeToDismiss` <div class="label android"></div>
+### `enableSwipeToDismiss`
 
 A boolean prop which allows to customize interactive keyboard behavior. If set to `false`, then any gesture will not affect keyboard position if the keyboard is shown. `true` by default.
 
 ## Example
 
 ```tsx
-<KeyboardGestureArea interpolator="ios">
+<KeyboardGestureArea interpolator="ios" offset={50}>
   <ScrollView>
     {/* The other UI components of application in your tree */}
   </ScrollView>

--- a/example/src/screens/Examples/InteractiveKeyboard/index.tsx
+++ b/example/src/screens/Examples/InteractiveKeyboard/index.tsx
@@ -91,6 +91,7 @@ function InteractiveKeyboard({ navigation }: Props) {
         testID="chat.gesture"
         interpolator={interpolator}
         showOnSwipeUp
+        offset={50}
       >
         <Reanimated.ScrollView
           testID="chat.scroll"

--- a/src/specs/KeyboardGestureAreaNativeComponent.ts
+++ b/src/specs/KeyboardGestureAreaNativeComponent.ts
@@ -2,12 +2,16 @@ import codegenNativeComponent from "react-native/Libraries/Utilities/codegenNati
 
 import type { HostComponent } from "react-native";
 import type { ViewProps } from "react-native/Libraries/Components/View/ViewPropTypes";
-import type { WithDefault } from "react-native/Libraries/Types/CodegenTypes";
+import type {
+  Double,
+  WithDefault,
+} from "react-native/Libraries/Types/CodegenTypes";
 
 export interface NativeProps extends ViewProps {
   interpolator?: WithDefault<"linear" | "ios", "linear">;
   showOnSwipeUp?: boolean;
   enableSwipeToDismiss?: boolean;
+  offset?: Double;
 }
 
 export default codegenNativeComponent<NativeProps>("KeyboardGestureArea", {

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,10 @@ export type KeyboardGestureAreaProps = {
    * Defaults to `true`.
    */
   enableSwipeToDismiss?: boolean;
+  /**
+   * Extra distance to the keyboard.
+   */
+  offset?: number;
 } & ViewProps;
 
 export type Direction = "next" | "prev" | "current";


### PR DESCRIPTION
## 📜 Description

Added `offset` property for `KeyboardGestureArea` component.

## 💡 Motivation and Context

Add requested changes in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/250 only on Android (for now). Later on I'll try to add similar functionality to iOS.

On Android such functionality can be easily implemented, because we have a full control over the keyboard position - so we just need to take an additional variable in math calculations and that's all 😎 

I am still not sure if adding negative number to the linear interpolator should change the behavior of linear interpolator - it's open question and I can fix it later on. Right now I'm happy to have such changes, because it definitely improves UX so :shipit: 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added info about `offset` property;

### JS

- update `KeyboardGestureArea` spec;
- update `types.ts` to include `offset` property for `KeyboardGestureArea`;

### Android

- added setter for new `offset` property;
- added new param to interpolator interface;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro (API 34).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/ba8fb69b-0c59-4ad0-a123-cc187c1e516d">|<video src="https://github.com/user-attachments/assets/f3a7bb61-b0d0-406a-b3ca-02502dd8a78e">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
