### PR TITLE
fix: missing update in `useWindowDimensions`

### DIFF
--- a/src/hooks/useWindowDimensions/index.android.ts
+++ b/src/hooks/useWindowDimensions/index.android.ts
@@ -24,6 +24,11 @@ export const useWindowDimensions = () => {
       },
     );
 
+    // we might have missed an update between reading a value in render and
+    // `addListener` in this handler, so we set it here. If there was
+    // no change, React will filter out this update as a no-op.
+    setDimensions(initialDimensions);
+
     return () => {
       subscription.remove();
     };


### PR DESCRIPTION
## 📜 Description

Fixed broken layout of `KeyboardAvoidingView` when `KeyboardAvoidingView` mounted on app start.

## 💡 Motivation and Context

The problem was in fact, that event arrived after `useState` initalization, but before adding a new listener. So we had a missing event and as a result `screenHeight` was `0`.

To fix this I applied a very similar logic to what `useWindowDimensions` hook does from `react-native`. When `useEffect` callback gets executed we update state with `initialDimensions`. The value of `initialDimensions` will be always actual, because it's located outside of the hook.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- force update state inside `useEffect` with `initialDimensions`;

## 🤔 How Has This Been Tested?

Tested manually on `Medium_Phone_API_35`.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
