### PR TITLE
fix: `OverKeyboardView` stretching on Android (fabric)

### DIFF
--- a/src/views/OverKeyboardView/index.tsx
+++ b/src/views/OverKeyboardView/index.tsx
@@ -14,14 +14,22 @@ const OverKeyboardView = ({
   const { height, width } = useWindowDimensions();
   const inner = useMemo(() => ({ height, width }), [height, width]);
   const style = useMemo(
-    () => [styles.absolute, Platform.OS === "ios" ? inner : undefined],
+    () => [
+      styles.absolute,
+      // On iOS - stretch view to full window dimensions to make yoga work
+      // On Android Fabric we temporarily use the same approach
+      // @ts-expect-error `_IS_FABRIC` is injected by REA
+      Platform.OS === "ios" || global._IS_FABRIC ? inner : undefined,
+    ],
     [inner],
   );
 
   return (
     <RCTOverKeyboardView visible={visible}>
-      {/* On iOS - stretch view to full window dimensions to make yoga work */}
-      <View style={style}>{children}</View>
+      {/* `OverKeyboardView` should always have a single child */}
+      <View collapsable={false} style={style}>
+        {children}
+      </View>
     </RCTOverKeyboardView>
   );
 };


### PR DESCRIPTION
## 📜 Description

Fixed a problem when `OverKeyboardView` is not stretched to the full screen (it's a workaround while I'm working on a proper fix).

## 💡 Motivation and Context

The problem comes form the fact, that an approach (setting up layout from `ShadowNode`) doesn't work on Fabric, because `ShadowNode`s lives in C++ code now.

It's a pretty big task to add C++ code, an actual fix, make file, set up everything etc., so to workaround this problem I simply add height/width style from JS. This approach doesn't break `GestureDetector` on Fabric (the fix and problem was described in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/602), so as a temporary workaround it can be used.

The downsides of this fix are:
- we rely on `_IS_FABRIC` variable injected by REA (this part is not documented anywhere in the code);
- `navigationBar` is not covered, because `useWindowDimension` hook doesn't include it in its calculations.

So we anyway will have to invent a better fix, but to unlock a release process let's merge this workaround.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `global._IS_FABRIC` check to workaround the problem;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 3A (API 33, emulator).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="408" alt="image" src="https://github.com/user-attachments/assets/812121a6-fe59-481c-bed6-68ba796473d8">|<img width="404" alt="image" src="https://github.com/user-attachments/assets/4d4c999e-23fa-4d6f-9661-ae428ae66f78">|
|<video src="https://github.com/user-attachments/assets/8c6b2ea1-41b2-4b06-9395-af73ff85d332">|<video src="https://github.com/user-attachments/assets/c98ccd96-dd8b-415b-8659-60cc36c4d4a2">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
