### PR TITLE
Detect react-native-edge-to-edge and bypass statusBarTranslucent / navigationBarTranslucent

### DIFF
--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -4637,6 +4637,11 @@ react-native-gesture-handler@2.18.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-is-edge-to-edge@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.0.tgz#45c0fb4ad2971b6c8dec49f4ace29bea4cf01b40"
+  integrity sha512-WQ14EZDVchiFQ8Xs1KtPhkSPFKHdIm/BVQoElyy6SjzDfFlhP0ERFkAAPmdgmmHjWwYyjm+ibvq1PieT8Xfpbw==
+
 "react-native-keyboard-controller@link:..":
   version "0.0.0"
   uid ""

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -4637,10 +4637,10 @@ react-native-gesture-handler@2.18.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-is-edge-to-edge@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.0.tgz#45c0fb4ad2971b6c8dec49f4ace29bea4cf01b40"
-  integrity sha512-WQ14EZDVchiFQ8Xs1KtPhkSPFKHdIm/BVQoElyy6SjzDfFlhP0ERFkAAPmdgmmHjWwYyjm+ibvq1PieT8Xfpbw==
+react-native-is-edge-to-edge@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.1.tgz#78ee045dab74868a4d1c37df9058c4bdecc28e62"
+  integrity sha512-F/CPckyjLgQNOv8BaUorSyjNv7Ev3eLuzWT+BrIp4504Zw1LAa44M3FPGz5E2nZMcvHHbSmBLHei5M3g+gmLHA==
 
 "react-native-keyboard-controller@link:..":
   version "0.0.0"

--- a/example/android/app/src/main/res/values/styles.xml
+++ b/example/android/app/src/main/res/values/styles.xml
@@ -5,7 +5,8 @@
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
 
-        <!-- Optional: set to transparent if your app is drawing behind the status bar. -->
+        <!-- Optional: If not using react-native-edge-to-edge, set to
+             transparent if your app is drawing behind the status bar. -->
         <item name="android:statusBarColor">
           @android:color/transparent
         </item>

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4747,10 +4747,10 @@ react-native-haptic-feedback@2.3.1:
   resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.3.1.tgz#2ef4ac7d4f63ac06bd64b659f509362f127b16e5"
   integrity sha512-dPfjV4iVHfhVyfG+nRd88ygjahbdup7KFZDM5L2aNIAzqbNtKxHZn5O1pHegwSj1t15VJliu0GyTX7XpBDeXUw==
 
-react-native-is-edge-to-edge@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.0.tgz#45c0fb4ad2971b6c8dec49f4ace29bea4cf01b40"
-  integrity sha512-WQ14EZDVchiFQ8Xs1KtPhkSPFKHdIm/BVQoElyy6SjzDfFlhP0ERFkAAPmdgmmHjWwYyjm+ibvq1PieT8Xfpbw==
+react-native-is-edge-to-edge@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.1.tgz#78ee045dab74868a4d1c37df9058c4bdecc28e62"
+  integrity sha512-F/CPckyjLgQNOv8BaUorSyjNv7Ev3eLuzWT+BrIp4504Zw1LAa44M3FPGz5E2nZMcvHHbSmBLHei5M3g+gmLHA==
 
 "react-native-keyboard-controller@link:..":
   version "0.0.0"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4747,10 +4747,10 @@ react-native-haptic-feedback@2.3.1:
   resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.3.1.tgz#2ef4ac7d4f63ac06bd64b659f509362f127b16e5"
   integrity sha512-dPfjV4iVHfhVyfG+nRd88ygjahbdup7KFZDM5L2aNIAzqbNtKxHZn5O1pHegwSj1t15VJliu0GyTX7XpBDeXUw==
 
-react-native-is-edge-to-edge@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.0.0.tgz#2187d7fa237354e12fddd0f9e84410a850988dbb"
-  integrity sha512-O+6OnYqey8lMyNvWZhWZF6NPBCvZNyeGX6qPvt7EJy310sVa4r05M0enxtmiVZl2xgj5vBJkYhROd5mSmZ/4mA==
+react-native-is-edge-to-edge@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.0.tgz#45c0fb4ad2971b6c8dec49f4ace29bea4cf01b40"
+  integrity sha512-WQ14EZDVchiFQ8Xs1KtPhkSPFKHdIm/BVQoElyy6SjzDfFlhP0ERFkAAPmdgmmHjWwYyjm+ibvq1PieT8Xfpbw==
 
 "react-native-keyboard-controller@link:..":
   version "0.0.0"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4747,6 +4747,11 @@ react-native-haptic-feedback@2.3.1:
   resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.3.1.tgz#2ef4ac7d4f63ac06bd64b659f509362f127b16e5"
   integrity sha512-dPfjV4iVHfhVyfG+nRd88ygjahbdup7KFZDM5L2aNIAzqbNtKxHZn5O1pHegwSj1t15VJliu0GyTX7XpBDeXUw==
 
+react-native-is-edge-to-edge@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.0.0.tgz#2187d7fa237354e12fddd0f9e84410a850988dbb"
+  integrity sha512-O+6OnYqey8lMyNvWZhWZF6NPBCvZNyeGX6qPvt7EJy310sVa4r05M0enxtmiVZl2xgj5vBJkYhROd5mSmZ/4mA==
+
 "react-native-keyboard-controller@link:..":
   version "0.0.0"
   uid ""

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
+  "dependencies": {
+    "react-native-is-edge-to-edge": "^1.0.0"
+  },
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",
     "@react-native/eslint-config": "^0.75.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "react-native-is-edge-to-edge": "^1.1.0"
+    "react-native-is-edge-to-edge": "^1.1.1"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "react-native-is-edge-to-edge": "^1.0.0"
+    "react-native-is-edge-to-edge": "^1.1.0"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -24,6 +24,8 @@ import type {
 } from "./types";
 import type { ViewStyle } from "react-native";
 
+const IS_EDGE_TO_EDGE = isEdgeToEdge();
+
 const KeyboardControllerViewAnimated = Reanimated.createAnimatedComponent(
   Animated.createAnimatedComponent(KeyboardControllerView),
 );
@@ -193,7 +195,7 @@ export const KeyboardProvider = ({
   useEffect(() => {
     if (__DEV__) {
       if (
-        isEdgeToEdge() &&
+        IS_EDGE_TO_EDGE &&
         (statusBarTranslucent !== undefined ||
           navigationBarTranslucent !== undefined)
       ) {
@@ -209,8 +211,8 @@ export const KeyboardProvider = ({
       <KeyboardControllerViewAnimated
         ref={viewTagRef}
         enabled={enabled}
-        navigationBarTranslucent={isEdgeToEdge() || navigationBarTranslucent}
-        statusBarTranslucent={isEdgeToEdge() || statusBarTranslucent}
+        navigationBarTranslucent={IS_EDGE_TO_EDGE || navigationBarTranslucent}
+        statusBarTranslucent={IS_EDGE_TO_EDGE || statusBarTranslucent}
         style={styles.container}
         // on*Reanimated prop must precede animated handlers to work correctly
         onKeyboardMoveReanimated={keyboardHandler}

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -1,7 +1,10 @@
 /* eslint react/jsx-sort-props: off */
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Animated, Platform, StyleSheet } from "react-native";
-import { isEdgeToEdge } from "react-native-is-edge-to-edge";
+import {
+  controlEdgeToEdgeValues,
+  isEdgeToEdge,
+} from "react-native-is-edge-to-edge";
 import Reanimated, { useSharedValue } from "react-native-reanimated";
 
 import { KeyboardControllerView } from "./bindings";
@@ -192,19 +195,9 @@ export const KeyboardProvider = ({
     }
   }, [enabled]);
 
-  useEffect(() => {
-    if (__DEV__) {
-      if (
-        IS_EDGE_TO_EDGE &&
-        (statusBarTranslucent !== undefined ||
-          navigationBarTranslucent !== undefined)
-      ) {
-        console.warn(
-          "statusBarTranslucent and navigationBarTranslucent props are ignored when using edge-to-edge",
-        );
-      }
-    }
-  }, [statusBarTranslucent, navigationBarTranslucent]);
+  if (__DEV__) {
+    controlEdgeToEdgeValues({ statusBarTranslucent, navigationBarTranslucent });
+  }
 
   return (
     <KeyboardContext.Provider value={context}>

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -188,7 +188,9 @@ export const KeyboardProvider = ({
     } else {
       revertMonkeyPatch();
     }
+  }, [enabled]);
 
+  useEffect(() => {
     if (__DEV__) {
       if (
         isEdgeToEdge() &&
@@ -200,7 +202,7 @@ export const KeyboardProvider = ({
         );
       }
     }
-  }, [enabled]);
+  }, [statusBarTranslucent, navigationBarTranslucent]);
 
   return (
     <KeyboardContext.Provider value={context}>

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -198,7 +198,7 @@ export const KeyboardProvider = ({
           navigationBarTranslucent !== undefined)
       ) {
         console.warn(
-          "statusBarTranslucent and navigationBarTranslucent props are ignored when using react-native-edge-to-edge",
+          "statusBarTranslucent and navigationBarTranslucent props are ignored when using edge-to-edge",
         );
       }
     }

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -22,6 +22,7 @@ import type {
   NativeEvent,
 } from "./types";
 import type { ViewStyle } from "react-native";
+import { isEdgeToEdge } from "react-native-is-edge-to-edge";
 
 const KeyboardControllerViewAnimated = Reanimated.createAnimatedComponent(
   Animated.createAnimatedComponent(KeyboardControllerView),
@@ -187,6 +188,18 @@ export const KeyboardProvider = ({
     } else {
       revertMonkeyPatch();
     }
+
+    if (__DEV__) {
+      if (
+        isEdgeToEdge() &&
+        (statusBarTranslucent !== undefined ||
+          navigationBarTranslucent !== undefined)
+      ) {
+        console.warn(
+          "statusBarTranslucent and navigationBarTranslucent props are ignored when using react-native-edge-to-edge",
+        );
+      }
+    }
   }, [enabled]);
 
   return (
@@ -194,8 +207,8 @@ export const KeyboardProvider = ({
       <KeyboardControllerViewAnimated
         ref={viewTagRef}
         enabled={enabled}
-        navigationBarTranslucent={navigationBarTranslucent}
-        statusBarTranslucent={statusBarTranslucent}
+        navigationBarTranslucent={isEdgeToEdge() || navigationBarTranslucent}
+        statusBarTranslucent={isEdgeToEdge() || statusBarTranslucent}
         style={styles.container}
         // on*Reanimated prop must precede animated handlers to work correctly
         onKeyboardMoveReanimated={keyboardHandler}

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -1,6 +1,7 @@
 /* eslint react/jsx-sort-props: off */
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Animated, Platform, StyleSheet } from "react-native";
+import { isEdgeToEdge } from "react-native-is-edge-to-edge";
 import Reanimated, { useSharedValue } from "react-native-reanimated";
 
 import { KeyboardControllerView } from "./bindings";
@@ -22,7 +23,6 @@ import type {
   NativeEvent,
 } from "./types";
 import type { ViewStyle } from "react-native";
-import { isEdgeToEdge } from "react-native-is-edge-to-edge";
 
 const KeyboardControllerViewAnimated = Reanimated.createAnimatedComponent(
   Animated.createAnimatedComponent(KeyboardControllerView),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7685,10 +7685,10 @@ react-native-builder-bob@^0.18.0:
   optionalDependencies:
     jetifier "^2.0.0"
 
-react-native-is-edge-to-edge@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.0.tgz#45c0fb4ad2971b6c8dec49f4ace29bea4cf01b40"
-  integrity sha512-WQ14EZDVchiFQ8Xs1KtPhkSPFKHdIm/BVQoElyy6SjzDfFlhP0ERFkAAPmdgmmHjWwYyjm+ibvq1PieT8Xfpbw==
+react-native-is-edge-to-edge@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.1.tgz#78ee045dab74868a4d1c37df9058c4bdecc28e62"
+  integrity sha512-F/CPckyjLgQNOv8BaUorSyjNv7Ev3eLuzWT+BrIp4504Zw1LAa44M3FPGz5E2nZMcvHHbSmBLHei5M3g+gmLHA==
 
 react-native-reanimated@3.16.1:
   version "3.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7685,6 +7685,11 @@ react-native-builder-bob@^0.18.0:
   optionalDependencies:
     jetifier "^2.0.0"
 
+react-native-is-edge-to-edge@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.0.0.tgz#2187d7fa237354e12fddd0f9e84410a850988dbb"
+  integrity sha512-O+6OnYqey8lMyNvWZhWZF6NPBCvZNyeGX6qPvt7EJy310sVa4r05M0enxtmiVZl2xgj5vBJkYhROd5mSmZ/4mA==
+
 react-native-reanimated@3.16.1:
   version "3.16.1"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.16.1.tgz#7c3cb256adb8fb436f57911d0e8e7cae68e28a67"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7685,10 +7685,10 @@ react-native-builder-bob@^0.18.0:
   optionalDependencies:
     jetifier "^2.0.0"
 
-react-native-is-edge-to-edge@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.0.0.tgz#2187d7fa237354e12fddd0f9e84410a850988dbb"
-  integrity sha512-O+6OnYqey8lMyNvWZhWZF6NPBCvZNyeGX6qPvt7EJy310sVa4r05M0enxtmiVZl2xgj5vBJkYhROd5mSmZ/4mA==
+react-native-is-edge-to-edge@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.0.tgz#45c0fb4ad2971b6c8dec49f4ace29bea4cf01b40"
+  integrity sha512-WQ14EZDVchiFQ8Xs1KtPhkSPFKHdIm/BVQoElyy6SjzDfFlhP0ERFkAAPmdgmmHjWwYyjm+ibvq1PieT8Xfpbw==
 
 react-native-reanimated@3.16.1:
   version "3.16.1"


### PR DESCRIPTION
## 📜 Description

This PR brings `react-native-edge-to-edge` detection to `react-native-keyboard-controller`.

## 💡 Motivation and Context

The future of Android is [edge-to-edge](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge), and to make the React Native developer experience seamless in this regard, the ecosystem needs to transition from “opaque system bars by default” to “edge-to-edge by default.”

To prevent library authors from implementing their own edge-to-edge solutions—which could interfere with other libraries—and because it’s not possible to reliably detect if edge-to-edge is already enabled on Android, we have collaborated with [Expo](https://expo.dev/) to create a library that handles this functionality and is detectable using a simple helper: [`react-native-is-edge-to-edge`](https://github.com/zoontek/react-native-edge-to-edge/tree/main/react-native-is-edge-to-edge).

This approach allows you to bypass certain options and props (in this case, `KeyboardProvider` `statusBarTranslucent` and `navigationBarTranslucent`), helping to avoid frustrating issues like, “My app starts in edge-to-edge, but the system bars reappear immediately.” (because RNKC causes them to reappear)

This PR is intentionally lightweight, as RNKC doesn’t seem to interfere with edge-to-edge when `statusBarTranslucent` and `navigationBarTranslucent` are set to `true`. However, if necessary, you could also use a small helper in Kotlin to skip part of your library code if needed:

```kt
object EdgeToEdge {
  val ENABLED: Boolean
    get() = try {
      // we cannot detect edge-to-edge, but we can detect react-native-edge-to-edge install
      Class.forName("com.zoontek.rnedgetoedge.EdgeToEdgePackage")
      true
    } catch (exception: ClassNotFoundException) {
      false
    }
}
```

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/259

## 📢 Changelog

- Detect `react-native-edge-to-edge` to potentially bypass `statusBarTranslucent` / `navigationBarTranslucent` values.

### JS

- Added a warning about `statusBarTranslucent` / `navigationBarTranslucent` usage when `react-native-edge-to-edge` is installed.

### iOS

- No change (native codebase) ❌

### Android

- No change (native codebase) ❌ 

## 🤔 How Has This Been Tested?

Install [`react-native-edge-to-edge`](https://github.com/zoontek/react-native-edge-to-edge) in the example app.

## 📸 Screenshots (if appropriate):

<img width="521" alt="Screenshot 2024-10-26 at 12 49 14" src="https://github.com/user-attachments/assets/d7c2cb7a-d42f-4d17-95b3-a5f411f4fb62">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
