### PR TITLE
docs: add info about `MutexLockWithTimeout` exception

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -127,7 +127,8 @@
     "autoresizing",
     "focusable",
     "iphonesimulator",
-    "suspendable"
+    "suspendable",
+    "libc"
   ],
   "ignorePaths": [
     "node_modules",

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -66,3 +66,21 @@ Since part of this library is written using `swift` language - your project need
 Sometimes you may see that animation performance is poor. If you are using `sentry@5` make sure `enableStallTracking` is disabled (i. e. `enableStallTracking: false`) or upgrade to `sentry@6`,
 
 See [this issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/641) for more details.
+
+## `MutexLockWithTimeout` C++ exception
+
+This exception is thrown when you are trying to use `KeyboardProvider` or `KeyboardAwareScrollView` on Android with new architecture enabled. A top of stacktrace will look like this:
+
+```bash
+NonPI::MutexLockWithTimeout at line 384 within libc
+offset 726000) (std::__ndk1::mutex::lock at line 12 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::Binding::schedulerDidFinishTransaction at line 84 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::Scheduler::uiManagerDidFinishTransaction at line 68 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::UIManager::shadowTreeDidFinishTransaction const at line 64 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::ShadowTree::mount const at line 348 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::ShadowTree::tryCommit const at line 2612 within split_config.arm64_v8a.apk
+```
+
+To fix this problem you have two ways to fix it:
+- enable `allowRecursiveCommitsWithSynchronousMountOnAndroid` feature flag (TODO: put more links on how to do that)
+- upgrade to `react-native@0.77+` (starting from this version this flag is enabled by default).

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -69,7 +69,7 @@ See [this issue](https://github.com/kirillzyusko/react-native-keyboard-controlle
 
 ## `MutexLockWithTimeout` C++ exception
 
-This exception is thrown when you are trying to use `KeyboardProvider` or `KeyboardAwareScrollView` on Android with new architecture enabled. A top of stacktrace will look like this:
+This exception is thrown when you are trying to use `KeyboardProvider` or `KeyboardAwareScrollView` on Android with the new architecture enabled. A top of stacktrace will look like this:
 
 ```bash
 NonPI::MutexLockWithTimeout at line 384 within libc
@@ -81,6 +81,7 @@ offset c01000) (facebook::react::ShadowTree::mount const at line 348 within spli
 offset c01000) (facebook::react::ShadowTree::tryCommit const at line 2612 within split_config.arm64_v8a.apk
 ```
 
-To fix this problem you have two ways to fix it:
-- enable `allowRecursiveCommitsWithSynchronousMountOnAndroid` feature flag (TODO: put more links on how to do that)
+You have two ways to fix this problem:
+
+- enable `allowRecursiveCommitsWithSynchronousMountOnAndroid` feature flag (see [react-native-reanimated#6418](https://github.com/software-mansion/react-native-reanimated/issues/6418#issuecomment-2296107100) and [react-native-keyboard-controller](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/687))
 - upgrade to `react-native@0.77+` (starting from this version this flag is enabled by default).

--- a/docs/versioned_docs/version-1.14.0/troubleshooting.md
+++ b/docs/versioned_docs/version-1.14.0/troubleshooting.md
@@ -66,3 +66,21 @@ Since part of this library is written using `swift` language - your project need
 Sometimes you may see that animation performance is poor. If you are using `sentry@5` make sure `enableStallTracking` is disabled (i. e. `enableStallTracking: false`) or upgrade to `sentry@6`,
 
 See [this issue](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/641) for more details.
+
+## `MutexLockWithTimeout` C++ exception
+
+This exception is thrown when you are trying to use `KeyboardProvider` or `KeyboardAwareScrollView` on Android with new architecture enabled. A top of stacktrace will look like this:
+
+```bash
+NonPI::MutexLockWithTimeout at line 384 within libc
+offset 726000) (std::__ndk1::mutex::lock at line 12 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::Binding::schedulerDidFinishTransaction at line 84 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::Scheduler::uiManagerDidFinishTransaction at line 68 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::UIManager::shadowTreeDidFinishTransaction const at line 64 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::ShadowTree::mount const at line 348 within split_config.arm64_v8a.apk
+offset c01000) (facebook::react::ShadowTree::tryCommit const at line 2612 within split_config.arm64_v8a.apk
+```
+
+To fix this problem you have two ways to fix it:
+- enable `allowRecursiveCommitsWithSynchronousMountOnAndroid` feature flag (TODO: put more links on how to do that)
+- upgrade to `react-native@0.77+` (starting from this version this flag is enabled by default).

--- a/docs/versioned_docs/version-1.14.0/troubleshooting.md
+++ b/docs/versioned_docs/version-1.14.0/troubleshooting.md
@@ -69,7 +69,7 @@ See [this issue](https://github.com/kirillzyusko/react-native-keyboard-controlle
 
 ## `MutexLockWithTimeout` C++ exception
 
-This exception is thrown when you are trying to use `KeyboardProvider` or `KeyboardAwareScrollView` on Android with new architecture enabled. A top of stacktrace will look like this:
+This exception is thrown when you are trying to use `KeyboardProvider` or `KeyboardAwareScrollView` on Android with the new architecture enabled. A top of stacktrace will look like this:
 
 ```bash
 NonPI::MutexLockWithTimeout at line 384 within libc
@@ -81,6 +81,7 @@ offset c01000) (facebook::react::ShadowTree::mount const at line 348 within spli
 offset c01000) (facebook::react::ShadowTree::tryCommit const at line 2612 within split_config.arm64_v8a.apk
 ```
 
-To fix this problem you have two ways to fix it:
-- enable `allowRecursiveCommitsWithSynchronousMountOnAndroid` feature flag (TODO: put more links on how to do that)
+You have two ways to fix this problem:
+
+- enable `allowRecursiveCommitsWithSynchronousMountOnAndroid` feature flag (see [react-native-reanimated#6418](https://github.com/software-mansion/react-native-reanimated/issues/6418#issuecomment-2296107100) and [react-native-keyboard-controller](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/687))
 - upgrade to `react-native@0.77+` (starting from this version this flag is enabled by default).


### PR DESCRIPTION
## 📜 Description

Added info about `MutexLockWithTimeout` exception and the way to resolve it.

## 💡 Motivation and Context

This is the best thing I can do at the moment - just mention that the problem exist and recommend to enable feature flag.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/687 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/683 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/640

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added new section in troubleshoot page;

## 🤔 How Has This Been Tested?

Tested via preview.

## 📸 Screenshots (if appropriate):

<img width="996" alt="image" src="https://github.com/user-attachments/assets/2fb05243-d14a-4941-8ec7-2350069af3ae">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
