### PR TITLE
fix: apply monkey patch before `StatusBar` updates

### DIFF
--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -1,5 +1,5 @@
 /* eslint react/jsx-sort-props: off */
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Animated, Platform, StyleSheet } from "react-native";
 import {
   controlEdgeToEdgeValues,
@@ -192,8 +192,8 @@ export const KeyboardProvider = ({
     [],
   );
 
-  // effects
-  useEffect(() => {
+  // layout effects
+  useLayoutEffect(() => {
     if (enabled) {
       applyMonkeyPatch();
     } else {


### PR DESCRIPTION
## 📜 Description

Execute monkey-patch applying earlier than `StatusBar` modifications.

## 💡 Motivation and Context

It happens when `KeyboardProvider` had direct child as `StatusBar` - and such thing can happen in `expo-router`, for example: https://github.com/expo/expo/blob/5f40a80019bb6b892eda94dd244fdc0df8880ccb/packages/expo-router/src/ExpoRoot.tsx#L57

To prevent this problem I'm executing monkey patch applying in "layout effect" instead of plain "effect". This gives me a precious time and an ability to apply patch earlier and thus re-direct a call to my module.

And if we dig a little bit deeper. When `KeyboardProvider` gets mounted the `useLayoutEffect` will be fired after component mount. On contrast `StatusBar` will try to change its properties in `componentDidMount`. And technically `componentDidMount` will be executed first (before `useLayoutEffect`). But `StatusBar` schedules update via `setImmediate` and `setImmediate` will execute its callback after `useLayoutEffect`, so this fix should work 🙂 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/708 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/587

## 📢 Changelog

### Android

- apply monkey patch in layout effect to be sure monkey patch can be applied earlier than first call to `StatusBar` module (if `KeyboardProvider` and `StatusBar` were mounted simultaneously).

## 🤔 How Has This Been Tested?

Tested manually in https://github.com/NyoriK/keyboard-controller-test-project

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/6e259ffe-de59-46a6-b9a6-26de05698b06

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
