### PR TITLE
fix: `react-native-haptic-feedback` in fabric example app

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -105,8 +105,8 @@ jobs:
       matrix:
         devices:
           [
-            { ios: 15, xcode: "14.3.1", runtime: "15.5" },
-            { ios: 16, xcode: "14.3.1" },
+            { ios: 15, xcode: "15.4", runtime: "15.5" },
+            { ios: 16, xcode: "15.4", runtime: "16.4" },
             { ios: 17, xcode: "15.4" },
             { ios: 18, xcode: "16.0" },
           ]

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1646,6 +1646,27 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNReactNativeHapticFeedback (2.3.3):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNReanimated (3.16.1):
     - DoubleConversion
     - glog
@@ -1851,6 +1872,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -1996,6 +2018,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNReactNativeHapticFeedback:
+    :path: "../node_modules/react-native-haptic-feedback"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -2072,6 +2096,7 @@ SPEC CHECKSUMS:
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNGestureHandler: f769e1b9057085db07546aa3e259daa85c898dc7
+  RNReactNativeHapticFeedback: 73756a3477a5a622fa16862a3ab0d0fc5e5edff5
   RNReanimated: 2d728bad3a69119be89c3431ee0ccda026ecffdc
   RNScreens: de6e57426ba0e6cbc3fb5b4f496e7f08cb2773c2
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -21,6 +21,7 @@
     "react": "18.3.1",
     "react-native": "0.75.3",
     "react-native-gesture-handler": "2.18.1",
+    "react-native-haptic-feedback": "2.3.3",
     "react-native-keyboard-controller": "link:../",
     "react-native-reanimated": "3.16.1",
     "react-native-safe-area-context": "4.10.5",

--- a/FabricExample/src/screens/Examples/Toolbar/index.tsx
+++ b/FabricExample/src/screens/Examples/Toolbar/index.tsx
@@ -1,7 +1,7 @@
 import { BlurView } from "@react-native-community/blur";
 import React, { useCallback, useState } from "react";
 import { Platform, StyleSheet, View } from "react-native";
-// import { trigger } from "react-native-haptic-feedback";
+import { trigger } from "react-native-haptic-feedback";
 import {
   KeyboardAwareScrollView,
   KeyboardToolbar,
@@ -18,7 +18,6 @@ const options = {
   enableVibrateFallback: true,
   ignoreAndroidSystemSettings: false,
 };
-const trigger = () => null;
 const haptic = () =>
   trigger(Platform.OS === "ios" ? "impactLight" : "keyboardTap", options);
 

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -4637,6 +4637,11 @@ react-native-gesture-handler@2.18.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-haptic-feedback@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.3.3.tgz#88b6876e91399a69bd1b551fe1681b2f3dc1214e"
+  integrity sha512-svS4D5PxfNv8o68m9ahWfwje5NqukM3qLS48+WTdhbDkNUkOhP9rDfDSRHzlhk4zq+ISjyw95EhLeh8NkKX5vQ==
+
 react-native-is-edge-to-edge@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.6.tgz#69ec13f70d76e9245e275eed4140d0873a78f902"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1587,7 +1587,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReactNativeHapticFeedback (2.3.1):
+  - RNReactNativeHapticFeedback (2.3.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2020,7 +2020,7 @@ SPEC CHECKSUMS:
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNGestureHandler: 939f21fabf5d45a725c0bf175eb819dd25cf2e70
-  RNReactNativeHapticFeedback: 2bdbd63bcdbb52c4ae81a7b0c48ab1f00c06980a
+  RNReactNativeHapticFeedback: 0d591ea1e150f36cb96d868d4e8d77272243d78a
   RNReanimated: f42a5044d121d68e91680caacb0293f4274228eb
   RNScreens: 19719a9c326e925498ac3b2d35c4e50fe87afc06
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d

--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,7 @@
     "react": "18.3.1",
     "react-native": "0.75.3",
     "react-native-gesture-handler": "2.18.1",
-    "react-native-haptic-feedback": "2.3.1",
+    "react-native-haptic-feedback": "2.3.3",
     "react-native-keyboard-controller": "link:../",
     "react-native-reanimated": "3.16.1",
     "react-native-safe-area-context": "4.10.5",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4742,10 +4742,10 @@ react-native-gesture-handler@2.18.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-haptic-feedback@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.3.1.tgz#2ef4ac7d4f63ac06bd64b659f509362f127b16e5"
-  integrity sha512-dPfjV4iVHfhVyfG+nRd88ygjahbdup7KFZDM5L2aNIAzqbNtKxHZn5O1pHegwSj1t15VJliu0GyTX7XpBDeXUw==
+react-native-haptic-feedback@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.3.3.tgz#88b6876e91399a69bd1b551fe1681b2f3dc1214e"
+  integrity sha512-svS4D5PxfNv8o68m9ahWfwje5NqukM3qLS48+WTdhbDkNUkOhP9rDfDSRHzlhk4zq+ISjyw95EhLeh8NkKX5vQ==
 
 react-native-is-edge-to-edge@^1.1.6:
   version "1.1.6"


### PR DESCRIPTION
## 📜 Description

Updated `react-native-haptic-feedback` to the latest version.

Stopped to use `xcode@14.x` on CI as it has been removed. 

## 💡 Motivation and Context

Before `react-native-haptic-feedback` was removed from `FabricExample` because it wasn't compatible with latest RN versions. Later on all issues were fixed and latest `2.3.3` version is fully compatible with all RN versions.

So in this PR I started to use `react-native-haptic-feedback@2.3.3` in both projects.

Additionally I fixed failing CI (xcode 14 was removed from macos-14 runners).

Fixes: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/678

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- don't use xcode 14 on CI and install iOS 16.4 for e2e test;

### JS

- update `react-native-haptic-feedback` to `2.3.3`.

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
