### PR TITLE
ci: interrupt sudo command in runtime installation

### DIFF
--- a/.github/actions/retry-sudo-with-timeout/action.yml
+++ b/.github/actions/retry-sudo-with-timeout/action.yml
@@ -1,5 +1,5 @@
-name: "Retry with Timeout"
-description: "Retries a command with a specified timeout and max retries."
+name: "Retry sudo with Timeout"
+description: "Retries a sudo command with a specified timeout and max retries."
 author: "Kiryl Ziusko"
 inputs:
   command:
@@ -82,12 +82,13 @@ runs:
             echo "Command execution successful."
             break
           elif [[ $COMMAND_EXIT_CODE -eq 124 ]]; then
-            echo "Command timed out after ${TIMEOUT} seconds. Retrying..."
+            echo "Command timed out after ${TIMEOUT} seconds."
           else
             echo "Command failed with exit code $COMMAND_EXIT_CODE"
-            echo "Retrying command in $RETRY_INTERVAL seconds..."
-            sleep $RETRY_INTERVAL
           fi
+
+          echo "Retrying command in $RETRY_INTERVAL seconds..."
+          sleep $RETRY_INTERVAL
 
           # Increment the retry counter
           RETRY_COUNT=$((RETRY_COUNT + 1))

--- a/.github/actions/retry-with-timeout/action.yml
+++ b/.github/actions/retry-with-timeout/action.yml
@@ -37,7 +37,7 @@ runs:
           local start_time=$(date +%s)
 
           # Run the command with sudo in the background
-          eval "$command" &
+          $command &
           local sudo_pid=$!
 
           # Wait briefly to allow sudo to spawn its child process

--- a/.github/actions/retry-with-timeout/action.yml
+++ b/.github/actions/retry-with-timeout/action.yml
@@ -37,7 +37,7 @@ runs:
           local start_time=$(date +%s)
 
           # Run the command with sudo in the background
-          $command &
+          sudo bash -c "$command" &
           local sudo_pid=$!
 
           # Wait briefly to allow sudo to spawn its child process

--- a/.github/actions/retry-with-timeout/action.yml
+++ b/.github/actions/retry-with-timeout/action.yml
@@ -1,0 +1,100 @@
+name: "Retry with Timeout"
+description: "Retries a command with a specified timeout and max retries."
+author: "Kiryl Ziusko"
+inputs:
+  command:
+    description: "The command to run with retry and timeout"
+    required: true
+  timeout:
+    description: "Timeout in seconds for each attempt"
+    required: true
+    default: 600
+  max_retries:
+    description: "Maximum number of retry attempts"
+    required: true
+    default: 3
+  retry_interval:
+    description: "Interval in seconds between retries"
+    required: true
+    default: 60
+runs:
+  using: "composite"
+  steps:
+    - name: Execute command with retry and timeout
+      shell: bash
+      run: |
+        # Parameters
+        TIMEOUT=${{ inputs.timeout }}
+        MAX_RETRIES=${{ inputs.max_retries }}
+        RETRY_INTERVAL=${{ inputs.retry_interval }}
+        COMMAND="${{ inputs.command }}"
+
+        RETRY_COUNT=0
+        SUCCESS=0
+
+        run_with_timeout() {
+          local command="$1"
+          local start_time=$(date +%s)
+
+          # Run the command with sudo in the background
+          eval "$command" &
+          local sudo_pid=$!
+
+          # Wait briefly to allow sudo to spawn its child process
+          sleep 2
+
+          # Find the child process of sudo (actual command)
+          local child_pid=$(pgrep -P $sudo_pid)
+
+          # Monitor the child process for timeout
+          while sudo kill -0 $child_pid 2>/dev/null; do
+            local current_time=$(date +%s)
+            local elapsed_time=$((current_time - start_time))
+
+            # If timeout is exceeded, kill the child process
+            if [[ $elapsed_time -ge $TIMEOUT ]]; then
+              echo "Command timed out after ${TIMEOUT} seconds. Killing process $child_pid."
+              sudo kill -9 $child_pid
+              wait $child_pid 2>/dev/null
+              return 124  # Return code 124 for timeout
+            fi
+
+            # Sleep briefly to avoid a busy loop
+            sleep 5
+          done
+
+          # Wait for sudo command to finish and capture exit code
+          wait $sudo_pid
+          return $?
+        }
+
+        # Start the retry loop
+        while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+          echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES for command..."
+
+          # Execute the command with targeted timeout
+          COMMAND_EXIT_CODE=0
+          run_with_timeout "$COMMAND" || COMMAND_EXIT_CODE=$?
+
+          # Check if the command succeeded
+          if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then
+            SUCCESS=1
+            echo "Command execution successful."
+            break
+          elif [[ $COMMAND_EXIT_CODE -eq 124 ]]; then
+            echo "Command timed out after ${TIMEOUT} seconds. Retrying..."
+          else
+            echo "Command failed with exit code $COMMAND_EXIT_CODE"
+            echo "Retrying command in $RETRY_INTERVAL seconds..."
+            sleep $RETRY_INTERVAL
+          fi
+
+          # Increment the retry counter
+          RETRY_COUNT=$((RETRY_COUNT + 1))
+        done
+
+        # Exit with error if all attempts failed
+        if [[ $SUCCESS -eq 0 ]]; then
+          echo "All attempts to execute command failed."
+          exit 1
+        fi

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -124,13 +124,45 @@ jobs:
         run: xcodebuild -version
       - name: Install additional iOS runtimes
         if: ${{ matrix.devices.runtime != '' && matrix.devices.runtime != null }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |
-            brew tap robotsandpencils/made
-            sudo xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'
+        run: |
+          # Set the parameters for retry logic
+          TIMEOUT=600  # Timeout for each attempt in seconds (10 minutes)
+          MAX_RETRIES=3
+          RETRY_INTERVAL=60  # Wait time between retries in seconds (1 minute)
+          RETRY_COUNT=0
+          SUCCESS=0
+
+          # Start the retry loop
+          while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+            echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES to install iOS runtime..."
+
+            # Execute the command with timeout
+            COMMAND_EXIT_CODE=0
+            timeout $TIMEOUT bash -c "brew tap robotsandpencils/made && sudo xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'" || COMMAND_EXIT_CODE=$?
+
+            # Check if the command succeeded
+            if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then
+              SUCCESS=1
+              echo "iOS runtime installation successful."
+              break
+            elif [[ $COMMAND_EXIT_CODE -eq 124 ]]; then
+              echo "Installation timed out after ${TIMEOUT} seconds"
+            else
+              echo "Installation failed with exit code $COMMAND_EXIT_CODE"
+            fi
+
+            echo "Retrying installation in $RETRY_INTERVAL seconds..."
+            sleep $RETRY_INTERVAL
+
+            # Increment the retry counter
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+          done
+
+          # Exit with error if all attempts failed
+          if [[ $SUCCESS -eq 0 ]]; then
+            echo "All attempts to install iOS runtime failed."
+            exit 1
+          fi
       - name: List all available simulators
         run: xcrun simctl list
       - name: Install AppleSimulatorUtils

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -130,7 +130,7 @@ jobs:
         uses: ./.github/actions/retry-with-timeout
         with:
           command: "xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'"
-          timeout: 600 # 10 minutes
+          timeout: 180 # 10 minutes
           max_retries: 3
           retry_interval: 60
       - name: List all available simulators

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -130,7 +130,7 @@ jobs:
         uses: ./.github/actions/retry-with-timeout
         with:
           command: |
-            sudo xcodes runtimes install --keep-archive "iOS ${{ matrix.devices.runtime }}"
+            "sudo xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'"
           timeout: 600 # 10 minutes
           max_retries: 3
           retry_interval: 60

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -127,7 +127,7 @@ jobs:
         run: brew tap robotsandpencils/made
       - name: Install additional iOS runtimes
         if: ${{ matrix.devices.runtime != '' && matrix.devices.runtime != null }}
-        uses: ./.github/actions/retry-with-timeout
+        uses: ./.github/actions/retry-sudo-with-timeout
         with:
           command: "xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'"
           timeout: 180 # 10 minutes

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -129,8 +129,7 @@ jobs:
         if: ${{ matrix.devices.runtime != '' && matrix.devices.runtime != null }}
         uses: ./.github/actions/retry-with-timeout
         with:
-          command: |
-            "sudo xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'"
+          command: "xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'"
           timeout: 600 # 10 minutes
           max_retries: 3
           retry_interval: 60

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -130,7 +130,7 @@ jobs:
         uses: ./.github/actions/retry-sudo-with-timeout
         with:
           command: "xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'"
-          timeout: 180 # 10 minutes
+          timeout: 600 # 10 minutes
           max_retries: 3
           retry_interval: 60
       - name: List all available simulators

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -122,78 +122,18 @@ jobs:
           xcode-version: ${{ matrix.devices.xcode }}
       - name: Get Xcode version
         run: xcodebuild -version
+      # needed for additional runtime installation
+      - name: Install Xcodes
+        run: brew tap robotsandpencils/made
       - name: Install additional iOS runtimes
         if: ${{ matrix.devices.runtime != '' && matrix.devices.runtime != null }}
-        run: |
-          # Set parameters for retry logic
-          TIMEOUT=600  # Timeout for each attempt in seconds (10 minutes)
-          MAX_RETRIES=3
-          RETRY_INTERVAL=60  # Wait time between retries in seconds (1 minute)
-          RETRY_COUNT=0
-          SUCCESS=0
-
-          # Function to execute command with a manual timeout
-          run_with_timeout() {
-            local command="$1"
-            local start_time=$(date +%s)
-
-            # Run the command in the background
-            eval "$command" &
-            local pid=$!
-
-            # Monitor the command with a timeout
-            while kill -0 $pid 2>/dev/null; do
-              local current_time=$(date +%s)
-              local elapsed_time=$((current_time - start_time))
-
-              # If timeout is exceeded, kill the command
-              if [[ $elapsed_time -ge $TIMEOUT ]]; then
-                echo "Command timed out after ${TIMEOUT} seconds."
-                kill -9 $pid
-                wait $pid 2>/dev/null
-                return 124  # Return code 124 for timeout
-              fi
-
-              # Sleep briefly to avoid a busy loop
-              sleep 5
-            done
-
-            # Wait for command to finish and capture exit code
-            wait $pid
-            return $?
-          }
-
-          # Start the retry loop
-          while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
-            echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES to install iOS runtime..."
-
-            # Execute the command with a manual timeout
-            COMMAND_EXIT_CODE=0
-            run_with_timeout "brew tap robotsandpencils/made && sudo xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'" || COMMAND_EXIT_CODE=$?
-
-            # Check if the command succeeded
-            if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then
-              SUCCESS=1
-              echo "iOS runtime installation successful."
-              break
-            elif [[ $COMMAND_EXIT_CODE -eq 124 ]]; then
-              echo "Installation timed out after ${TIMEOUT} seconds"
-            else
-              echo "Installation failed with exit code $COMMAND_EXIT_CODE"
-            fi
-
-            echo "Retrying installation in $RETRY_INTERVAL seconds..."
-            sleep $RETRY_INTERVAL
-
-            # Increment the retry counter
-            RETRY_COUNT=$((RETRY_COUNT + 1))
-          done
-
-          # Exit with error if all attempts failed
-          if [[ $SUCCESS -eq 0 ]]; then
-            echo "All attempts to install iOS runtime failed."
-            exit 1
-          fi
+        uses: ./.github/actions/retry-with-timeout
+        with:
+          command: |
+            sudo xcodes runtimes install --keep-archive "iOS ${{ matrix.devices.runtime }}"
+          timeout: 600 # 10 minutes
+          max_retries: 3
+          retry_interval: 60
       - name: List all available simulators
         run: xcrun simctl list
       - name: Install AppleSimulatorUtils

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -125,20 +125,51 @@ jobs:
       - name: Install additional iOS runtimes
         if: ${{ matrix.devices.runtime != '' && matrix.devices.runtime != null }}
         run: |
-          # Set the parameters for retry logic
+          # Set parameters for retry logic
           TIMEOUT=600  # Timeout for each attempt in seconds (10 minutes)
           MAX_RETRIES=3
           RETRY_INTERVAL=60  # Wait time between retries in seconds (1 minute)
           RETRY_COUNT=0
           SUCCESS=0
 
+          # Function to execute command with a manual timeout
+          run_with_timeout() {
+            local command="$1"
+            local start_time=$(date +%s)
+
+            # Run the command in the background
+            eval "$command" &
+            local pid=$!
+
+            # Monitor the command with a timeout
+            while kill -0 $pid 2>/dev/null; do
+              local current_time=$(date +%s)
+              local elapsed_time=$((current_time - start_time))
+
+              # If timeout is exceeded, kill the command
+              if [[ $elapsed_time -ge $TIMEOUT ]]; then
+                echo "Command timed out after ${TIMEOUT} seconds."
+                kill -9 $pid
+                wait $pid 2>/dev/null
+                return 124  # Return code 124 for timeout
+              fi
+
+              # Sleep briefly to avoid a busy loop
+              sleep 5
+            done
+
+            # Wait for command to finish and capture exit code
+            wait $pid
+            return $?
+          }
+
           # Start the retry loop
           while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
             echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES to install iOS runtime..."
 
-            # Execute the command with timeout
+            # Execute the command with a manual timeout
             COMMAND_EXIT_CODE=0
-            timeout $TIMEOUT bash -c "brew tap robotsandpencils/made && sudo xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'" || COMMAND_EXIT_CODE=$?
+            run_with_timeout "brew tap robotsandpencils/made && sudo xcodes runtimes install --keep-archive 'iOS ${{ matrix.devices.runtime }}'" || COMMAND_EXIT_CODE=$?
 
             # Check if the command succeeded
             if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then


### PR DESCRIPTION
## 📜 Description

Fixed an issue when additional runtime installation can not be terminated after 10 minutes.

## 💡 Motivation and Context

When using [nick-fields/retry](https://github.com/nick-fields/retry) and we interrupt sudo command then we are getting errors like this https://github.com/nick-fields/retry/issues/114 or https://github.com/nick-fields/retry/issues/124

To overcome this problem I decided to create own script for retrying a command. This PR delivers that. 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- replace `nick-fields/retry` with own action;

## 🤔 How Has This Been Tested?

Reduced timeout to 2 minutes and verified that action was repeated 3 times with 1 minute delay between attempts.

## 📸 Screenshots (if appropriate):

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/051aea2e-32d1-4878-bf8f-b6831948c7c2">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
