### PR TITLE
fix: broken `StatusBar` when `Activity` changes

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/StatusBarManagerCompatModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/StatusBarManagerCompatModuleImpl.kt
@@ -2,6 +2,7 @@ package com.reactnativekeyboardcontroller.modules
 
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
+import android.app.Activity
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.view.WindowInsetsCompat
@@ -11,6 +12,7 @@ import com.facebook.react.bridge.UiThreadUtil
 import com.reactnativekeyboardcontroller.extensions.rootView
 import com.reactnativekeyboardcontroller.log.Logger
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
+import java.lang.ref.WeakReference
 
 private val TAG = StatusBarManagerCompatModuleImpl::class.qualifiedName
 
@@ -18,6 +20,7 @@ class StatusBarManagerCompatModuleImpl(
   private val mReactContext: ReactApplicationContext,
 ) {
   private var controller: WindowInsetsControllerCompat? = null
+  private var lastActivity = WeakReference<Activity?>(null)
 
   fun setHidden(hidden: Boolean) {
     UiThreadUtil.runOnUiThread {
@@ -71,8 +74,9 @@ class StatusBarManagerCompatModuleImpl(
   }
 
   private fun getController(): WindowInsetsControllerCompat? {
-    if (this.controller == null) {
-      val activity = mReactContext.currentActivity
+    val activity = mReactContext.currentActivity
+
+    if (this.controller == null || activity != lastActivity.get()) {
       if (activity == null) {
         Logger.w(
           TAG,
@@ -82,6 +86,7 @@ class StatusBarManagerCompatModuleImpl(
       }
 
       val window = activity.window
+      lastActivity = WeakReference(activity)
 
       this.controller = WindowInsetsControllerCompat(window, window.decorView)
     }


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

I suggest keeping track of the last activity and if it changes we should update the controller with the current window

## 💡 Motivation and Context

StatusBar is not responding when the activity changes - see [issue](https://github.com/Expensify/App/issues/48782#issue-2513801944).

The problem is located [here](https://github.com/kirillzyusko/react-native-keyboard-controller/blob/bb5e9e1d1e00278ce800b9558b75e56ff799abda/android/src/main/java/com/reactnativekeyboardcontroller/modules/StatusBarManagerCompatModuleImpl.kt#L74) in `getController` method.

We check if the controller is not `null` but if the activity changes (is closed and reopened) the controller is initialized and points to a non-existent window (taken from the previous activity), so we won't update the controller.

Outdated controller can't control the StatusBar (it doesn't have access to the current window)

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- fixed status bar when activity changes

## 🤔 How Has This Been Tested?

Tested manually in Expensify project.

### Android only

I tested it with Expensify HybridApp. For those who don't have access to it, the flow looks like this:
- open activity A (which doesn't use keyboard controller)
- activity A opens activity B (which is New Expensify app)
- activity B can control the status bar
- close activity B
- reopen activity B
- the status bar can't be modified

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img src="https://private-user-images.githubusercontent.com/10736861/365645072-c41c4a52-d562-4870-9ab2-61aae20c5e17.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mjg1Nzk0NjYsIm5iZiI6MTcyODU3OTE2NiwicGF0aCI6Ii8xMDczNjg2MS8zNjU2NDUwNzItYzQxYzRhNTItZDU2Mi00ODcwLTlhYjItNjFhYWUyMGM1ZTE3LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEwMTAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMDEwVDE2NTI0NlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTZmZGNiZGZlZjA3MjgwZWY5NDBkZTBiODg4ODk3MDEyMzhkMDcxZmRlYTY0YmRlOGJlNGE2M2E3NTg0MTEzN2UmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.DPVEO8T2s4kBvI9aG1XA9uOq0zLwRrxdzCvRgypHtVw">|<img src="https://private-user-images.githubusercontent.com/10736861/365645078-970452d0-a0c5-4190-b219-bf3571c4349e.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mjg1Nzk0NjYsIm5iZiI6MTcyODU3OTE2NiwicGF0aCI6Ii8xMDczNjg2MS8zNjU2NDUwNzgtOTcwNDUyZDAtYTBjNS00MTkwLWIyMTktYmYzNTcxYzQzNDllLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEwMTAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMDEwVDE2NTI0NlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTM0NTk4ZDIwZmExYjE4ODRjYzU5OWI0ZDQ1ZGI4NjYxN2YzODNmNGY3ZWY2ZGQ1N2YyZWVhNzU0NDZjMWI3ZTEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.j0lTP8XGIQlGhFCT7E5JmLEYsSgIWbbk1Y2zI76ODyk">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
