### PR TITLE
fix: `KeyboardToolbar` a11y wording

### DIFF
--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -155,7 +155,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
         {showArrows && (
           <>
             <ButtonContainer
-              accessibilityHint="Will move focus to previous field"
+              accessibilityHint="Moves focus to the previous field"
               accessibilityLabel="Previous"
               disabled={isPrevDisabled}
               testID={TEST_ID_KEYBOARD_TOOLBAR_PREVIOUS}
@@ -169,7 +169,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
               />
             </ButtonContainer>
             <ButtonContainer
-              accessibilityHint="Will move focus to next field"
+              accessibilityHint="Moves focus to the next field"
               accessibilityLabel="Next"
               disabled={isNextDisabled}
               testID={TEST_ID_KEYBOARD_TOOLBAR_NEXT}
@@ -189,7 +189,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
           {content}
         </View>
         <ButtonContainer
-          accessibilityHint="Will close the keyboard"
+          accessibilityHint="Closes the keyboard"
           accessibilityLabel="Done"
           rippleRadius={28}
           style={styles.doneButtonContainer}


### PR DESCRIPTION
## 📜 Description

Corrected wording for `accessibilityHint`. Move from "future simple" to "present simple" tense.

## 💡 Motivation and Context

I missed "the" article and decided to add it. But then I asked ChatGPT what else can be improved and ChatGPT suggested to write everything in present simple tense. I kind of agree, because we describe what button does, not what it will do.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- changed `accessibilityHint`;

## 🤔 How Has This Been Tested?

Tested on iPhone 15 Pro and e2e tests.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
