### PR TITLE
fix: invisible `ScrollView` when `OverKeyboardView` is used

### DIFF
--- a/src/views/OverKeyboardView/index.tsx
+++ b/src/views/OverKeyboardView/index.tsx
@@ -12,7 +12,10 @@ const OverKeyboardView = ({
   visible,
 }: PropsWithChildren<OverKeyboardViewProps>) => {
   const { height, width } = useWindowDimensions();
-  const inner = useMemo(() => ({ height, width }), [height, width]);
+  const inner = useMemo(
+    () => ({ position: "absolute", height, width }),
+    [height, width],
+  );
 
   return (
     <RCTOverKeyboardView visible={visible}>

--- a/src/views/OverKeyboardView/index.tsx
+++ b/src/views/OverKeyboardView/index.tsx
@@ -6,13 +6,14 @@ import { useWindowDimensions } from "../../hooks";
 
 import type { OverKeyboardViewProps } from "../../types";
 import type { PropsWithChildren } from "react";
+import type { ViewStyle } from "react-native";
 
 const OverKeyboardView = ({
   children,
   visible,
 }: PropsWithChildren<OverKeyboardViewProps>) => {
   const { height, width } = useWindowDimensions();
-  const inner = useMemo(
+  const inner: ViewStyle = useMemo(
     () => ({ position: "absolute", height, width }),
     [height, width],
   );


### PR DESCRIPTION
## 📜 Description

Fixed a problem when content of `ScrollView` becomes invisible when `OverKeyboardView` is used.

## 💡 Motivation and Context

The problem happens because we stretch inner view to full screen size and if we mount it directly to the children, then it takes all the space and growing containers can not be stretched.

The ideal fix would be to get rid off these hacks with setting `width` + `height`, but I've tried to do that in the past and iOS layout is broken without this workaround. To fix the problem I added `position: "absolute"` - it'll not affect the layout of other elements, because it has a different positioning. For now it works, but in future it would be good place to re-visit and to re-work and come up with a better solution.

Code for reproduction can be found at https://github.com/kirillzyusko/react-native-keyboard-controller/pull/599

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `position: "absolute"` style as style to inner view of `OverKeyboardView`;

## 🤔 How Has This Been Tested?

Tested manually on:
- Pixel 3a (API 33, emulator);
- iPhone 15 Pro (iOS 17.5, simulator).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="400" src="https://github.com/user-attachments/assets/bc699a1a-5c5b-427d-9f8a-3ff90ecc15a9">|<img width="400" src="https://github.com/user-attachments/assets/dab6d457-aaf0-44a3-a3e2-8684cfd1a930">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
