### PR TITLE
refactor: `OverKeyboardView` (variable names, manager interfaces)

### DIFF
--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/OverKeyboardViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/OverKeyboardViewManager.kt
@@ -3,24 +3,23 @@ package com.reactnativekeyboardcontroller
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.OverKeyboardViewManagerDelegate
 import com.facebook.react.viewmanagers.OverKeyboardViewManagerInterface
-import com.facebook.react.views.view.ReactViewGroup
-import com.facebook.react.views.view.ReactViewManager
 import com.reactnativekeyboardcontroller.managers.OverKeyboardViewManagerImpl
 import com.reactnativekeyboardcontroller.views.overlay.OverKeyboardHostShadowNode
 import com.reactnativekeyboardcontroller.views.overlay.OverKeyboardHostView
 
 class OverKeyboardViewManager(
   mReactContext: ReactApplicationContext,
-) : ReactViewManager(),
-  OverKeyboardViewManagerInterface<ReactViewGroup> {
+) : ViewGroupManager<OverKeyboardHostView>(),
+  OverKeyboardViewManagerInterface<OverKeyboardHostView> {
   private val manager = OverKeyboardViewManagerImpl(mReactContext)
   private val mDelegate = OverKeyboardViewManagerDelegate(this)
 
-  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup?> = mDelegate
+  override fun getDelegate(): ViewManagerDelegate<OverKeyboardHostView?> = mDelegate
 
   override fun getName(): String = OverKeyboardViewManagerImpl.NAME
 
@@ -33,9 +32,9 @@ class OverKeyboardViewManager(
 
   @ReactProp(name = "visible")
   override fun setVisible(
-    view: ReactViewGroup?,
+    view: OverKeyboardHostView,
     value: Boolean,
   ) {
-    manager.setVisible(view as OverKeyboardHostView, value)
+    manager.setVisible(view, value)
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardHostShadowNode.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardHostShadowNode.kt
@@ -23,8 +23,8 @@ internal class OverKeyboardHostShadowNode : LayoutShadowNode() {
     i: Int,
   ) {
     super.addChildAt(child, i)
-    val modalSize = themedContext.getDisplaySize()
-    child.setStyleWidth(modalSize.x.toFloat())
-    child.setStyleHeight(modalSize.y.toFloat())
+    val displaySize = themedContext.getDisplaySize()
+    child.setStyleWidth(displaySize.x.toFloat())
+    child.setStyleHeight(displaySize.y.toFloat())
   }
 }


### PR DESCRIPTION
## 📜 Description

Refactored `OverKeyboardView`. Changed managers interfaces, variable names.

## 💡 Motivation and Context

Key points:
- use `displaySize` when we use `getDisplaySize` function;
- inherit from `ViewGroupManager` instead of `ReactViewManager` (same as we do in paper arch).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- `modalSize` -> `displaySize`;
- `ReactViewManager` -> `ViewGroupManager`.

## 🤔 How Has This Been Tested?

Tested on Pixel 3A.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
