### PR TITLE
feat: state

### DIFF
--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -84,6 +84,14 @@ if (KeyboardController.isVisible()) {
 }
 ```
 
+### `state`
+
+```ts
+static state(): KeyboardEventData | null;
+```
+
+This method returns the last keyboard state. It returns `null` if keyboard was not shown in the app yet.
+
 ### `setFocusTo`
 
 ```ts

--- a/jest/index.js
+++ b/jest/index.js
@@ -55,6 +55,7 @@ const mock = {
     dismiss: jest.fn().mockReturnValue(Promise.resolve()),
     setFocusTo: jest.fn(),
     isVisible: jest.fn().mockReturnValue(false),
+    state: jest.fn().mockReturnValue(null),
   },
   AndroidSoftInputModes: {
     SOFT_INPUT_ADJUST_NOTHING: 48,

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,15 +1,18 @@
 import { KeyboardControllerNative, KeyboardEvents } from "./bindings";
 
-import type { KeyboardControllerModule } from "./types";
+import type { KeyboardControllerModule, KeyboardEventData } from "./types";
 
 let isClosed = false;
+let lastEvent: KeyboardEventData | null = null;
 
-KeyboardEvents.addListener("keyboardDidHide", () => {
+KeyboardEvents.addListener("keyboardDidHide", (e) => {
   isClosed = true;
+  lastEvent = e;
 });
 
-KeyboardEvents.addListener("keyboardDidShow", () => {
+KeyboardEvents.addListener("keyboardDidShow", (e) => {
   isClosed = false;
+  lastEvent = e;
 });
 
 const dismiss = async (): Promise<void> => {
@@ -29,11 +32,13 @@ const dismiss = async (): Promise<void> => {
   });
 };
 const isVisible = () => !isClosed;
+const state = () => lastEvent;
 
 export const KeyboardController: KeyboardControllerModule = {
   setDefaultMode: KeyboardControllerNative.setDefaultMode,
   setInputMode: KeyboardControllerNative.setInputMode,
   setFocusTo: KeyboardControllerNative.setFocusTo,
-  dismiss: dismiss,
+  dismiss,
   isVisible,
+  state,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,7 @@ export type KeyboardControllerModule = {
   dismiss: () => Promise<void>;
   setFocusTo: (direction: Direction) => void;
   isVisible: () => boolean;
+  state: () => KeyboardEventData | null;
 };
 export type KeyboardControllerNativeModule = {
   // android only


### PR DESCRIPTION
## 📜 Description

Added `KeyboardController.state()` method.

## 💡 Motivation and Context

To achieve a parity with `Keyboard` API from `react-native` I decided to add `KeyboardController.state()` method. By design it should act as `Keyboard.metrics()` method. The reason why I choose `state` name instead of `metrics` is because our data structure returns more like state rather than a metrics - instead of `height` and layout information we also return additional data, such as `duration` of last animation, `timestamp` when last open happened, `target` of focused input and in future potentially `type`, `appearance` and maybe other properties.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `KeyboardController.state()` method;

### Docs

- added a reference about `KeyboardController.state()` method;

## 🤔 How Has This Been Tested?

Tested manually in example app.

## 📸 Screenshots (if appropriate):

<img width="898" alt="image" src="https://github.com/user-attachments/assets/338b6d9d-e82a-4f69-a023-01a1f41c1d20">

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
