### PR TITLE
docs: troubleshooting page

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -89,57 +89,6 @@ export default function App() {
 
 Congratulations! 🎉 You've just finished installation process. Go to the [next section](./guides/first-animation.md) to get more insights of what you can do using this library. 😎
 
-## Troubleshooting
-
-### Incompatible `kotlinVersion` and failed Android builds
-
-Sometimes you may see failed Android builds complaining that your version of kotlin is lower than expected version.
-
-`error: module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.6.0, expected version is 1.4.1.`
-
-To overcome this issue you will need to set higher version of the kotlin:
-
-#### react-native or expo bare workflow
-
-You need to modify `android/build.gradle` and specify correct `kotlinVersion`:
-
-```java
-buildscript {
-    ext {
-        kotlinVersion = "1.6.21"
-    }
-}
-```
-
-For more information please, see how it's configured in [example](https://github.com/kirillzyusko/react-native-keyboard-controller/blob/9d0e63712a2f55dab0f6f3f95398567bb9ca1efa/example/android/build.gradle#L9) project.
-
-#### Expo managed workflow
-
-If you are using Expo managed workflow you need to install `expo-build-properties`
-
-```sh
-npx expo install expo-build-properties
-```
-
-And add plugin inside of your `app.json` or `app.config.js` with following configuration:
-
-```json
-{
-  "expo": {
-    "plugins": [
-      [
-        "expo-build-properties",
-        {
-          "android": {
-            "kotlinVersion": "1.6.21"
-          }
-        }
-      ]
-    ]
-  }
-}
-```
-
-### Swift support
-
-Since part of this library is written using `swift` language - your project needs to support it. For that you can create empty `.swift` file with bridging header. See this [step-by-step](https://stackoverflow.com/a/56176956/9272042) guide if you have problems.
+:::danger Troubleshooting guide
+If you encounter some issues make sure to read the [Troubleshooting](./troubleshooting.md) section.
+:::

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1,0 +1,62 @@
+# Troubleshooting
+
+This section attempts to outline issues that users frequently encounter when first getting accustomed to using `react-native-keyboard-controller`. These issues may or may not be related to `react-native-keyboard-controller`.
+
+## Incompatible `kotlinVersion` and failed Android builds
+
+Sometimes you may see failed Android builds complaining that your version of kotlin is lower than expected version.
+
+`error: module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.6.0, expected version is 1.4.1.`
+
+To overcome this issue you will need to set higher version of the kotlin:
+
+### `react-native` or `expo` bare workflow
+
+You need to modify `android/build.gradle` and specify correct `kotlinVersion`:
+
+```java
+buildscript {
+    ext {
+        kotlinVersion = "1.6.21"
+    }
+}
+```
+
+For more information please, see how it's configured in [example](https://github.com/kirillzyusko/react-native-keyboard-controller/blob/9d0e63712a2f55dab0f6f3f95398567bb9ca1efa/example/android/build.gradle#L9) project.
+
+### `Expo` managed workflow
+
+If you are using Expo managed workflow you need to install `expo-build-properties`
+
+```sh
+npx expo install expo-build-properties
+```
+
+And add plugin inside of your `app.json` or `app.config.js` with following configuration:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "kotlinVersion": "1.6.21"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+## Swift support
+
+Since part of this library is written using `swift` language - your project needs to support it. For that you can create empty `.swift` file with bridging header. See this [step-by-step](https://stackoverflow.com/a/56176956/9272042) guide if you have problems.
+
+## Animations frame drops
+
+Sometimes you may see that animation performance is poor. If you are using `sentry@5` make sure `enableStallTracking` is disabled (i. e. `enableStallTracking: false`) or upgrade to `sentry@6`,
+
+See [this issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/641) for more details.

--- a/docs/versioned_docs/version-1.14.0/installation.mdx
+++ b/docs/versioned_docs/version-1.14.0/installation.mdx
@@ -89,57 +89,6 @@ export default function App() {
 
 Congratulations! 🎉 You've just finished installation process. Go to the [next section](./guides/first-animation.md) to get more insights of what you can do using this library. 😎
 
-## Troubleshooting
-
-### Incompatible `kotlinVersion` and failed Android builds
-
-Sometimes you may see failed Android builds complaining that your version of kotlin is lower than expected version.
-
-`error: module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.6.0, expected version is 1.4.1.`
-
-To overcome this issue you will need to set higher version of the kotlin:
-
-#### react-native or expo bare workflow
-
-You need to modify `android/build.gradle` and specify correct `kotlinVersion`:
-
-```java
-buildscript {
-    ext {
-        kotlinVersion = "1.6.21"
-    }
-}
-```
-
-For more information please, see how it's configured in [example](https://github.com/kirillzyusko/react-native-keyboard-controller/blob/9d0e63712a2f55dab0f6f3f95398567bb9ca1efa/example/android/build.gradle#L9) project.
-
-#### Expo managed workflow
-
-If you are using Expo managed workflow you need to install `expo-build-properties`
-
-```sh
-npx expo install expo-build-properties
-```
-
-And add plugin inside of your `app.json` or `app.config.js` with following configuration:
-
-```json
-{
-  "expo": {
-    "plugins": [
-      [
-        "expo-build-properties",
-        {
-          "android": {
-            "kotlinVersion": "1.6.21"
-          }
-        }
-      ]
-    ]
-  }
-}
-```
-
-### Swift support
-
-Since part of this library is written using `swift` language - your project needs to support it. For that you can create empty `.swift` file with bridging header. See this [step-by-step](https://stackoverflow.com/a/56176956/9272042) guide if you have problems.
+:::danger Troubleshooting guide
+If you encounter some issues make sure to read the [Troubleshooting](./troubleshooting.md) section.
+:::

--- a/docs/versioned_docs/version-1.14.0/troubleshooting.md
+++ b/docs/versioned_docs/version-1.14.0/troubleshooting.md
@@ -1,0 +1,62 @@
+# Troubleshooting
+
+This section attempts to outline issues that users frequently encounter when first getting accustomed to using `react-native-keyboard-controller`. These issues may or may not be related to `react-native-keyboard-controller`.
+
+## Incompatible `kotlinVersion` and failed Android builds
+
+Sometimes you may see failed Android builds complaining that your version of kotlin is lower than expected version.
+
+`error: module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.6.0, expected version is 1.4.1.`
+
+To overcome this issue you will need to set higher version of the kotlin:
+
+### `react-native` or `expo` bare workflow
+
+You need to modify `android/build.gradle` and specify correct `kotlinVersion`:
+
+```java
+buildscript {
+    ext {
+        kotlinVersion = "1.6.21"
+    }
+}
+```
+
+For more information please, see how it's configured in [example](https://github.com/kirillzyusko/react-native-keyboard-controller/blob/9d0e63712a2f55dab0f6f3f95398567bb9ca1efa/example/android/build.gradle#L9) project.
+
+### `Expo` managed workflow
+
+If you are using Expo managed workflow you need to install `expo-build-properties`
+
+```sh
+npx expo install expo-build-properties
+```
+
+And add plugin inside of your `app.json` or `app.config.js` with following configuration:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "kotlinVersion": "1.6.21"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+## Swift support
+
+Since part of this library is written using `swift` language - your project needs to support it. For that you can create empty `.swift` file with bridging header. See this [step-by-step](https://stackoverflow.com/a/56176956/9272042) guide if you have problems.
+
+## Animations frame drops
+
+Sometimes you may see that animation performance is poor. If you are using `sentry@5` make sure `enableStallTracking` is disabled (i. e. `enableStallTracking: false`) or upgrade to `sentry@6`,
+
+See [this issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/641) for more details.


### PR DESCRIPTION
## 📜 Description

Added new `Troubleshooting` page.

## 💡 Motivation and Context

The installation section seems to contain the information that may be not used directly on this page. So I decided to move the content of this page to separate page + add a new use-case with sentry@v5.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/641

## 📢 Changelog

### Docs

- added dedicated `Troubleshooting` page;
- added a reference to `Troubleshooting` page on `Installation` page.
- added a new use-case with Sentry@v5.

## 🤔 How Has This Been Tested?

Tested via preview.

## 📸 Screenshots (if appropriate):

### Installation

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/5f30d945-0487-490f-af03-1d213a7eae1e">

### Troubleshooting

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/9d086f13-07e0-43c2-a38b-db1791559bd0">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
