### PR TITLE
fix: Android specific CI checks

### DIFF
--- a/.github/workflows/verify-android.yml
+++ b/.github/workflows/verify-android.yml
@@ -96,4 +96,4 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --cwd ..
       - name: Run Unit Tests
-        run: ./gradlew testDebugUnitTest
+        run: ./gradlew testDebugUnitTest -PreactNativeVersion=${{ env.REACT_NATIVE_VERSION }}

--- a/.github/workflows/verify-android.yml
+++ b/.github/workflows/verify-android.yml
@@ -1,5 +1,8 @@
 name: 📱 Validate Android
 
+env:
+  REACT_NATIVE_VERSION: 0.76.2
+
 on:
   push:
     branches:
@@ -40,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --cwd ..
       - name: Run Gradle Lint
-        run: ./gradlew lint
+        run: ./gradlew lint -PreactNativeVersion=${{ env.REACT_NATIVE_VERSION }}
   android-build:
     runs-on: ubuntu-latest
     name: 🏗️ Android Build
@@ -57,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --cwd ..
       - name: Run Gradle Assemble
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleDebug -PreactNativeVersion=${{ env.REACT_NATIVE_VERSION }}
   detekt:
     runs-on: ubuntu-latest
     name: 🧬 Run detekt

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -158,14 +158,15 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
+def reactNativeVersion = getExtOrDefault('reactNativeVersion')
 
 dependencies {
   if (project.ext.shouldConsumeReactNativeFromMavenCentral()) {
     // noinspection GradleDynamicVersion
-    implementation 'com.facebook.react:react-android:+'
+    implementation "com.facebook.react:react-android:$reactNativeVersion"
   } else {
     // noinspection GradleDynamicVersion
-    implementation 'com.facebook.react:react-native:+'
+    implementation "com.facebook.react:react-native:$reactNativeVersion"
   }
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'androidx.core:core-ktx:1.5.0-beta03'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,5 +2,6 @@ KeyboardController_kotlinVersion=1.8.22
 KeyboardController_compileSdkVersion=33
 KeyboardController_targetSdkVersion=33
 KeyboardController_minSdkVersion=16
+KeyboardController_reactNativeVersion=+
 
 android.useAndroidX=true


### PR DESCRIPTION
## 📜 Description

These 3 checks may constantly fail due to various reasons - one of them is new releases from RN (0.77.0-rc.0 triggered failures last time). In this PR I'm locking the version for CI jobs for these checks.

## 💡 Motivation and Context

I'm tired of random CI failures not related to actual changes that I made in PR. The solution with locking RN version on CI is the most obvious one.

I made my changes in a backward compatible way - unless you specify `reactNativeVersion` everything should work as before (and I highly doubt anyone is using such variable name - if needed I can rename it to `keyboardControllerRNVersion` but I don't think it's required).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- specify RN version in `verify-android` in env;
- use env RN version for build, lint and unit-tests jobs.

### Android

- added new `reactNativeVersion` gradle variable with default `+` value;
- use this variable instead of hardcoded `+`;

## 🤔 How Has This Been Tested?

Tested on CI.

## 📸 Screenshots (if appropriate):

<img width="915" alt="image" src="https://github.com/user-attachments/assets/706c4642-57de-4130-9d86-26e89f4fbd96">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
