### PR TITLE
e2e: stabilise iOS 18 tests

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -95,7 +95,7 @@ jobs:
   e2e-test:
     name: ⚙️ Automated test cases (iOS-${{ matrix.devices.ios }})
     runs-on: macos-${{ matrix.devices.macos }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       WORKING_DIRECTORY: example
     concurrency:
@@ -108,7 +108,7 @@ jobs:
             { ios: 15, xcode: "13.4.1", macos: 12 },
             { ios: 16, xcode: "14.3.1", macos: 14 },
             { ios: 17, xcode: "15.4", macos: 14 },
-            { ios: 18, xcode: "16-beta", macos: 14 },
+            { ios: 18, xcode: "16.0", macos: 14 },
           ]
     needs: build
     steps:


### PR DESCRIPTION
## 📜 Description

Stabilized e2e tests on iOS 18.

## 💡 Motivation and Context

Improved stability of e2e tests on CI (iOS 18) by increasing timeout and locking XCode version.

For me it looks like iOS 18 and detox still doesn't work well together, but we can't do anything here at the moment, so I'm just increasing timeout to increase a probability of passing e2e tests.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- increased timeout to 90 minutes;
- locked XCode to stable `16.0` version;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
