### PR TITLE
docs: hook names truncated in menu bar

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -18,7 +18,7 @@
 }
 
 .menu__link {
-  word-break: break-all;
+  word-break: break-word;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -15,7 +15,6 @@
   --ifm-color-primary-lightest: #1090ee;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-  --doc-sidebar-width: 340px !important;
 }
 
 .menu__link {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -15,6 +15,11 @@
   --ifm-color-primary-lightest: #1090ee;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --doc-sidebar-width: 340px !important;
+}
+
+.menu__link {
+  word-break: break-all;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
## 📜 Description

Added `word-break` rule for menu items.

## 💡 Motivation and Context

`useReanimatedKeyboardAnimation` is a long name and can't fit into one line. As a result part of the name was truncated and it's not good. So in this PR I'm fixing this.

Originally I wanted to increase sidebar width, but then realized that I need to handle cases for small devices (smartphones) and bigger sidebar doesn't look well there.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added `word-break` to `menu__link` class;

## 🤔 How Has This Been Tested?

Tested manually on `localhost:3000`.

## 📸 Screenshots (if appropriate):

<img width="1516" alt="image" src="https://github.com/user-attachments/assets/03cd7f1b-b1dc-45bb-9f6e-e7cebb858192">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
