### PR TITLE
fix: e2e iOS 18 tests

### DIFF
--- a/e2e/.detoxrc.js
+++ b/e2e/.detoxrc.js
@@ -60,7 +60,9 @@ module.exports = {
       device: {
         // TODO: switch to iPhone 16 Pro when it'll be released
         type: "iPhone 14",
-        os: "iOS 18.0",
+        // temporarily not lock OS version, because we are using beta XCode
+        // and depending on the runner the OS version can be 18.0 or 18.1
+        // os: "iOS 18.0",
       },
     },
     attached: {


### PR DESCRIPTION
## 📜 Description

Fixed flaky iOS 18 tests.

## 💡 Motivation and Context

Problem because of the fact, that on GitHub we may be running on different runners and these runners have different XCode beta versions (16.0 and 16.1 with iOS 18.0 and iOS 18.1).

If we lock OS to iOS 18.1 then test can crash immediately if simulator is not found. So in this PR I temporarily unlock OS version until stable XCode will be rolled out to all runners.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### E2E

- don't lock OS version for iOS 18;

## 🤔 How Has This Been Tested?

Tested on CI (with XCode 16.1).

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
