### PR TITLE
refactor: do not use event names as magic values

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputLayoutChangedEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputLayoutChangedEvent.kt
@@ -20,7 +20,7 @@ class FocusedInputLayoutChangedEvent(
   viewId: Int,
   private val event: FocusedInputLayoutChangedEventData,
 ) : Event<FocusedInputLayoutChangedEvent>(surfaceId, viewId) {
-  override fun getEventName() = "topFocusedInputLayoutChanged"
+  override fun getEventName() = EVENT_NAME
 
   // All events for a given view can be coalesced
   override fun getCoalescingKey(): Short = 0
@@ -41,4 +41,8 @@ class FocusedInputLayoutChangedEvent(
         },
       )
     }
+
+  companion object {
+    const val EVENT_NAME = "topFocusedInputLayoutChanged"
+  }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputSelectionChangedEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputSelectionChangedEvent.kt
@@ -19,7 +19,7 @@ class FocusedInputSelectionChangedEvent(
   viewId: Int,
   private val event: FocusedInputSelectionChangedEventData,
 ) : Event<FocusedInputSelectionChangedEvent>(surfaceId, viewId) {
-  override fun getEventName() = "topFocusedInputSelectionChanged"
+  override fun getEventName() = EVENT_NAME
 
   // All events for a given view can be coalesced
   override fun getCoalescingKey(): Short = 0
@@ -49,4 +49,8 @@ class FocusedInputSelectionChangedEvent(
         },
       )
     }
+
+  companion object {
+    const val EVENT_NAME = "topFocusedInputSelectionChanged"
+  }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputTextChangedEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/FocusedInputTextChangedEvent.kt
@@ -9,7 +9,7 @@ class FocusedInputTextChangedEvent(
   viewId: Int,
   private val text: String,
 ) : Event<FocusedInputTextChangedEvent>(surfaceId, viewId) {
-  override fun getEventName() = "topFocusedInputTextChanged"
+  override fun getEventName() = EVENT_NAME
 
   // All events for a given view can be coalesced
   override fun getCoalescingKey(): Short = 0
@@ -18,4 +18,8 @@ class FocusedInputTextChangedEvent(
     Arguments.createMap().apply {
       putString("text", text)
     }
+
+  companion object {
+    const val EVENT_NAME = "topFocusedInputTextChanged"
+  }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
@@ -8,13 +8,13 @@ import com.facebook.react.uimanager.events.Event
 class KeyboardTransitionEvent(
   surfaceId: Int,
   viewId: Int,
-  private val event: String,
+  private val event: EventName,
   private val height: Double,
   private val progress: Double,
   private val duration: Int,
   private val target: Int,
 ) : Event<KeyboardTransitionEvent>(surfaceId, viewId) {
-  override fun getEventName() = event
+  override fun getEventName() = event.value
 
   // All events for a given view can be coalesced?
   override fun getCoalescingKey(): Short = 0
@@ -26,4 +26,23 @@ class KeyboardTransitionEvent(
       putInt("duration", duration)
       putInt("target", target)
     }
+
+  companion object {
+    const val MOVE_EVENT_NAME = "topKeyboardMove"
+    const val START_EVENT_NAME = "topKeyboardMoveStart"
+    const val END_EVENT_NAME = "topKeyboardMoveEnd"
+    const val INTERACTIVE_EVENT_NAME = "topKeyboardMoveInteractive"
+
+    enum class EventName(val value: String) {
+      Move(MOVE_EVENT_NAME),
+      Start(START_EVENT_NAME),
+      End(END_EVENT_NAME),
+      Interactive(INTERACTIVE_EVENT_NAME)
+    }
+
+    val Move get() = EventName.Move
+    val Start get() = EventName.Start
+    val End get() = EventName.End
+    val Interactive get() = EventName.Interactive
+  }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
@@ -28,23 +28,18 @@ class KeyboardTransitionEvent(
     }
 
   companion object {
-    const val MOVE_EVENT_NAME = "topKeyboardMove"
-    const val START_EVENT_NAME = "topKeyboardMoveStart"
-    const val END_EVENT_NAME = "topKeyboardMoveEnd"
-    const val INTERACTIVE_EVENT_NAME = "topKeyboardMoveInteractive"
-
     enum class EventName(
       val value: String,
     ) {
-      Move(MOVE_EVENT_NAME),
-      Start(START_EVENT_NAME),
-      End(END_EVENT_NAME),
-      Interactive(INTERACTIVE_EVENT_NAME),
+      Move("topKeyboardMove"),
+      Start("topKeyboardMoveStart"),
+      End("topKeyboardMoveEnd"),
+      Interactive("topKeyboardMoveInteractive"),
     }
 
-    val Move get() = EventName.Move
-    val Start get() = EventName.Start
-    val End get() = EventName.End
-    val Interactive get() = EventName.Interactive
+    val Move = EventName.Move
+    val Start = EventName.Start
+    val End = EventName.End
+    val Interactive = EventName.Interactive
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
@@ -33,11 +33,13 @@ class KeyboardTransitionEvent(
     const val END_EVENT_NAME = "topKeyboardMoveEnd"
     const val INTERACTIVE_EVENT_NAME = "topKeyboardMoveInteractive"
 
-    enum class EventName(val value: String) {
+    enum class EventName(
+      val value: String,
+    ) {
       Move(MOVE_EVENT_NAME),
       Start(START_EVENT_NAME),
       End(END_EVENT_NAME),
-      Interactive(INTERACTIVE_EVENT_NAME)
+      Interactive(INTERACTIVE_EVENT_NAME),
     }
 
     val Move get() = EventName.Move

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -79,7 +79,7 @@ class KeyboardAnimationCallback(
             KeyboardTransitionEvent(
               surfaceId,
               eventPropagationView.id,
-              "topKeyboardMoveStart",
+              KeyboardTransitionEvent.Start,
               this.persistentKeyboardHeight,
               1.0,
               0,
@@ -91,7 +91,7 @@ class KeyboardAnimationCallback(
             KeyboardTransitionEvent(
               surfaceId,
               eventPropagationView.id,
-              "topKeyboardMoveEnd",
+              KeyboardTransitionEvent.End,
               this.persistentKeyboardHeight,
               1.0,
               0,
@@ -203,7 +203,7 @@ class KeyboardAnimationCallback(
       KeyboardTransitionEvent(
         surfaceId,
         eventPropagationView.id,
-        "topKeyboardMoveStart",
+        KeyboardTransitionEvent.Start,
         keyboardHeight,
         if (!isKeyboardVisible) 0.0 else 1.0,
         duration,
@@ -258,7 +258,7 @@ class KeyboardAnimationCallback(
       "DiffY: $diffY $height $progress ${InteractiveKeyboardProvider.isInteractive} $viewTagFocused",
     )
 
-    val event = if (InteractiveKeyboardProvider.isInteractive) "topKeyboardMoveInteractive" else "topKeyboardMove"
+    val event = if (InteractiveKeyboardProvider.isInteractive) KeyboardTransitionEvent.Interactive else KeyboardTransitionEvent.Move
     context.dispatchEvent(
       eventPropagationView.id,
       KeyboardTransitionEvent(
@@ -315,7 +315,7 @@ class KeyboardAnimationCallback(
       KeyboardTransitionEvent(
         surfaceId,
         eventPropagationView.id,
-        "topKeyboardMoveEnd",
+        KeyboardTransitionEvent.End,
         keyboardHeight,
         if (!isKeyboardVisible) 0.0 else 1.0,
         duration,
@@ -343,7 +343,7 @@ class KeyboardAnimationCallback(
       getEventParams(keyboardHeight),
     )
     // dispatch `onMove` to update RN animated value and `onEnd` to indicate that transition finished
-    listOf("topKeyboardMove", "topKeyboardMoveEnd").forEach { eventName ->
+    listOf(KeyboardTransitionEvent.Move, KeyboardTransitionEvent.End).forEach { eventName ->
       context.dispatchEvent(
         eventPropagationView.id,
         KeyboardTransitionEvent(
@@ -371,7 +371,7 @@ class KeyboardAnimationCallback(
     duration = 0
 
     context.emitEvent("KeyboardController::keyboardWillShow", getEventParams(keyboardHeight))
-    listOf("topKeyboardMoveStart", "topKeyboardMove", "topKeyboardMoveEnd").forEach { eventName ->
+    listOf(KeyboardTransitionEvent.Start, KeyboardTransitionEvent.Move, KeyboardTransitionEvent.End).forEach { eventName ->
       context.dispatchEvent(
         eventPropagationView.id,
         KeyboardTransitionEvent(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -258,7 +258,12 @@ class KeyboardAnimationCallback(
       "DiffY: $diffY $height $progress ${InteractiveKeyboardProvider.isInteractive} $viewTagFocused",
     )
 
-    val event = if (InteractiveKeyboardProvider.isInteractive) KeyboardTransitionEvent.Interactive else KeyboardTransitionEvent.Move
+    val event =
+      if (InteractiveKeyboardProvider.isInteractive) {
+        KeyboardTransitionEvent.Interactive
+      } else {
+        KeyboardTransitionEvent.Move
+      }
     context.dispatchEvent(
       eventPropagationView.id,
       KeyboardTransitionEvent(
@@ -371,7 +376,11 @@ class KeyboardAnimationCallback(
     duration = 0
 
     context.emitEvent("KeyboardController::keyboardWillShow", getEventParams(keyboardHeight))
-    listOf(KeyboardTransitionEvent.Start, KeyboardTransitionEvent.Move, KeyboardTransitionEvent.End).forEach { eventName ->
+    listOf(
+      KeyboardTransitionEvent.Start,
+      KeyboardTransitionEvent.Move,
+      KeyboardTransitionEvent.End,
+    ).forEach { eventName ->
       context.dispatchEvent(
         eventPropagationView.id,
         KeyboardTransitionEvent(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -3,6 +3,10 @@ package com.reactnativekeyboardcontroller.managers
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
+import com.reactnativekeyboardcontroller.events.FocusedInputLayoutChangedEvent
+import com.reactnativekeyboardcontroller.events.FocusedInputSelectionChangedEvent
+import com.reactnativekeyboardcontroller.events.FocusedInputTextChangedEvent
+import com.reactnativekeyboardcontroller.events.KeyboardTransitionEvent
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
 @Suppress("detekt:UnusedPrivateProperty")
@@ -36,19 +40,19 @@ class KeyboardControllerViewManagerImpl(
   fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
     val map: MutableMap<String, Any> =
       MapBuilder.of(
-        "topKeyboardMove",
+        KeyboardTransitionEvent.Move.value,
         MapBuilder.of("registrationName", "onKeyboardMove"),
-        "topKeyboardMoveStart",
+        KeyboardTransitionEvent.Start.value,
         MapBuilder.of("registrationName", "onKeyboardMoveStart"),
-        "topKeyboardMoveEnd",
+        KeyboardTransitionEvent.End.value,
         MapBuilder.of("registrationName", "onKeyboardMoveEnd"),
-        "topKeyboardMoveInteractive",
+        KeyboardTransitionEvent.Interactive.value,
         MapBuilder.of("registrationName", "onKeyboardMoveInteractive"),
-        "topFocusedInputLayoutChanged",
+        FocusedInputLayoutChangedEvent.EVENT_NAME,
         MapBuilder.of("registrationName", "onFocusedInputLayoutChanged"),
-        "topFocusedInputTextChanged",
+        FocusedInputTextChangedEvent.EVENT_NAME,
         MapBuilder.of("registrationName", "onFocusedInputTextChanged"),
-        "topFocusedInputSelectionChanged",
+        FocusedInputSelectionChangedEvent.EVENT_NAME,
         MapBuilder.of("registrationName", "onFocusedInputSelectionChanged"),
       )
 


### PR DESCRIPTION
## 📜 Description

Do not use magic values as event names.

## 💡 Motivation and Context

The "magic value" is an anti-pattern. This PR fixes code duplication and creates reusable strings/enums.

I created corresponding `EVENT_NAME` constant for events that are associated with one event. Events that have may have different names but the same structure I created an enum and shortened alias.

This issue was spotted by @IvanIhnatsiukso let's make him happy 😊 

## 📢 Changelog

### Android

- create corresponding `EVENT_NAME` constant as companion object for certain events;
- re-use `EVENT_NAME` in `getName` method and in event mapping;
- create enum for events that may have multiple events;
- re-use enum values in the rest of the code.

## 🤔 How Has This Been Tested?

Tested in CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
