### PR TITLE
fix: install additional iOS runtimes

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -42,6 +42,9 @@ jobs:
           xcode-version: "15.4"
       - name: Get Xcode version
         run: xcodebuild -version
+      - uses: muukii/actions-xcode-install-simulator@main
+        with:
+          ios_version: "15.5"
       - name: Save yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -42,9 +42,6 @@ jobs:
           xcode-version: "15.4"
       - name: Get Xcode version
         run: xcodebuild -version
-      - uses: muukii/actions-xcode-install-simulator@main
-        with:
-          ios_version: "15.5"
       - name: Save yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -97,7 +94,7 @@ jobs:
           path: example/ios/build/Build/Products/Release-iphonesimulator/KeyboardControllerExample.app/**
   e2e-test:
     name: ⚙️ Automated test cases (iOS-${{ matrix.devices.ios }})
-    runs-on: macos-${{ matrix.devices.macos }}
+    runs-on: macos-14
     timeout-minutes: 90
     env:
       WORKING_DIRECTORY: example
@@ -108,10 +105,10 @@ jobs:
       matrix:
         devices:
           [
-            { ios: 15, xcode: "13.4.1", macos: 12 },
-            { ios: 16, xcode: "14.3.1", macos: 14 },
-            { ios: 17, xcode: "15.4", macos: 14 },
-            { ios: 18, xcode: "16.0", macos: 14 },
+            { ios: 15, xcode: "14.3.1" },
+            { ios: 16, xcode: "14.3.1" },
+            { ios: 17, xcode: "15.4" },
+            { ios: 18, xcode: "16.0" },
           ]
     needs: build
     steps:
@@ -126,6 +123,9 @@ jobs:
           xcode-version: ${{ matrix.devices.xcode }}
       - name: Get Xcode version
         run: xcodebuild -version
+      - uses: muukii/actions-xcode-install-simulator@main
+        with:
+          ios_version: "15.5"
       - name: List all available simulators
         run: xcrun simctl list
       - name: Install AppleSimulatorUtils

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -105,7 +105,7 @@ jobs:
       matrix:
         devices:
           [
-            { ios: 15, xcode: "14.3.1" },
+            { ios: 15, xcode: "14.3.1", runtime: "15.5" },
             { ios: 16, xcode: "14.3.1" },
             { ios: 17, xcode: "15.4" },
             { ios: 18, xcode: "16.0" },
@@ -123,9 +123,15 @@ jobs:
           xcode-version: ${{ matrix.devices.xcode }}
       - name: Get Xcode version
         run: xcodebuild -version
-      - uses: muukii/actions-xcode-install-simulator@main
+      - name: Install additional iOS runtimes
+        if: ${{ matrix.devices.runtime != '' && matrix.devices.runtime != null }}
+        uses: nick-fields/retry@v3
         with:
-          ios_version: "15.5"
+          timeout_minutes: 10
+          max_attempts: 3
+          command: |
+            brew tap robotsandpencils/made
+            sudo xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'
       - name: List all available simulators
         run: xcrun simctl list
       - name: Install AppleSimulatorUtils


### PR DESCRIPTION
## 📜 Description

Don't use `macos-12` in CI anymore.

## 💡 Motivation and Context

Handling https://github.com/actions/runner-images/issues/10721 in advance

Key points:
- run all tests on `macos-14` runner;
- installation may fail or [hang](https://github.com/kirillzyusko/react-native-keyboard-controller/actions/runs/11271787357/job/31345659022) a process, so I added a retry;
- using cache seams unreasonable, because with and without cache installation takes [the same](https://github.com/kirillzyusko/react-native-keyboard-controller/actions/runs/11271787357/job/31345659344) amount of time;
- install additional runtime only if `runtime` value is provided (otherwise skip operation to execute tests faster).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- added new `Install additional iOS runtimes` step for iOS e2e tests;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
