### PR TITLE
fix: web compilation

### DIFF
--- a/src/event-handler.web.js
+++ b/src/event-handler.web.js
@@ -1,0 +1,5 @@
+const NOOP = () => {};
+const registerEventHandler = NOOP;
+const unregisterEventHandler = NOOP;
+
+export { registerEventHandler, unregisterEventHandler };


### PR DESCRIPTION
## 📜 Description

Fixed web compilation.

## 💡 Motivation and Context

Since I added new `event-handler` file - on web it'll try to import that, but it'll lead to errors, because this file depends on native module which is available on Android and iOS.

To fix that I'm exporting a mock function to make sure this library is still compilable on web.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `event-handler.web.js` file.

## 🤔 How Has This Been Tested?

Tested manually on web project - the compilation error has gone.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
