### PR TITLE
fix: non working `GestureDetector` inside `OverKeyboardView`

### DIFF
--- a/src/views/OverKeyboardView/index.tsx
+++ b/src/views/OverKeyboardView/index.tsx
@@ -1,32 +1,35 @@
 import React, { useMemo } from "react";
-import { TouchableWithoutFeedback, View } from "react-native";
+import { Platform, StyleSheet, View } from "react-native";
 
 import { RCTOverKeyboardView } from "../../bindings";
 import { useWindowDimensions } from "../../hooks";
 
 import type { OverKeyboardViewProps } from "../../types";
 import type { PropsWithChildren } from "react";
-import type { ViewStyle } from "react-native";
 
 const OverKeyboardView = ({
   children,
   visible,
 }: PropsWithChildren<OverKeyboardViewProps>) => {
   const { height, width } = useWindowDimensions();
-  const inner: ViewStyle = useMemo(
-    () => ({ position: "absolute", height, width }),
-    [height, width],
+  const inner = useMemo(() => ({ height, width }), [height, width]);
+  const style = useMemo(
+    () => [styles.absolute, Platform.OS === "ios" ? inner : undefined],
+    [inner],
   );
 
   return (
     <RCTOverKeyboardView visible={visible}>
-      {/* TouchableWithoutFeedback is needed to prevent click handing on RootView (Android) */}
-      <TouchableWithoutFeedback>
-        {/* On iOS - stretch view to full window dimensions to make yoga work */}
-        <View style={inner}>{children}</View>
-      </TouchableWithoutFeedback>
+      {/* On iOS - stretch view to full window dimensions to make yoga work */}
+      <View style={style}>{children}</View>
     </RCTOverKeyboardView>
   );
 };
+
+const styles = StyleSheet.create({
+  absolute: {
+    position: "absolute",
+  },
+});
 
 export default OverKeyboardView;


### PR DESCRIPTION
## 📜 Description

Fixed integration of `GestureDetector` inside `OverKeyboardView`.

## 💡 Motivation and Context

The problem came to the fact that `TouchableWithoutFeedback` kind of intercepted touches and `GestureDetector` didn't receive it. I added `TouchableWithoutFeedback` in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/589 - in that PR it was reasonable to keep it there as it prevented crashes when touch gets handled by `rootView`. However in most cases developers will wrap area in `OverKeyboardView` in `Touchable*` to handle closing of their views, so now for me it seems to be safe to remove it.

The second thing is that if we apply styles to stretch inner view in JS then `GestureDetector` becomes broken again. I added this fix as iOS only and back to the time I haven't discovered any issues on Android. Now I see, that it introduces some edge-case bugs, so I apply this style/fix conditionally (iOS only).

Applying these 2 fixes `GestureDetector` can work in `OverKeyboardView`.

Fixes an issue discovered in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/599

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- removed `TouchableWithoutFeedback`;
- apply `width`/`height` style only for `ios`.

## 🤔 How Has This Been Tested?

Tested manually on Pixel 3a (API 33, emulator) and Pixel 7 Pro (API 34, real device).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/b26347e8-38ee-48b8-ba2c-2a5f4a354c70">|<video src="https://github.com/user-attachments/assets/5b54733b-9f2d-4c73-80ce-441c1f43c7a6">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
