### PR TITLE
fix: ignore non scrollable ScrollView's for `parentScrollViewTarget`

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
@@ -6,7 +6,7 @@ import android.text.TextWatcher
 import android.util.Log
 import android.view.View
 import android.widget.EditText
-import android.widget.ScrollView
+import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.textinput.ReactEditText
 import com.reactnativekeyboardcontroller.ui.FrameScheduler
 import java.lang.reflect.Field
@@ -78,8 +78,8 @@ val EditText.parentScrollViewTarget: Int
     while (currentView != null) {
       val parentView = currentView.parent as? View
 
-      if (parentView is ScrollView) {
-        // If the parent is a vertical ScrollView, return its id
+      if (parentView is ReactScrollView && parentView.scrollEnabled) {
+        // If the parent is a vertical, scrollable ScrollView - return its id
         return parentView.id
       }
 

--- a/ios/extensions/UIResponder.swift
+++ b/ios/extensions/UIResponder.swift
@@ -51,10 +51,11 @@ public extension Optional where Wrapped: UIResponder {
     var currentResponder: UIResponder? = self
 
     while let currentView = currentResponder {
-      // If the current responder is a vertical UIScrollView (excluding UITextView), return its tag
+      // If the current responder is a vertical, scrollable UIScrollView (excluding UITextView), return its tag
       if let scrollView = currentView as? UIScrollView,
          !(currentView is UITextView),
-         scrollView.frame.width >= scrollView.contentSize.width
+         scrollView.frame.width >= scrollView.contentSize.width,
+         scrollView.isScrollEnabled
       // it was fixed in swiftlint https://github.com/realm/SwiftLint/issues/3756 but a new release is not available yet
       // swiftlint:disable all
       {


### PR DESCRIPTION
## 📜 Description

Ignore disabled (explicitly non-scrollable) `ScrollView`s for `parentScrollViewTarget` property.

## 💡 Motivation and Context

If people disabled `ScrollView` (via `scrollEnabled=false`) then we shouldn't consider this `ScrollView` as parent and should continue a search.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/565

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added `isScrollEnabled` check;

### Android

- change casting from `ScrollView` to `ReactScrollView` and verify that `scrollEnabled` equals `true`;

## 🤔 How Has This Been Tested?

Tested manually on paper architecture (both iOS and Android).

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
