### PR TITLE
chore: update swiftlint

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -27,6 +27,7 @@
     "instancetype",
     "androidx",
     "swiftlint",
+    "swiftformat",
     "detekt",
     "docsearch",
     "searchbox",

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
   # trailing comma is forced by swiftformat
   - trailing_comma
+  - for_where
 
 line_length:
   warning: 120

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,6 +1,6 @@
 disabled_rules:
+  # trailing comma is forced by swiftformat
   - trailing_comma
-  - for_where
 
 line_length:
   warning: 120
@@ -9,6 +9,10 @@ line_length:
 identifier_name:
   excluded:
     - i # allow `i` variable in cycles
+
+opening_brace:
+  # this is controlled by `swiftformat` and we can not change config of formatter
+  ignore_multiline_statement_conditions: true
 
 excluded:
   - Pods

--- a/ios/extensions/UIResponder.swift
+++ b/ios/extensions/UIResponder.swift
@@ -55,11 +55,7 @@ public extension Optional where Wrapped: UIResponder {
       if let scrollView = currentView as? UIScrollView,
          !(currentView is UITextView),
          scrollView.frame.width >= scrollView.contentSize.width,
-         scrollView.isScrollEnabled
-      // it was fixed in swiftlint https://github.com/realm/SwiftLint/issues/3756 but a new release is not available yet
-      // swiftlint:disable all
-      {
-        // swiftlint:enable all
+         scrollView.isScrollEnabled {
         return scrollView.reactViewTag
       }
 

--- a/ios/extensions/UIResponder.swift
+++ b/ios/extensions/UIResponder.swift
@@ -55,7 +55,8 @@ public extension Optional where Wrapped: UIResponder {
       if let scrollView = currentView as? UIScrollView,
          !(currentView is UITextView),
          scrollView.frame.width >= scrollView.contentSize.width,
-         scrollView.isScrollEnabled {
+         scrollView.isScrollEnabled
+      {
         return scrollView.reactViewTag
       }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "!android/gradlew.bat",
     "!ios/build",
     "!ios/KeyboardControllerNative",
+    "!ios/.swiftlint.yml",
+    "!ios/.swiftformat",
+    "!ios/.clang-format",
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__"


### PR DESCRIPTION
## 📜 Description

Updated `swiftlint` to latest version.

## 💡 Motivation and Context

Updated `swiftlint` to latest version.

Unfortunately I got a conflict between `swiftformat` and `opening_brace` rule from `swiftlint`. So I disabled a specific rule-case `ignore_multiline_statement_conditions` because `swiftformat` handles that.

Additionally I realized that some lint-related configs are included in final npm-bundle, so I added them to ignore list.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- removed lint-related files from npm package;

### iOS

- removed ridiculous lint disabling approach in `UIResponder.swift`;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
