### PR TITLE
fix: mount handlers when view is not mounted yet

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -14,7 +14,7 @@ export function useEventHandlerRegistration<
 ) {
   const onRegisterHandler = (handler: H) => {
     const ids: (number | null)[] = [];
-    const proceedToRegistration = () => {
+    const attachWorkletHandlers = () => {
       const viewTag = findNodeHandle(viewTagRef.current);
 
       if (__DEV__ && !viewTag) {
@@ -46,11 +46,10 @@ export function useEventHandlerRegistration<
     };
 
     if (viewTagRef.current) {
-      proceedToRegistration();
+      attachWorkletHandlers();
     } else {
-      // if ref is not available yet it can be a case when view is not mounted yet
-      // so we need to wait for it to be mounted and then proceed with registration
-      setImmediate(proceedToRegistration);
+      // view may not be mounted yet - defer registration to next event loop
+      setImmediate(attachWorkletHandlers);
     }
 
     return () => {


### PR DESCRIPTION
## 📜 Description

Defer attaching workelt handlers if ref is not initialized yet.

## 💡 Motivation and Context

When we use `KeyboardAwareScrollView` next to `KeyboardProvider` we end up in situation when ref is not initialized yet and in this case we can not attach our handler.

This is a common scenario because documentation page tells is's a valid code but developers can be confused by that fact that sample code is not working and may not want to integrate the library in the code.

To fix this problem I'm deferring attaching till `ref` is initialized (`setImmediate` does the job).

Also I added meaningful warning that will spot potential problems in future:

<p align="center">
<img width="300" src="https://github.com/user-attachments/assets/0686fc7b-2194-4220-8289-c202416f9912">
</p>

With all these changes I think a new code gets a better revision and handles more edge-cases.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/574

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- check `viewRef` for nullability and defer initialization if it's `null`;
- check if `viewTag` is null and if it's null then print a warning.

## 🤔 How Has This Been Tested?

Tested on iPhone 15 Pro.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/f116dafb-2f67-41d7-9d57-8d3a70fd497a">|<video src="https://github.com/user-attachments/assets/d70994cb-18bf-439e-bd01-8319e209fcdd">|


## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
