### PR TITLE
fix: web compatibility

### DIFF
--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -4637,10 +4637,10 @@ react-native-gesture-handler@2.18.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-is-edge-to-edge@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.5.tgz#9dff7a1fad17ceb39ff48192c9ddaff5c72a637a"
-  integrity sha512-zt/0wLKBYTdoQdaZEvN9Ghi8Kz3Fo3LaWMzWZyJl7aLhvCNPebyi0DW449+PzC5xpIQdfcmumwkaB9VpymvViQ==
+react-native-is-edge-to-edge@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.6.tgz#69ec13f70d76e9245e275eed4140d0873a78f902"
+  integrity sha512-1pHnFTlBahins6UAajXUqeCOHew9l9C2C8tErnpGC3IyLJzvxD+TpYAixnCbrVS52f7+NvMttbiSI290XfwN0w==
 
 "react-native-keyboard-controller@link:..":
   version "0.0.0"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4747,10 +4747,10 @@ react-native-haptic-feedback@2.3.1:
   resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.3.1.tgz#2ef4ac7d4f63ac06bd64b659f509362f127b16e5"
   integrity sha512-dPfjV4iVHfhVyfG+nRd88ygjahbdup7KFZDM5L2aNIAzqbNtKxHZn5O1pHegwSj1t15VJliu0GyTX7XpBDeXUw==
 
-react-native-is-edge-to-edge@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.5.tgz#9dff7a1fad17ceb39ff48192c9ddaff5c72a637a"
-  integrity sha512-zt/0wLKBYTdoQdaZEvN9Ghi8Kz3Fo3LaWMzWZyJl7aLhvCNPebyi0DW449+PzC5xpIQdfcmumwkaB9VpymvViQ==
+react-native-is-edge-to-edge@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.6.tgz#69ec13f70d76e9245e275eed4140d0873a78f902"
+  integrity sha512-1pHnFTlBahins6UAajXUqeCOHew9l9C2C8tErnpGC3IyLJzvxD+TpYAixnCbrVS52f7+NvMttbiSI290XfwN0w==
 
 "react-native-keyboard-controller@link:..":
   version "0.0.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "react-native-is-edge-to-edge": "^1.1.5"
+    "react-native-is-edge-to-edge": "^1.1.6"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7685,10 +7685,10 @@ react-native-builder-bob@^0.18.0:
   optionalDependencies:
     jetifier "^2.0.0"
 
-react-native-is-edge-to-edge@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.5.tgz#9dff7a1fad17ceb39ff48192c9ddaff5c72a637a"
-  integrity sha512-zt/0wLKBYTdoQdaZEvN9Ghi8Kz3Fo3LaWMzWZyJl7aLhvCNPebyi0DW449+PzC5xpIQdfcmumwkaB9VpymvViQ==
+react-native-is-edge-to-edge@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.6.tgz#69ec13f70d76e9245e275eed4140d0873a78f902"
+  integrity sha512-1pHnFTlBahins6UAajXUqeCOHew9l9C2C8tErnpGC3IyLJzvxD+TpYAixnCbrVS52f7+NvMttbiSI290XfwN0w==
 
 react-native-reanimated@3.16.1:
   version "3.16.1"


### PR DESCRIPTION
## 📜 Description

Bump `react-native-is-edge-to-edge` as it breaks web (webpack) compatibility.

## 💡 Motivation and Context

There was a problem because `web` was resolving `index.mjs`, which had a reference ti TurboModule and crashed the app:

![image](https://github.com/user-attachments/assets/7ce5c242-fecf-4254-8506-0ebf188b35d8)

It was fixed in `1.1.6` - all extensions were removed and files were named correspondingly. So now all files can be properly resolved 😊 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- bump `react-native-is-edge-to-edge` to `1.1.6`;

## 🤔 How Has This Been Tested?

Tested manually on webpack app.

## 📸 Screenshots (if appropriate):

<img width="2141" alt="image" src="https://github.com/user-attachments/assets/0a2f12ef-eb06-4b63-8d4b-53826c677585">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
