### PR TITLE
e2e: better stability of `BottomTabBarRotation` test

### DIFF
--- a/e2e/kit/010-bottom-tab-bar-rotation.e2e.ts
+++ b/e2e/kit/010-bottom-tab-bar-rotation.e2e.ts
@@ -3,6 +3,7 @@ import {
   closeKeyboard,
   scrollDownUntilElementIsVisible,
   waitAndTap,
+  waitForElementById,
   waitForExpect,
 } from "./helpers";
 
@@ -13,6 +14,7 @@ describe("Bottom tab bar", () => {
   });
 
   it("should have expected state in portrait mode", async () => {
+    await waitForElementById("keyboard_animation_text_input");
     await waitForExpect(async () => {
       await expectBitmapsToBeEqual("BottomTabBarPortrait", 0.25);
     });


### PR DESCRIPTION
## 📜 Description

Added `waitFor` to exclude case when we start execution of the test without opening a screen:

![BottomTabBarLandscape](https://github.com/user-attachments/assets/ade018d8-2e42-43ab-a5c4-91b7f54c98b8)


## 💡 Motivation and Context

To keep e2e more stable. Flakiness can break tests in pretty near future.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### E2E

- added `await waitForElementById("keyboard_animation_text_input");` check.

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
