### PR TITLE
feat(android): add JSPointerDispatcherCompat for RN < 0.72

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
@@ -1,22 +1,36 @@
-
 package com.reactnativekeyboardcontroller.views.overlay
 
 import android.view.MotionEvent
 import android.view.ViewGroup
-
 import com.facebook.react.uimanager.JSPointerDispatcher
 import com.facebook.react.uimanager.events.EventDispatcher
 
 /**
  * Compat layer for `JSPointerDispatcher` interface for RN < 0.72
  */
-class JSPointerDispatcherCompat(private val viewGroup: ViewGroup) : JSPointerDispatcher(viewGroup) {
-  fun handleMotionEventCompat(event: MotionEvent?, eventDispatcher: EventDispatcher?, isCapture: Boolean) {
-    val method = try {
-      JSPointerDispatcher::class.java.getMethod("handleMotionEvent", MotionEvent::class.java, EventDispatcher::class.java, Boolean::class.javaPrimitiveType)
-    } catch (e: NoSuchMethodException) {
-      JSPointerDispatcher::class.java.getMethod("handleMotionEvent", MotionEvent::class.java, EventDispatcher::class.java)
-    }
+class JSPointerDispatcherCompat(
+  private val viewGroup: ViewGroup,
+) : JSPointerDispatcher(viewGroup) {
+  fun handleMotionEventCompat(
+    event: MotionEvent?,
+    eventDispatcher: EventDispatcher?,
+    isCapture: Boolean,
+  ) {
+    val method =
+      try {
+        JSPointerDispatcher::class.java.getMethod(
+          "handleMotionEvent",
+          MotionEvent::class.java,
+          EventDispatcher::class.java,
+          Boolean::class.javaPrimitiveType,
+        )
+      } catch (e: NoSuchMethodException) {
+        JSPointerDispatcher::class.java.getMethod(
+          "handleMotionEvent",
+          MotionEvent::class.java,
+          EventDispatcher::class.java,
+        )
+      }
     method.invoke(this, event, eventDispatcher, isCapture)
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
@@ -18,6 +18,7 @@ class JSPointerDispatcherCompat(
   ) {
     val method =
       try {
+       // The RN version with 3 arguments (i.e., RN >= 0.72)
         JSPointerDispatcher::class.java.getMethod(
           "handleMotionEvent",
           MotionEvent::class.java,
@@ -25,6 +26,7 @@ class JSPointerDispatcherCompat(
           Boolean::class.javaPrimitiveType,
         )
       } catch (_: NoSuchMethodException) {
+        // The RN version with 2 arguments (i.e., RN < 0.72)
         JSPointerDispatcher::class.java.getMethod(
           "handleMotionEvent",
           MotionEvent::class.java,

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
@@ -24,7 +24,7 @@ class JSPointerDispatcherCompat(
           EventDispatcher::class.java,
           Boolean::class.javaPrimitiveType,
         )
-      } catch (e: NoSuchMethodException) {
+      } catch (_: NoSuchMethodException) {
         JSPointerDispatcher::class.java.getMethod(
           "handleMotionEvent",
           MotionEvent::class.java,

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
@@ -1,0 +1,22 @@
+
+package com.reactnativekeyboardcontroller.views.overlay
+
+import android.view.MotionEvent
+import android.view.ViewGroup
+
+import com.facebook.react.uimanager.JSPointerDispatcher
+import com.facebook.react.uimanager.events.EventDispatcher
+
+/**
+ * Compat layer for `JSPointerDispatcher` interface for RN < 0.72
+ */
+class JSPointerDispatcherCompat(private val viewGroup: ViewGroup) : JSPointerDispatcher(viewGroup) {
+  fun handleMotionEventCompat(event: MotionEvent?, eventDispatcher: EventDispatcher?, isCapture: Boolean) {
+    val method = try {
+      JSPointerDispatcher::class.java.getMethod("handleMotionEvent", MotionEvent::class.java, EventDispatcher::class.java, Boolean::class.javaPrimitiveType)
+    } catch (e: NoSuchMethodException) {
+      JSPointerDispatcher::class.java.getMethod("handleMotionEvent", MotionEvent::class.java, EventDispatcher::class.java)
+    }
+    method.invoke(this, event, eventDispatcher, isCapture)
+  }
+}

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
@@ -16,23 +16,25 @@ class JSPointerDispatcherCompat(
     eventDispatcher: EventDispatcher?,
     isCapture: Boolean,
   ) {
-    val method =
-      try {
-       // The RN version with 3 arguments (i.e., RN >= 0.72)
+    try {
+      // Try to get the method with 3 parameters (for RN >= 0.72)
+      val method =
         JSPointerDispatcher::class.java.getMethod(
           "handleMotionEvent",
           MotionEvent::class.java,
           EventDispatcher::class.java,
           Boolean::class.javaPrimitiveType,
         )
-      } catch (_: NoSuchMethodException) {
-        // The RN version with 2 arguments (i.e., RN < 0.72)
+      method.invoke(this, event, eventDispatcher, isCapture)
+    } catch (_: NoSuchMethodException) {
+      // Fallback to 2-parameter version (for RN < 0.72)
+      val method =
         JSPointerDispatcher::class.java.getMethod(
           "handleMotionEvent",
           MotionEvent::class.java,
           EventDispatcher::class.java,
         )
-      }
-    method.invoke(this, event, eventDispatcher, isCapture)
+      method.invoke(this, event, eventDispatcher)
+    }
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -149,7 +149,7 @@ class OverKeyboardRootViewGroup(
   }
 
   override fun onHoverEvent(event: MotionEvent): Boolean {
-    eventDispatcher?.let { 
+    eventDispatcher?.let {
       jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, false)
     }
     return super.onHoverEvent(event)

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.WindowManager
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.config.ReactFeatureFlags
-import com.facebook.react.uimanager.JSPointerDispatcher
 import com.facebook.react.uimanager.JSTouchDispatcher
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
@@ -99,13 +98,13 @@ class OverKeyboardRootViewGroup(
 ) : ReactViewGroup(reactContext),
   RootViewCompat {
   private val jsTouchDispatcher: JSTouchDispatcher = JSTouchDispatcher(this)
-  private var jsPointerDispatcher: JSPointerDispatcher? = null
+  private var jsPointerDispatcher: JSPointerDispatcherCompat? = null
   internal var eventDispatcher: EventDispatcher? = null
   internal var isAttached = false
 
   init {
     if (ReactFeatureFlags.dispatchPointerEvents) {
-      jsPointerDispatcher = JSPointerDispatcher(this)
+      jsPointerDispatcher = JSPointerDispatcherCompat(this)
     }
   }
 
@@ -125,7 +124,7 @@ class OverKeyboardRootViewGroup(
   override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let { eventDispatcher ->
       jsTouchDispatcher.handleTouchEvent(event, eventDispatcher)
-      jsPointerDispatcher?.handleMotionEvent(event, eventDispatcher, true)
+      jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, true)
     }
     return super.onInterceptTouchEvent(event)
   }
@@ -134,7 +133,7 @@ class OverKeyboardRootViewGroup(
   override fun onTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let { eventDispatcher ->
       jsTouchDispatcher.handleTouchEvent(event, eventDispatcher)
-      jsPointerDispatcher?.handleMotionEvent(event, eventDispatcher, false)
+      jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, false)
     }
     super.onTouchEvent(event)
     // In case when there is no children interested in handling touch event, we return true from
@@ -143,12 +142,16 @@ class OverKeyboardRootViewGroup(
   }
 
   override fun onInterceptHoverEvent(event: MotionEvent): Boolean {
-    eventDispatcher?.let { jsPointerDispatcher?.handleMotionEvent(event, it, true) }
+    eventDispatcher?.let {
+      jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, true)
+    }
     return super.onHoverEvent(event)
   }
 
   override fun onHoverEvent(event: MotionEvent): Boolean {
-    eventDispatcher?.let { jsPointerDispatcher?.handleMotionEvent(event, it, false) }
+    eventDispatcher?.let { 
+      jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, false)
+    }
     return super.onHoverEvent(event)
   }
 


### PR DESCRIPTION
## 📜 Description
To add a compatibility layer for `JSPointerDispatcher`, ensure that the method functions correctly regardless of whether it is called with two or three parameters.

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

Related:
https://github.com/facebook/react-native/commit/1e53f88b72e24ae2654b31f5c8bfbf8a07d51e09#diff-e874545c1f508ac02d63d67356fe0519f6c0dd5f380afeb900cf1de4fce6835aL202-R203

With the change, the number of parameters has increased from two to three. Since React Native 0.71.14 only uses two parameters, this causes a build error on Android.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- add `JSPointerDispatcherCompat` class

## 🤔 How Has This Been Tested?
- I've tried compiling from 0.71
- I've tried compiling from 0.76
- **I would like to test the compatibility layer to ensure it functions smoothly. Could you help me with a plan for testing this code?**

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):
<img width="978" alt="image" src="https://github.com/user-attachments/assets/b3f96c4e-fc5d-40f3-9c6c-7fe9929d658c">

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
