### PR TITLE
perf: lookup method only once

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
@@ -41,7 +41,7 @@ class JSPointerDispatcherCompat(
     isCapture: Boolean,
   ) {
     handleMotionEventMethod?.let { method ->
-      if (method.parameterCount == THREE_PARAMETERS) {
+      if (method.parameterCount == RN_72_PARAMS_COUNT) {
         method.invoke(this, event, eventDispatcher, isCapture)
       } else {
         method.invoke(this, event, eventDispatcher)
@@ -51,6 +51,6 @@ class JSPointerDispatcherCompat(
 
   companion object {
     private const val HANDLE_MOTION_EVENT = "handleMotionEvent"
-    private const val THREE_PARAMETERS = 3
+    private const val RN_72_PARAMS_COUNT = 3
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -143,14 +143,14 @@ class OverKeyboardRootViewGroup(
 
   override fun onInterceptHoverEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let {
-      jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, true)
+      jsPointerDispatcher?.handleMotionEventCompat(event, it, true)
     }
     return super.onHoverEvent(event)
   }
 
   override fun onHoverEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let {
-      jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, false)
+      jsPointerDispatcher?.handleMotionEventCompat(event, it, false)
     }
     return super.onHoverEvent(event)
   }


### PR DESCRIPTION
## 📜 Description

In https://github.com/kirillzyusko/react-native-keyboard-controller/pull/681 we started to use reflection for detection the amount of params. But reflection is a slow mechanism, so in this PR I'm optimizing lookup stage by calculating a correct method only one time.

## 💡 Motivation and Context

Lookup can be up to 10-100 times slower comparing to the direct function call. If we call this method too frequently, we can encounter a bottleneck. To make this code faster I decided to cache the method (thus we do a lookup only one time).

This approach should almost neglect performance impact for a lookup stage. The call stage (method invocation) still will add an overhead, but it should have a small impact.

## 📢 Changelog

### Android

- cache method (make it lazy calculated);
- move constants to companion object.

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
