### PR TITLE
fix: `OverKeyboardView` compatibility with RN 0.72

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -10,7 +10,6 @@ import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.uimanager.JSPointerDispatcher
 import com.facebook.react.uimanager.JSTouchDispatcher
-import com.facebook.react.uimanager.RootView
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.EventDispatcher
@@ -98,7 +97,7 @@ class OverKeyboardHostView(
 class OverKeyboardRootViewGroup(
   private val reactContext: ThemedReactContext,
 ) : ReactViewGroup(reactContext),
-  RootView {
+  RootViewCompat {
   private val jsTouchDispatcher: JSTouchDispatcher = JSTouchDispatcher(this)
   private var jsPointerDispatcher: JSPointerDispatcher? = null
   internal var eventDispatcher: EventDispatcher? = null

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/RootViewCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/RootViewCompat.kt
@@ -1,0 +1,18 @@
+package com.reactnativekeyboardcontroller.views.overlay
+
+import android.view.MotionEvent
+import com.facebook.react.uimanager.RootView
+
+/**
+ * Compat layer for `RootView` interface for RN < 0.73
+ * which has a default implementation of deprecated method.
+ */
+interface RootViewCompat : RootView {
+  @Deprecated(
+    "This method shouldn't be used anymore.",
+    ReplaceWith("onChildStartedNativeGesture(View childView, MotionEvent ev)")
+  )
+  override fun onChildStartedNativeGesture(ev: MotionEvent?) {
+    onChildStartedNativeGesture(null, ev)
+  }
+}

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/RootViewCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/RootViewCompat.kt
@@ -10,7 +10,7 @@ import com.facebook.react.uimanager.RootView
 interface RootViewCompat : RootView {
   @Deprecated(
     "This method shouldn't be used anymore.",
-    ReplaceWith("onChildStartedNativeGesture(View childView, MotionEvent ev)")
+    ReplaceWith("onChildStartedNativeGesture(View childView, MotionEvent ev)"),
   )
   override fun onChildStartedNativeGesture(ev: MotionEvent?) {
     onChildStartedNativeGesture(null, ev)


### PR DESCRIPTION
## 📜 Description

Added `RootViewCompat` interface to prevent build issues on RN < 0.72. 

## 💡 Motivation and Context

Prior to RN 0.73 `RootView` marked `onChildStartedNativeGesture(ev: MotionEvent?)` as deprecated, but without default implementation, so if you use `RootView` you had to override two methods:
- `onChildStartedNativeGesture(ev: MotionEvent?)`
- `override fun onChildStartedNativeGesture(childView: View, ev: MotionEvent)`;

To fix this problem I decided to introduce common `RootViewCompat` interface that will have a stub for deprecated method.

The reason why I moved it to separate file was mostly following SOLID principles - potentially this interface can be re-used in other parts of application, and I can not implement method directly in `OverKeyboardRootViewGroup` because I'll exceed maximum methods amount (11+).

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/657

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added `RootViewCompat`;
- use `RootViewCompat` instead of `RootView`.

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
