### PR TITLE
fix: interactive `KeyboardAvoidingView`

### DIFF
--- a/src/components/KeyboardAvoidingView/hooks.ts
+++ b/src/components/KeyboardAvoidingView/hooks.ts
@@ -27,6 +27,12 @@ export const useKeyboardAnimation = () => {
         progress.value = e.progress;
         height.value = e.height;
       },
+      onInteractive: (e) => {
+        "worklet";
+
+        progress.value = e.progress;
+        height.value = e.height;
+      },
       onEnd: (e) => {
         "worklet";
 


### PR DESCRIPTION
## 📜 Description

Make `KeyboardAvoidingView` resizable when keyboard moved in an interactive way.

## 💡 Motivation and Context

Even though adding `onInteractive` doesn't fully solve the problem, it's still better to move layout even though scrolling speed will be 2x.

At least it'll give a feeling, that it works but not very properly rather than not working at all.

Later on I may revisit this problem and try to find a way how to resize it in a correct way 👀 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/594

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `onInteractive` handler to `KeyboardAvoidingView`;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/05c9c812-7e2c-4969-aee0-64edf49ae584">|<video src="https://github.com/user-attachments/assets/acbbf7c6-586d-40ff-910f-39626d078c49">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
