### PR TITLE
fix: replace `setImmediate` with `queueMicrotask`

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -48,8 +48,8 @@ export function useEventHandlerRegistration<
     if (viewTagRef.current) {
       attachWorkletHandlers();
     } else {
-      // view may not be mounted yet - defer registration to next event loop
-      setImmediate(attachWorkletHandlers);
+      // view may not be mounted yet - defer registration until call-stack becomes empty
+      queueMicrotask(attachWorkletHandlers);
     }
 
     return () => {


### PR DESCRIPTION
## 📜 Description

Fixes a crash when `setImmediate` is not defined.

## 💡 Motivation and Context

It looks like on web `setImmediate` is polyfilled by `webpack`. However in certain cases we may try to use `setImmediate` but it may be not polyfilled yet.

To fix this problem I had two options:

### 1️⃣ Replace `setImmediate` with `setTimeout(..., 0)`

It also fixes a problem, but:
- specifying `0` always feels like a hacky solution;
- it will schedule a macrotask, which eventually will add more delay than required.

### 2️⃣ Replace `setImmediate` with `queueMicrotasks`

I selected this approach because:
- it seems like both `queueMicrotasks` and `setImmediate` acts similarly in terms of task scheduling and adding it to a queue;
- the same solution was chosen by Reanimated team.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/712

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- use `queueMicrotask` instead of `setImmediate`;

## 🤔 How Has This Been Tested?

Tested on example when `setImmediate` was added.

## 📸 Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/b6177cb9-fa90-4d68-9ac5-1e80a2c90155)

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
