### PR TITLE
fix: handle progress being infinite

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -251,7 +251,7 @@ class KeyboardAnimationCallback(
 
     var progress = 0.0
     try {
-      progress = abs((height / persistentKeyboardHeight)).let { if (it.isNaN()) 0.0 else it }
+      progress = abs((height / persistentKeyboardHeight)).let { if (it.isNaN() || it.isInfinite()) 0.0 else it }
     } catch (e: ArithmeticException) {
       // do nothing, just log an exception send progress as 0
       Logger.w(TAG, "Caught arithmetic exception during `progress` calculation: $e")


### PR DESCRIPTION
## 📜 Description

Add a numerical safety test to keyboard animation progress

## 💡 Motivation and Context

It solves a random crash in production where progress is infinite

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/739 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/737 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/735

## 📢 Changelog

### Android

- added `isInfinite` check along with `isNaN`;

## 🤔 How Has This Been Tested?

Releasing it to production via a patch package the error report disappeared

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
