### PR TITLE
fix: incorrect `KeyboardStickyView` state when keyboard animation interrupted

### DIFF
--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -169,6 +169,11 @@ export const KeyboardProvider = ({
 
         updateSharedValues(event, ["android", "ios"]);
       },
+      onKeyboardMoveEnd: (event: NativeEvent) => {
+        "worklet";
+
+        updateSharedValues(event, ["android"]);
+      },
     },
     [],
   );
@@ -213,6 +218,7 @@ export const KeyboardProvider = ({
         onKeyboardMoveStart={OS === "ios" ? onKeyboardMove : undefined}
         onKeyboardMove={OS === "android" ? onKeyboardMove : undefined}
         onKeyboardMoveInteractive={onKeyboardMove}
+        onKeyboardMoveEnd={OS === "android" ? onKeyboardMove : undefined}
         onFocusedInputLayoutChangedReanimated={inputLayoutHandler}
       >
         {children}


### PR DESCRIPTION
## 📜 Description

Fixed broken `KeyboardStickyView` position if keyboard dismissing has been interrupted (by showing a native sheet, for example).

## 💡 Motivation and Context

This problem was discovered in https://github.com/bluesky-social/social-app/pull/6739

However I discovered such issue even earlier in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/667 - there I found out that progress can be interrupted (keyboard can start its movement, but then will be interrupted and will be instantly hidden) and `onEnd` event will be triggered.

Back to the times I fixed a problem by calling `maybeScroll` in `onEnd` handler. in this PR I want to do a similar thing - the only difference is that I want to add `onEnd` event to mapping for Animated/Reanimated values (`useKeyboardAnimation`/`useReanimatedKeyboardAnimation` hooks).

A proper fix for https://github.com/bluesky-social/social-app/pull/6739

## 📢 Changelog

### Android

- update `SharedValue` for `end` event on Android;
- update `Animated.Value` for `end` event on iOS;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
