### PR TITLE
fix: unmount `OverKeyboardView` from native side

### DIFF
--- a/ios/views/OverKeyboardViewManager.mm
+++ b/ios/views/OverKeyboardViewManager.mm
@@ -106,6 +106,14 @@ RCT_EXPORT_VIEW_PROPERTY(visible, BOOL)
 }
 #endif
 
+// MARK: lifecycle methods
+- (void)didMoveToSuperview
+{
+  if (self.superview == nil) {
+    [self hide];
+  }
+}
+
 // MARK: touch handling
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {


### PR DESCRIPTION
## 📜 Description

Fixed `OverKeyboardView` unmount if view is attached to `.lastWindow`.

## 💡 Motivation and Context

The key problem here is the fact that we unmount a view in JS, but `visible` property remains `true`, as a result view keeps mounted.

It doesn't happen when keyboard is visible, because in this case keyboard window gets destroyed and view gets destroyed as well. But when we attache a view to `.lastWindow` then we catch a bug.

This bug doesn't happen in Android, because on Android we've implemented `onDetachedFromWindow` where we call `hide`. I thought it would be reasonable to implement the same approach, so I added `didMoveToSuperview` method where I'm checking that unmount happened (i. e. `superview` is `nil`) and if so then I call `hide`.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/632

## 📢 Changelog

### iOS

- add lifecycles regions;
- add `didMoveToSuperview` method implementation;
- check if `superview==nil` and call `hide` in this case.

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro (iOS 17.5).

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/b1f501fe-c20a-40c4-b1f8-c212552e7651

## 📝 Checklist

- [x] CI successfully passed
- [x]  I added new mocks and corresponding unit-tests if library API was changed
