### PR TITLE
fix: allow to pass additional params to `.dismiss()` unintentionally

### DIFF
--- a/FabricExample/src/components/KeyboardAnimation/index.tsx
+++ b/FabricExample/src/components/KeyboardAnimation/index.tsx
@@ -62,7 +62,7 @@ export default function KeyboardAnimation({
     <TouchableOpacity
       activeOpacity={1}
       style={styles.container}
-      onPress={() => KeyboardController.dismiss()}
+      onPress={KeyboardController.dismiss}
     >
       <>
         <View>

--- a/FabricExample/src/screens/Examples/Close/index.tsx
+++ b/FabricExample/src/screens/Examples/Close/index.tsx
@@ -7,7 +7,7 @@ function CloseScreen() {
       <Button
         testID="close_keyboard_button"
         title="Close keyboard"
-        onPress={() => KeyboardController.dismiss()}
+        onPress={KeyboardController.dismiss}
       />
       <TextInput
         placeholder="Touch to open the keyboard..."

--- a/example/src/components/KeyboardAnimation/index.tsx
+++ b/example/src/components/KeyboardAnimation/index.tsx
@@ -62,7 +62,7 @@ export default function KeyboardAnimation({
     <TouchableOpacity
       activeOpacity={1}
       style={styles.container}
-      onPress={() => KeyboardController.dismiss()}
+      onPress={KeyboardController.dismiss}
     >
       <>
         <View>

--- a/example/src/screens/Examples/Close/index.tsx
+++ b/example/src/screens/Examples/Close/index.tsx
@@ -7,7 +7,7 @@ function CloseScreen() {
       <Button
         testID="close_keyboard_button"
         title="Close keyboard"
-        onPress={() => KeyboardController.dismiss()}
+        onPress={KeyboardController.dismiss}
       />
       <TextInput
         placeholder="Touch to open the keyboard..."

--- a/src/bindings.native.ts
+++ b/src/bindings.native.ts
@@ -3,6 +3,7 @@ import { NativeEventEmitter, Platform } from "react-native";
 import type {
   FocusedInputEventsModule,
   KeyboardControllerModule,
+  KeyboardControllerNativeModule,
   KeyboardControllerProps,
   KeyboardEventsModule,
   KeyboardGestureAreaProps,
@@ -19,7 +20,7 @@ const LINKING_ERROR =
 const RCTKeyboardController =
   require("./specs/NativeKeyboardController").default;
 
-export const KeyboardController = (
+export const KeyboardControllerNative = (
   RCTKeyboardController
     ? RCTKeyboardController
     : new Proxy(
@@ -30,14 +31,21 @@ export const KeyboardController = (
           },
         },
       )
-) as KeyboardControllerModule;
+) as KeyboardControllerNativeModule;
 
 const KEYBOARD_CONTROLLER_NAMESPACE = "KeyboardController::";
-const eventEmitter = new NativeEventEmitter(KeyboardController);
+const eventEmitter = new NativeEventEmitter(KeyboardControllerNative);
 
 export const KeyboardEvents: KeyboardEventsModule = {
   addListener: (name, cb) =>
     eventEmitter.addListener(KEYBOARD_CONTROLLER_NAMESPACE + name, cb),
+};
+export const KeyboardController: KeyboardControllerModule = {
+  setDefaultMode: KeyboardControllerNative.setDefaultMode,
+  setInputMode: KeyboardControllerNative.setInputMode,
+  setFocusTo: KeyboardControllerNative.setFocusTo,
+  // additional function is needed because of this https://github.com/kirillzyusko/react-native-keyboard-controller/issues/684
+  dismiss: () => KeyboardControllerNative.dismiss(),
 };
 /**
  * This API is not documented, it's for internal usage only (for now), and is a subject to potential breaking changes in future.

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -18,8 +18,6 @@ export const KeyboardController: KeyboardControllerModule = {
   setInputMode: NOOP,
   dismiss: NOOP,
   setFocusTo: NOOP,
-  addListener: NOOP,
-  removeListeners: NOOP,
 };
 export const KeyboardEvents: KeyboardEventsModule = {
   addListener: () => ({ remove: NOOP } as EmitterSubscription),

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -64,10 +64,6 @@ const KEYBOARD_TOOLBAR_HEIGHT = 42;
 const DEFAULT_OPACITY: HEX = "FF";
 const offset = { closed: KEYBOARD_TOOLBAR_HEIGHT };
 
-const dismissKeyboard = () => KeyboardController.dismiss();
-const goToNextField = () => KeyboardController.setFocusTo("next");
-const goToPrevField = () => KeyboardController.setFocusTo("prev");
-
 /**
  * `KeyboardToolbar` is a component that is shown above the keyboard with `Prev`/`Next` and
  * `Done` buttons.
@@ -122,7 +118,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
       onNextCallback?.(event);
 
       if (!event.isDefaultPrevented()) {
-        goToNextField();
+        KeyboardController.setFocusTo("next");
       }
     },
     [onNextCallback],
@@ -132,7 +128,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
       onPrevCallback?.(event);
 
       if (!event.isDefaultPrevented()) {
-        goToPrevField();
+        KeyboardController.setFocusTo("prev");
       }
     },
     [onPrevCallback],
@@ -142,7 +138,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
       onDoneCallback?.(event);
 
       if (!event.isDefaultPrevented()) {
-        dismissKeyboard();
+        KeyboardController.dismiss();
       }
     },
     [onDoneCallback],

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,10 +121,12 @@ export type KeyboardControllerModule = {
   // all platforms
   dismiss: () => void;
   setFocusTo: (direction: Direction) => void;
+};
+export type KeyboardControllerNativeModule = {
   // native event module stuff
   addListener: (eventName: string) => void;
   removeListeners: (count: number) => void;
-};
+} & KeyboardControllerModule;
 
 // Event module declarations
 export type KeyboardControllerEvents =


### PR DESCRIPTION
## 📜 Description

Allow to pass additional params to `KeyboardController.dismiss()` method unintentionally.

## 💡 Motivation and Context

When we pass params unintentionally like `onPress={KeyboardController.dismiss}` then we will try to serialize big JS object to the native side, which eventually crash the application.

To avoid this I decided to wrap `dismiss` in additional function and always send empty params to a native function.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/684

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- removed undocumented `addListener`/`removeListener` methods from `KeyboardController`;
- allow to pass any params to `dismiss`;
- removed unnecessary functions nesting in `KeyboardToolbar`;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
