### PR TITLE
chore: bump minimal `react-native-reanimated` version in `package.json` peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-reanimated": ">=2.11.0"
+    "react-native-reanimated": ">=3.0.0"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
## 📜 Description

Minimal supported version of `react-native-reanimated` is `3.0.0`.

## 💡 Motivation and Context

These changes were introduced in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/538

In this PR I'm just changing version in `package.josn`.

Follow up for https://github.com/kirillzyusko/react-native-keyboard-controller/pull/538

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- bump `react-native-reanimated` to `3.0.0`;

## 🤔 How Has This Been Tested?

There is no way to test it 😀 

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
