### PR TITLE
Update react-native-is-edge-to-edge to 1.1.3

### DIFF
--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -4637,10 +4637,10 @@ react-native-gesture-handler@2.18.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-is-edge-to-edge@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.1.tgz#78ee045dab74868a4d1c37df9058c4bdecc28e62"
-  integrity sha512-F/CPckyjLgQNOv8BaUorSyjNv7Ev3eLuzWT+BrIp4504Zw1LAa44M3FPGz5E2nZMcvHHbSmBLHei5M3g+gmLHA==
+react-native-is-edge-to-edge@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.3.tgz#ae290192b7053d0e09e1870c7a17a765f673863a"
+  integrity sha512-wcY560MvZ1yS54TFAfv8L+Df4lzwv44kOVYXpIDNyC2s8FNymkBeOwCEnR7eDCEzBOKZIwCAidcwM5tNFIJ/eQ==
 
 "react-native-keyboard-controller@link:..":
   version "0.0.0"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4747,10 +4747,10 @@ react-native-haptic-feedback@2.3.1:
   resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.3.1.tgz#2ef4ac7d4f63ac06bd64b659f509362f127b16e5"
   integrity sha512-dPfjV4iVHfhVyfG+nRd88ygjahbdup7KFZDM5L2aNIAzqbNtKxHZn5O1pHegwSj1t15VJliu0GyTX7XpBDeXUw==
 
-react-native-is-edge-to-edge@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.1.tgz#78ee045dab74868a4d1c37df9058c4bdecc28e62"
-  integrity sha512-F/CPckyjLgQNOv8BaUorSyjNv7Ev3eLuzWT+BrIp4504Zw1LAa44M3FPGz5E2nZMcvHHbSmBLHei5M3g+gmLHA==
+react-native-is-edge-to-edge@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.3.tgz#ae290192b7053d0e09e1870c7a17a765f673863a"
+  integrity sha512-wcY560MvZ1yS54TFAfv8L+Df4lzwv44kOVYXpIDNyC2s8FNymkBeOwCEnR7eDCEzBOKZIwCAidcwM5tNFIJ/eQ==
 
 "react-native-keyboard-controller@link:..":
   version "0.0.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "react-native-is-edge-to-edge": "^1.1.1"
+    "react-native-is-edge-to-edge": "^1.1.3"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7685,10 +7685,10 @@ react-native-builder-bob@^0.18.0:
   optionalDependencies:
     jetifier "^2.0.0"
 
-react-native-is-edge-to-edge@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.1.tgz#78ee045dab74868a4d1c37df9058c4bdecc28e62"
-  integrity sha512-F/CPckyjLgQNOv8BaUorSyjNv7Ev3eLuzWT+BrIp4504Zw1LAa44M3FPGz5E2nZMcvHHbSmBLHei5M3g+gmLHA==
+react-native-is-edge-to-edge@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.3.tgz#ae290192b7053d0e09e1870c7a17a765f673863a"
+  integrity sha512-wcY560MvZ1yS54TFAfv8L+Df4lzwv44kOVYXpIDNyC2s8FNymkBeOwCEnR7eDCEzBOKZIwCAidcwM5tNFIJ/eQ==
 
 react-native-reanimated@3.16.1:
   version "3.16.1"


### PR DESCRIPTION
## 📜 Description

This PR update react-native-is-edge-to-edge to 1.1.3.

## 💡 Motivation and Context

There's an issue with module resolution when new architecture is enabled: platforms extensions (`index.android.js`) are not resolved for dependencies. I had to switch the package implementation to use `index.js` + `index.web.js` instead.

## 📢 Changelog

- Update react-native-is-edge-to-edge to 1.1.3

## 🤔 How Has This Been Tested?

- Tested on old and new architecture

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
