### PR TITLE
docs: TS errors in `KeyboardAvoidingView`

### DIFF
--- a/docs/docs/api/components/keyboard-avoiding-view.mdx
+++ b/docs/docs/api/components/keyboard-avoiding-view.mdx
@@ -48,7 +48,6 @@ export default function KeyboardAvoidingViewExample() {
   return (
     <KeyboardAvoidingView
       behavior={"padding"}
-      contentContainerStyle={styles.container}
       keyboardVerticalOffset={100}
       style={styles.content}
     >
@@ -67,9 +66,6 @@ export default function KeyboardAvoidingViewExample() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   content: {
     flex: 1,
     maxHeight: 600,

--- a/docs/versioned_docs/version-1.15.0/api/components/keyboard-avoiding-view.mdx
+++ b/docs/versioned_docs/version-1.15.0/api/components/keyboard-avoiding-view.mdx
@@ -48,7 +48,6 @@ export default function KeyboardAvoidingViewExample() {
   return (
     <KeyboardAvoidingView
       behavior={"padding"}
-      contentContainerStyle={styles.container}
       keyboardVerticalOffset={100}
       style={styles.content}
     >
@@ -67,9 +66,6 @@ export default function KeyboardAvoidingViewExample() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   content: {
     flex: 1,
     maxHeight: 600,


### PR DESCRIPTION
## 📜 Description

Remove `contentContainerStyle` for `KeyboardAvoidingView` in documentation as it's not needed and after https://github.com/kirillzyusko/react-native-keyboard-controller/pull/711 it trigerrs TS errors.

## 💡 Motivation and Context

Conditional types were added intentionally to spot issues like this. Glad to see it works 😅 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/732

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- remove `contentContainerStyle` for `KeyboardAvoidingView`.

## 🤔 How Has This Been Tested?

Tested on localhost:3000

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
