### PR TITLE
fix: `KeyboardToolbar` view props inheritance

### DIFF
--- a/docs/docs/api/components/keyboard-toolbar/index.mdx
+++ b/docs/docs/api/components/keyboard-toolbar/index.mdx
@@ -40,7 +40,9 @@ import toolbar from "./toolbar.lottie.json";
 
 ## Props
 
-Inherits [all props from the react-native View component](https://reactnative.dev/docs/view#props).
+### [View Props](https://reactnative.dev/docs/view#props)
+
+Inherits [View Props](https://reactnative.dev/docs/view#props).
 
 ### `button`
 

--- a/docs/docs/api/components/keyboard-toolbar/index.mdx
+++ b/docs/docs/api/components/keyboard-toolbar/index.mdx
@@ -40,7 +40,7 @@ import toolbar from "./toolbar.lottie.json";
 
 ## Props
 
-### [View Props](https://reactnative.dev/docs/view#props)
+### [`View Props`](https://reactnative.dev/docs/view#props)
 
 Inherits [View Props](https://reactnative.dev/docs/view#props).
 

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -150,7 +150,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
 
   return (
     <KeyboardStickyView offset={offset}>
-      <View style={toolbarStyle} testID={TEST_ID_KEYBOARD_TOOLBAR} {...rest}>
+      <View {...rest} style={toolbarStyle} testID={TEST_ID_KEYBOARD_TOOLBAR}>
         {blur}
         {showArrows && (
           <>


### PR DESCRIPTION
## 📜 Description

Minor tweaks to `KeyboardToolbar` view props inheritance coming from this PR https://github.com/kirillzyusko/react-native-keyboard-controller/pull/603

## 💡 Motivation and Context

I wanted to unify documentation style.

On JS side we should do spreading first, because otherwise unspecified props can overwrite our props and it may lead to unpredictable behavior.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- spread `rest` before specifying other props (because in props declaration we omit props that we use);

### Docs

- unify props inheritance style across documentation style.

## 🤔 How Has This Been Tested?

Tested manually on localhost:3000.

## 📸 Screenshots (if appropriate):

<img width="1423" alt="image" src="https://github.com/user-attachments/assets/4cb3f44c-129b-43e1-a0bf-eeeac7568491">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
