### PR TITLE
refactor: move data extraction from notification to extensions layer

### DIFF
--- a/ios/extensions/Notification.swift
+++ b/ios/extensions/Notification.swift
@@ -1,0 +1,17 @@
+//
+//  Notification.swift
+//  Pods
+//
+//  Created by Kiryl Ziusko on 04/11/2024.
+//
+
+extension Notification {
+  func keyboardMetaData() -> (Int, NSValue?) {
+    let duration = Int(
+      (userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double ?? 0) * 1000
+    )
+    let keyboardFrame = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
+
+    return (duration, keyboardFrame)
+  }
+}

--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -163,7 +163,7 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   @objc func keyboardWillAppear(_ notification: Notification) {
-    let (duration, frame) = metaDataFromNotification(notification)
+    let (duration, frame) = notification.keyboardMetaData()
     if let keyboardFrame = frame {
       tag = UIResponder.current.reactViewTag
       let keyboardHeight = keyboardFrame.cgRectValue.size.height
@@ -181,7 +181,7 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   @objc func keyboardWillDisappear(_ notification: Notification) {
-    let (duration, _) = metaDataFromNotification(notification)
+    let (duration, _) = notification.keyboardMetaData()
     tag = UIResponder.current.reactViewTag
     self.duration = duration
 
@@ -196,7 +196,7 @@ public class KeyboardMovementObserver: NSObject {
 
   @objc func keyboardDidAppear(_ notification: Notification) {
     let timestamp = Date.currentTimeStamp
-    let (duration, frame) = metaDataFromNotification(notification)
+    let (duration, frame) = notification.keyboardMetaData()
     if let keyboardFrame = frame {
       let (position, _) = keyboardView.frameTransitionInWindow
       let keyboardHeight = keyboardFrame.cgRectValue.size.height
@@ -219,7 +219,7 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   @objc func keyboardDidDisappear(_ notification: Notification) {
-    let (duration, _) = metaDataFromNotification(notification)
+    let (duration, _) = notification.keyboardMetaData()
     tag = UIResponder.current.reactViewTag
 
     onCancelAnimation()
@@ -308,15 +308,6 @@ public class KeyboardMovementObserver: NSObject {
       duration as NSNumber,
       tag
     )
-  }
-
-  private func metaDataFromNotification(_ notification: Notification) -> (Int, NSValue?) {
-    let duration = Int(
-      (notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double ?? 0) * 1000
-    )
-    let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
-
-    return (duration, keyboardFrame)
   }
 
   private func getEventParams(_ height: Double, _ duration: Int) -> [AnyHashable: Any] {


### PR DESCRIPTION
## 📜 Description

Moved notification data extraction to separate extension.

## 💡 Motivation and Context

`keyboardMovementObserver` class is pretty big and I'd like to keep it smaller. So the first action is to extract all pure functions into own separate files with specific area of responsibility/functionality.

## 📢 Changelog

### iOS

- create `Notification` extension;
- create `keyboardMetaData` function-extension.

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
