### PR TITLE
fix: `.dismiss()` should trigger a blur on Android

### DIFF
--- a/FabricExample/src/screens/Examples/Close/index.tsx
+++ b/FabricExample/src/screens/Examples/Close/index.tsx
@@ -13,6 +13,8 @@ function CloseScreen() {
         placeholder="Touch to open the keyboard..."
         placeholderTextColor="#7C7C7C"
         style={styles.input}
+        onBlur={() => console.log("blur")}
+        onFocus={() => console.log("focus")}
       />
     </View>
   );

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
@@ -37,7 +37,11 @@ class KeyboardControllerModuleImpl(
 
   fun setFocusTo(direction: String) {
     if (direction == "current") {
-      return FocusedInputHolder.focus()
+      UiThreadUtil.runOnUiThread {
+        FocusedInputHolder.focus()
+      }
+
+      return
     }
 
     val view: View? = FocusedInputHolder.get()

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
@@ -27,8 +27,11 @@ class KeyboardControllerModuleImpl(
     val view: View? = FocusedInputHolder.get()
 
     if (view != null) {
-      val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
-      imm?.hideSoftInputFromWindow(view.windowToken, 0)
+      UiThreadUtil.runOnUiThread {
+        val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        imm?.hideSoftInputFromWindow(view.windowToken, 0)
+        view.clearFocus()
+      }
     }
   }
 

--- a/e2e/kit/005-keyboard-toolbar.e2e.ts
+++ b/e2e/kit/005-keyboard-toolbar.e2e.ts
@@ -11,6 +11,7 @@ import {
   waitAndTap,
   waitForElementById,
   waitForExpect,
+  waitForCompletion,
 } from "./helpers";
 
 describe("`KeyboardToolbar` specification", () => {
@@ -36,11 +37,9 @@ describe("`KeyboardToolbar` specification", () => {
   it("should set focus back when modal closed", async () => {
     await waitAndTap("autofill_contacts_close");
     await expect(element(by.id("TextInput#1"))).toBeFocused();
-    await expectElementBitmapsToBeEqual(
-      "keyboard.toolbar",
-      "ToolbarFirstInputFocused",
-    );
-    await tap("autofill_contacts");
+    await waitForCompletion(async () => {
+      await tap("autofill_contacts");
+    });
   });
 
   it("should do correct actions when contact gets selected", async () => {

--- a/e2e/kit/005-keyboard-toolbar.e2e.ts
+++ b/e2e/kit/005-keyboard-toolbar.e2e.ts
@@ -36,6 +36,10 @@ describe("`KeyboardToolbar` specification", () => {
   it("should set focus back when modal closed", async () => {
     await waitAndTap("autofill_contacts_close");
     await expect(element(by.id("TextInput#1"))).toBeFocused();
+    await expectElementBitmapsToBeEqual(
+      "keyboard.toolbar",
+      "ToolbarFirstInputFocused",
+    );
     await tap("autofill_contacts");
   });
 

--- a/e2e/kit/005-keyboard-toolbar.e2e.ts
+++ b/e2e/kit/005-keyboard-toolbar.e2e.ts
@@ -9,9 +9,9 @@ import {
   scrollDownUntilElementIsVisible,
   tap,
   waitAndTap,
+  waitForCompletion,
   waitForElementById,
   waitForExpect,
-  waitForCompletion,
 } from "./helpers";
 
 describe("`KeyboardToolbar` specification", () => {

--- a/e2e/kit/helpers/awaitable/index.ts
+++ b/e2e/kit/helpers/awaitable/index.ts
@@ -63,3 +63,7 @@ const options = {
 export const waitForExpect = async (expectation: () => Promise<void>) => {
   await retry(expectation, options);
 };
+
+export const waitForCompletion = async (operation: () => Promise<void>) => {
+  await retry(operation, options);
+};

--- a/example/src/screens/Examples/Close/index.tsx
+++ b/example/src/screens/Examples/Close/index.tsx
@@ -13,6 +13,8 @@ function CloseScreen() {
         placeholder="Touch to open the keyboard..."
         placeholderTextColor="#7C7C7C"
         style={styles.input}
+        onBlur={() => console.log("blur")}
+        onFocus={() => console.log("focus")}
       />
     </View>
   );


### PR DESCRIPTION
## 📜 Description

Unfocus `TextInput` and trigger `onBlur` when `.dismiss` is called on Android.

## 💡 Motivation and Context

It was an inconsistency if we compare it to iOS or to `Keyboard.dismiss()` implementation, so I decided to fix it. Before we just hide a keyboard, but we also need to unfocus the field.

I think about changing the signature of `dismiss` or adding a new method `.hide` that will allow to hide a keyboard and keep a focus on the field (however it's only plans at the moment).

I also fixed e2e tests - before `tap` on AutoFill could be triggered too early and because of that test could fail, so I added `waitForCompletion` utility function and now this test is much more stable.

## 📢 Changelog

### Android

- wrap `FocusedInputHolder.focus()` into `UiThreadUtil.runOnUiThread`;
- call `clearFocus` when we dismiss a keyboard.

## 🤔 How Has This Been Tested?

Tested manually on:
- Pixel 3a (API 33)
- Pixel 7 Pro (A{I 35)

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/b45de184-6496-47dc-a3b2-a2c6a2b2bcb5">|<video src="https://github.com/user-attachments/assets/8a621196-2da0-4c9d-9766-39041640fb0d">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
