### PR TITLE
fix: ios unit tests (CI)

### DIFF
--- a/.github/workflows/verify-ios.yml
+++ b/.github/workflows/verify-ios.yml
@@ -56,7 +56,7 @@ jobs:
         run: yarn lint-clang
   unit-tests:
     name: 📖 Unit tests
-    runs-on: macOS-14
+    runs-on: macOS-15
     defaults:
       run:
         working-directory: ./ios/KeyboardControllerNative


### PR DESCRIPTION
## 📜 Description

Fixed failing iOS unit tests.

## 💡 Motivation and Context

Seems like moving to latest runner fixes the problem.

## 📢 Changelog

### CI

- change macos runner t 15 for iOS unit tests;

## 🤔 How Has This Been Tested?

Tested in this PR.

## 📸 Screenshots (if appropriate):

<img width="851" alt="image" src="https://github.com/user-attachments/assets/4c194727-8fbf-407c-9da7-0f202d5fc70f" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
