### PR TITLE
fix: do not substitute delegate back if it's `nil`

### DIFF
--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -204,10 +204,10 @@ public class FocusedInputObserver: NSObject {
   }
 
   private func substituteDelegateBack(_ input: UIResponder?) {
-    if let textField = input as? UITextField {
-      textField.delegate = delegate.activeDelegate as? UITextFieldDelegate
-    } else if let textView = input as? UITextView {
-      (textView as? RCTUITextView)?.setForceDelegate(delegate.activeDelegate as? UITextViewDelegate)
+    if let textField = input as? UITextField, let oldDelegate = delegate.activeDelegate as? UITextFieldDelegate {
+      textField.delegate = oldDelegate
+    } else if let textView = input as? UITextView, let oldDelegate = delegate.activeDelegate as? UITextViewDelegate {
+      (textView as? RCTUITextView)?.setForceDelegate(oldDelegate)
     }
   }
 


### PR DESCRIPTION
## 📜 Description

Fixes a problem when all events such as `onFocus`/`onBlur`/etc. will stop working after keyboard dismissal.

## 💡 Motivation and Context

It looks like a delegate in original `TextInput` can be somehow substituted and we are loosing a pointer to original delegate. If on keyboard-hide event we'll substitute delegate with `nil` - we will make all events, such as `onFocus`, `onBlur` etc. not coming to JS.

So the most obvious decision is to check, if we actually have a delegate and do a substitution only in this case.

Of course a rhetorical question arises - if we had original delegate, then injected our delegate, then it was substituted with a new one -> turns out that our events will not come, right? Right. But:
- I don't know how it's possible - I checked RN sources and I don't see a way how delegate can be injected after component creation;
- for now it's still safer to miss events in `keyboard-controller` rather than disable all events at framework level;
- I can not reliably reproduce this in empty project and the issue is reproducible on relatively old devices (iO 15.2).

So yeah, the problem is somewhere deeper, but I don't have an access to the code so can't debug what exactly happens there. So for now it'll be safer not to ruin the RN framework and merge this fix 🙃 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/456

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- check previous delegate presence when substitute delegate back;

## 🤔 How Has This Been Tested?

Tested manually on iOS 15.2

## 📸 Screenshots (if appropriate):

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/a12dcf98-b3ea-4d6f-9c02-c0d132c4e3ac">|<video src="https://github.com/user-attachments/assets/06b1ed57-aa11-4e13-b11d-8233aa5a0bdf">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
