### PR TITLE
fix: google password manager breaks `KeyboardAwareScrollView`

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -326,6 +326,14 @@ const KeyboardAwareScrollView = forwardRef<
 
           keyboardHeight.value = e.height;
           scrollPosition.value = position.value;
+
+          const keyboardFrame = interpolate(
+            e.height,
+            [0, keyboardHeight.value],
+            [0, keyboardHeight.value + extraKeyboardSpace],
+          );
+
+          currentKeyboardFrameHeight.value = keyboardFrame;
         },
       },
       [maybeScroll, disableScrollOnKeyboardHide, extraKeyboardSpace],

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -27,6 +27,7 @@ import type {
 import type {
   FocusedInputLayoutChangedEvent,
   FocusedInputSelectionChangedEvent,
+  NativeEvent,
 } from "react-native-keyboard-controller";
 
 export type KeyboardAwareScrollViewProps = {
@@ -190,6 +191,20 @@ const KeyboardAwareScrollView = forwardRef<
       },
       [bottomOffset, enabled, height, snapToOffsets],
     );
+    const syncKeyboardFrame = useCallback(
+      (e: NativeEvent) => {
+        "worklet";
+
+        const keyboardFrame = interpolate(
+          e.height,
+          [0, keyboardHeight.value],
+          [0, keyboardHeight.value + extraKeyboardSpace],
+        );
+
+        currentKeyboardFrameHeight.value = keyboardFrame;
+      },
+      [extraKeyboardSpace],
+    );
 
     const scrollFromCurrentPosition = useCallback(
       (customHeight?: number) => {
@@ -308,13 +323,7 @@ const KeyboardAwareScrollView = forwardRef<
         onMove: (e) => {
           "worklet";
 
-          const keyboardFrame = interpolate(
-            e.height,
-            [0, keyboardHeight.value],
-            [0, keyboardHeight.value + extraKeyboardSpace],
-          );
-
-          currentKeyboardFrameHeight.value = keyboardFrame;
+          syncKeyboardFrame(e);
 
           // if the user has set disableScrollOnKeyboardHide, only auto-scroll when the keyboard opens
           if (!disableScrollOnKeyboardHide || keyboardWillAppear.value) {
@@ -327,16 +336,10 @@ const KeyboardAwareScrollView = forwardRef<
           keyboardHeight.value = e.height;
           scrollPosition.value = position.value;
 
-          const keyboardFrame = interpolate(
-            e.height,
-            [0, keyboardHeight.value],
-            [0, keyboardHeight.value + extraKeyboardSpace],
-          );
-
-          currentKeyboardFrameHeight.value = keyboardFrame;
+          syncKeyboardFrame(e);
         },
       },
-      [maybeScroll, disableScrollOnKeyboardHide, extraKeyboardSpace],
+      [maybeScroll, disableScrollOnKeyboardHide, syncKeyboardFrame],
     );
 
     useAnimatedReaction(


### PR DESCRIPTION
## 📜 Description

Fixed input hiding when google password manager pops up.

## 💡 Motivation and Context

The native code worked correctly, however when Google Password manager popup appears, then we have next events:

```bash
onStart -> 0
onMove -> 289.66
onMove -> 289.44
onEnd -> 0
```

So because of this fact we kept bottom area (fake view). When keyboard appear again, then we were animating this bottom view again from 0 to 290. But since in the beginning of the keyboard movement focused input was above the keyboard - we don't perform `scrollTo` operation. But when bottom padding collapses to `0` an then input moves behind the keyboard. And since we don't call `scrollTo` it keeps its present there.

To fix the problem and don't break the state machine we need to synchronize keyboardFrame (currentKeybaordFrame) in `onEnd` handler. Thus when popup appears, the input will be moved to bottom. When keyboard appear it'll correctly understand, that the keyboard will overlap the input and thus it will push the input as expected.

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/665

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- update `currentKeyboardFrame` in `onEnd` handler;
- create `syncKeyboardFrame` function.

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro API 35.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/4a468d1d-0e41-4ba8-9f61-677bcf96a4c2">|<video src="https://github.com/user-attachments/assets/5341a649-3ae5-464d-ac11-a49e09524b9d">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
