### PR TITLE
fix: increase minimum ios deployment to 12

### DIFF
--- a/react-native-keyboard-controller.podspec
+++ b/react-native-keyboard-controller.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "11.0" }
+  s.platforms    = { :ios => "12.0" }
   s.source       = { :git => "https://github.com/kirillzyusko/react-native-keyboard-controller.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"


### PR DESCRIPTION
## 📜 Description

Increase ios minimum deployment to 12

## 💡 Motivation and Context

When new arch is enabled xcode will complain with the following error in the latest RN version 0.75.3:

```
error: 'value' is unavailable: introduced in iOS 12.0
```

![Screenshot 2024-09-13 at 14 20 16](https://github.com/user-attachments/assets/072bf4f8-86a7-452a-814a-67974015906d)


## 📢 Changelog

### iOS

- Increase ios minimum deployment to 12


## 🤔 How Has This Been Tested?

Run pod install and build again in xcode.

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
