### PR TITLE
fix: resolve react native dir in monorepo in android build

### DIFF
--- a/android/react-native-helpers.gradle
+++ b/android/react-native-helpers.gradle
@@ -4,23 +4,17 @@ def safeAppExtGet(prop, fallback) {
 }
 
 // Let's detect react-native's directory, it will be used to determine RN's version
-// https://github.com/software-mansion/react-native-reanimated/blob/cda4627c3337c33674f05f755b7485165c6caca9/android/build.gradle#L88
+// https://github.com/software-mansion/react-native-reanimated/blob/36c291a15880c78a94dd125c51484630546ceb7c/packages/react-native-reanimated/android/build.gradle#L73
 def resolveReactNativeDirectory() {
   def reactNativeLocation = safeAppExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
   if (reactNativeLocation != null) {
     return file(reactNativeLocation)
   }
 
-  // monorepo workaround
-  // react-native can be hoisted or in project's own node_modules
-  def reactNativeFromProjectNodeModules = file("${rootProject.projectDir}/../node_modules/react-native")
-  if (reactNativeFromProjectNodeModules.exists()) {
-    return reactNativeFromProjectNodeModules
-  }
-
-  def reactNativeFromNodeModules = file("${projectDir}/../../react-native")
-  if (reactNativeFromNodeModules.exists()) {
-    return reactNativeFromNodeModules
+  // Fallback to node resolver for custom directory structures like monorepos.
+  def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
+  if(reactNativePackage.exists()) {
+      return reactNativePackage.parentFile
   }
 
   throw new GradleException(

--- a/android/react-native-helpers.gradle
+++ b/android/react-native-helpers.gradle
@@ -13,7 +13,7 @@ def resolveReactNativeDirectory() {
 
   // Fallback to node resolver for custom directory structures like monorepos.
   def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
-  if(reactNativePackage.exists()) {
+  if (reactNativePackage.exists()) {
       return reactNativePackage.parentFile
   }
 


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->
I updated `resolveReactNativeDirectory` in  `android/react-native-helpers.gradle` to handle custom directory structures in a more generic way.

As in the previous version, I followed how [software-mansion resolved this problem](https://github.com/software-mansion/react-native-reanimated/blob/36c291a15880c78a94dd125c51484630546ceb7c/packages/react-native-reanimated/android/build.gradle#L73).

## 💡 Motivation and Context

I am working on a monorepo that's follow this structure

```plaintext
apps
├── react-native-app
│   ├── node_modules
│   │   └── react-native-keyboard-controller
packages
node_modules
├── react-native
package.json
```

The previous monorepo workaround was limited to two hardcoded paths.

My monorepo is build with Turborepo. Referring to [their docs](https://turbo.build/repo/docs/crafting-your-repository/managing-dependencies#node_modules-locations):
> Referencing `node_modules` in your code
> 
> The specific locations for node_modules within the Workspace are not a part of the public API of package managers. This means that referencing node_modules directly (like node ./node_modules/a-package/dist/index.js) can be brittle, since the location of the dependency on disk can change with other dependency changes around the Workspace.
> 
> Instead, rely on conventions of the Node.js ecosystem for accessing dependency modules whenever possible.

We can't be sure that `react-native` and `react-native-keyboard-controller` folders are in the same `node_modules` folder.

## 📢 Changelog

fixed android build in monorepo

### Android

resolve node modules react native directory using node resolver instead of hardcoded paths
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I tested android build in a monorepo created with turbo repo, in standalone react native app repo and in the example app.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
