### PR TITLE
docs: add info about view props inheritance to `KeyboardAvoidingView` page

### DIFF
--- a/docs/docs/api/components/keyboard-avoiding-view.mdx
+++ b/docs/docs/api/components/keyboard-avoiding-view.mdx
@@ -110,6 +110,10 @@ const styles = StyleSheet.create({
 
 ## Props
 
+### [`View Props`](https://reactnative.dev/docs/view#props)
+
+Inherits [View Props](https://reactnative.dev/docs/view#props).
+
 ### `behavior`
 
 Specify how to react to the presence of the keyboard. Could be one value of:

--- a/docs/versioned_docs/version-1.10.0/api/components/keyboard-avoiding-view.mdx
+++ b/docs/versioned_docs/version-1.10.0/api/components/keyboard-avoiding-view.mdx
@@ -110,6 +110,10 @@ const styles = StyleSheet.create({
 
 ## Props
 
+### [`View Props`](https://reactnative.dev/docs/view#props)
+
+Inherits [View Props](https://reactnative.dev/docs/view#props).
+
 ### `behavior`
 
 Specify how to react to the presence of the keyboard. Could be one value of:

--- a/docs/versioned_docs/version-1.11.0/api/components/keyboard-avoiding-view.mdx
+++ b/docs/versioned_docs/version-1.11.0/api/components/keyboard-avoiding-view.mdx
@@ -110,6 +110,10 @@ const styles = StyleSheet.create({
 
 ## Props
 
+### [`View Props`](https://reactnative.dev/docs/view#props)
+
+Inherits [View Props](https://reactnative.dev/docs/view#props).
+
 ### `behavior`
 
 Specify how to react to the presence of the keyboard. Could be one value of:

--- a/docs/versioned_docs/version-1.12.0/api/components/keyboard-avoiding-view.mdx
+++ b/docs/versioned_docs/version-1.12.0/api/components/keyboard-avoiding-view.mdx
@@ -110,6 +110,10 @@ const styles = StyleSheet.create({
 
 ## Props
 
+### [`View Props`](https://reactnative.dev/docs/view#props)
+
+Inherits [View Props](https://reactnative.dev/docs/view#props).
+
 ### `behavior`
 
 Specify how to react to the presence of the keyboard. Could be one value of:

--- a/docs/versioned_docs/version-1.13.0/api/components/keyboard-avoiding-view.mdx
+++ b/docs/versioned_docs/version-1.13.0/api/components/keyboard-avoiding-view.mdx
@@ -110,6 +110,10 @@ const styles = StyleSheet.create({
 
 ## Props
 
+### [`View Props`](https://reactnative.dev/docs/view#props)
+
+Inherits [View Props](https://reactnative.dev/docs/view#props).
+
 ### `behavior`
 
 Specify how to react to the presence of the keyboard. Could be one value of:

--- a/docs/versioned_docs/version-1.7.0/api/components/keyboard-avoiding-view.mdx
+++ b/docs/versioned_docs/version-1.7.0/api/components/keyboard-avoiding-view.mdx
@@ -110,6 +110,10 @@ const styles = StyleSheet.create({
 
 ## Props
 
+### [`View Props`](https://reactnative.dev/docs/view#props)
+
+Inherits [View Props](https://reactnative.dev/docs/view#props).
+
 ### `behavior`
 
 Specify how to react to the presence of the keyboard. Could be one value of:

--- a/docs/versioned_docs/version-1.8.0/api/components/keyboard-avoiding-view.mdx
+++ b/docs/versioned_docs/version-1.8.0/api/components/keyboard-avoiding-view.mdx
@@ -110,6 +110,10 @@ const styles = StyleSheet.create({
 
 ## Props
 
+### [`View Props`](https://reactnative.dev/docs/view#props)
+
+Inherits [View Props](https://reactnative.dev/docs/view#props).
+
 ### `behavior`
 
 Specify how to react to the presence of the keyboard. Could be one value of:

--- a/docs/versioned_docs/version-1.9.0/api/components/keyboard-avoiding-view.mdx
+++ b/docs/versioned_docs/version-1.9.0/api/components/keyboard-avoiding-view.mdx
@@ -110,6 +110,10 @@ const styles = StyleSheet.create({
 
 ## Props
 
+### [`View Props`](https://reactnative.dev/docs/view#props)
+
+Inherits [View Props](https://reactnative.dev/docs/view#props).
+
 ### `behavior`
 
 Specify how to react to the presence of the keyboard. Could be one value of:


### PR DESCRIPTION
## 📜 Description

Add info about view props inheritance for `KeyboardAvoidingView` component.

## 💡 Motivation and Context

It may be useful for people to know that `KeyboardAvoidingView` accepts `ViewProps` (to add `testID` for example).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- add info about view props inheritance for `KeyboardAvoidingView` component.

## 🤔 How Has This Been Tested?

Tested on localhost:3000

## 📸 Screenshots (if appropriate):

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/421fa6d6-82de-419b-a56e-f6a50896e10b">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
