### PR TITLE
fix: `KeyboardToolbar` in `Modal` on Android

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
@@ -22,10 +22,10 @@ class KeyboardControllerModuleImpl(private val mReactContext: ReactApplicationCo
 
   fun dismiss() {
     val activity = mReactContext.currentActivity
-    val view: View? = activity?.currentFocus
+    val view: View? = FocusedInputHolder.get()
 
     if (view != null) {
-      val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+      val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
       imm?.hideSoftInputFromWindow(view.windowToken, 0)
     }
   }
@@ -35,8 +35,7 @@ class KeyboardControllerModuleImpl(private val mReactContext: ReactApplicationCo
       return FocusedInputHolder.focus()
     }
 
-    val activity = mReactContext.currentActivity
-    val view: View? = activity?.currentFocus
+    val view: View? = FocusedInputHolder.get()
 
     if (view != null) {
       ViewHierarchyNavigator.setFocusTo(direction, view)


### PR DESCRIPTION
## 📜 Description

Fixed a problem of non-working `KeyboardToolbar` functionality inside of `Modal` on Android.

## 💡 Motivation and Context

The problem comes from the fact, that `Modal` on Android lives in their own `window` hierarchy and as a result `activity?.currentFocus` is always `null` (`currentFocus` is `null`).

A similar fix was added to iOS in this [commit](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/346/commits/22babd2cd0c63936c812d6e48db94b0235a9974b). On iOS the problem was in fact that we can not retrieve focused input if keyboard is dismissed (unlike Android, because on Android the view still in focus and carret is blinking after even keyboard dismissal). So on Android it was harder to notice that bug (especially when `Modal`s weren't officially supported).

So the fix with replacing `.currentFocus` with `FocusedInputHolder.get()` seems to be pretty reliable, because our `FocusedInputHolder` will always hold a reference to currently focused input (doesn't matter which window contains that input, because we attach `OnGlobalFocusChangeListener` to every window).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- replace `activity?.currentFocus` with `FocusedInputHolder.get()`;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 3A (API 33, emulator).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/f9390eed-f5cb-4e3d-840a-716399527b0b">|<video src="https://github.com/user-attachments/assets/5232d81f-8020-4e9f-a8d1-d145d33d71f1">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
