### PR TITLE
fix: deprecated `keyWindow` usage

### DIFF
--- a/ios/extensions/UIApplication.swift
+++ b/ios/extensions/UIApplication.swift
@@ -26,7 +26,7 @@ public extension UIApplication {
   }
 
   static func topViewController(
-    base: UIViewController? = UIApplication.shared.keyWindow?.rootViewController
+    base: UIViewController? = UIApplication.shared.activeWindow?.rootViewController
   ) -> UIViewController? {
     if let nav = base as? UINavigationController {
       return topViewController(base: nav.visibleViewController)

--- a/ios/extensions/UIView.swift
+++ b/ios/extensions/UIView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 public extension UIView {
   var globalFrame: CGRect? {
-    let rootView = UIApplication.shared.keyWindow?.rootViewController?.view
+    let rootView = UIApplication.shared.activeWindow?.rootViewController?.view
     return superview?.convert(frame, to: rootView)
   }
 }


### PR DESCRIPTION
## 📜 Description

Replaced the usage of deprecated `keyWindow` with our `activeWindow` extension (which is not depecated).

## 💡 Motivation and Context

We shouldn't rely on deprecated syntax.

In https://github.com/kirillzyusko/react-native-keyboard-controller/pull/621 we added `.activeWindow` extension which represents a better alternative to `.keyWindow`.

So I thought it would be better to not use deprecated syntax anymore and use new extension.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- replace `.keyWindow` with `.activeWindow`;

## 🤔 How Has This Been Tested?

Tested manually on CI (e2e tests).

## 📸 Screenshots (if appropriate):

|Before|After|
|------|------|
|<img width="1709" alt="image" src="https://github.com/user-attachments/assets/5e7bfe97-ad64-4871-8d0e-3405034f1eb6">|<img width="1741" alt="image" src="https://github.com/user-attachments/assets/298c1e4e-d499-48a3-990d-2c1c0e21b699">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
