### PR TITLE
fix: hide `OverKeyboardView` on app reload

### DIFF
--- a/ios/views/OverKeyboardViewManager.mm
+++ b/ios/views/OverKeyboardViewManager.mm
@@ -102,9 +102,18 @@ RCT_EXPORT_VIEW_PROPERTY(visible, BOOL)
     _touchHandler = [[RCTTouchHandler alloc] initWithBridge:bridge];
     _contentView = [[UIView alloc] initWithFrame:CGRectZero];
   }
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(hide)
+                                               name:RCTJavaScriptWillStartLoadingNotification
+                                             object:nil];
   return self;
 }
 #endif
+
+- (void)dealloc
+{
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
 
 // MARK: lifecycle methods
 - (void)didMoveToSuperview


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

-
-

### iOS

-
-

### Android

-
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/e94240bf-ddac-4e97-97ab-faa5f262c5e1">|<video src="https://github.com/user-attachments/assets/c069277a-74b4-4b4a-91ad-12a852f89abb">|

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
