### PR TITLE
Add preserveEdgeToEdge prop

### DIFF
--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -36,6 +36,12 @@ class KeyboardControllerViewManager(
     value: Boolean,
   ) = manager.setNavigationBarTranslucent(view as EdgeToEdgeReactViewGroup, value)
 
+  @ReactProp(name = "preserveEdgeToEdge")
+  override fun setPreserveEdgeToEdge(
+    view: ReactViewGroup,
+    value: Boolean,
+  ) = manager.setPreserveEdgeToEdge(view as EdgeToEdgeReactViewGroup, value)
+
   @ReactProp(name = "enabled")
   override fun setEnabled(
     view: ReactViewGroup,

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -37,6 +37,13 @@ class KeyboardControllerViewManagerImpl(
     view.setNavigationBarTranslucent(isNavigationBarTranslucent)
   }
 
+  fun setPreserveEdgeToEdge(
+    view: EdgeToEdgeReactViewGroup,
+    isPreservingEdgeToEdge: Boolean,
+  ) {
+    view.setPreserveEdgeToEdge(isPreservingEdgeToEdge)
+  }
+
   fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
     val map: MutableMap<String, Any> =
       MapBuilder.of(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -29,9 +29,9 @@ class EdgeToEdgeReactViewGroup(
   private val reactContext: ThemedReactContext,
 ) : ReactViewGroup(reactContext) {
   // props
-  private var isStatusBarTranslucent = false
-  private var isNavigationBarTranslucent = false
-  private var active = false
+  private var isStatusBarTranslucent = EDGE_TO_EDGE_ENFORCED
+  private var isNavigationBarTranslucent = EDGE_TO_EDGE_ENFORCED
+  private var active = EDGE_TO_EDGE_ENFORCED
 
   // internal class members
   private var eventView: ReactViewGroup? = null
@@ -124,11 +124,13 @@ class EdgeToEdgeReactViewGroup(
   }
 
   private fun goToEdgeToEdge(edgeToEdge: Boolean) {
-    reactContext.currentActivity?.let {
-      WindowCompat.setDecorFitsSystemWindows(
-        it.window,
-        !edgeToEdge,
-      )
+    if (!EDGE_TO_EDGE_ENFORCED) {
+      reactContext.currentActivity?.let {
+        WindowCompat.setDecorFitsSystemWindows(
+          it.window,
+          !edgeToEdge,
+        )
+      }
     }
   }
 
@@ -201,20 +203,32 @@ class EdgeToEdgeReactViewGroup(
 
   // region Props setters
   fun setStatusBarTranslucent(isStatusBarTranslucent: Boolean) {
-    this.isStatusBarTranslucent = isStatusBarTranslucent
+    if (!EDGE_TO_EDGE_ENFORCED) {
+      this.isStatusBarTranslucent = isStatusBarTranslucent
+    }
   }
 
   fun setNavigationBarTranslucent(isNavigationBarTranslucent: Boolean) {
-    this.isNavigationBarTranslucent = isNavigationBarTranslucent
+    if (!EDGE_TO_EDGE_ENFORCED) {
+      this.isNavigationBarTranslucent = isNavigationBarTranslucent
+    }
   }
 
   fun setActive(active: Boolean) {
-    this.active = active
+    if (!EDGE_TO_EDGE_ENFORCED) {
+      this.active = active
+    }
 
     if (active) {
-      this.enable()
+      this.goToEdgeToEdge(true)
+      this.setupWindowInsets()
+      this.setupKeyboardCallbacks()
+      modalAttachedWatcher.enable()
     } else {
-      this.disable()
+      this.goToEdgeToEdge(false)
+      this.setupWindowInsets()
+      this.removeKeyboardCallbacks()
+      modalAttachedWatcher.disable()
     }
   }
   // endregion
@@ -230,5 +244,12 @@ class EdgeToEdgeReactViewGroup(
 
   companion object {
     val VIEW_TAG = EdgeToEdgeReactViewGroup::class.simpleName
+
+    val EDGE_TO_EDGE_ENFORCED: Boolean = try {
+      Class.forName("com.zoontek.rnedgetoedge.EdgeToEdgePackage")
+      true
+    } catch (exception: ClassNotFoundException) {
+      false
+    }
   }
 }

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -41,6 +41,14 @@ class KeyboardControllerViewManager(
     manager.setNavigationBarTranslucent(view, isNavigationBarTranslucent)
   }
 
+  @ReactProp(name = "preserveEdgeToEdge")
+  fun setPreserveEdgeToEdge(
+    view: EdgeToEdgeReactViewGroup,
+    isPreservingEdgeToEdge: Boolean,
+  ) {
+    manager.setPreserveEdgeToEdge(view, isPreservingEdgeToEdge)
+  }
+
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
     manager.getExportedCustomDirectEventTypeConstants()
 }

--- a/docs/docs/api/keyboard-controller-view.md
+++ b/docs/docs/api/keyboard-controller-view.md
@@ -45,6 +45,10 @@ A boolean prop to indicate whether `StatusBar` should be translucent on `Android
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 
+### `preserveEdgeToEdge` <div className="label android"></div>
+
+A boolean property indicating whether to keep [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) mode always enabled (even when you disable the module). This is useful if you are using an external library to enable it and don't want this library to disable it.
+
 ### `enabled`
 
 A boolean prop indicating whether the view is active or not. If it's `true` then it moves application to [edge-to-edge](https://developer.android.com/training/gestures/edge-to-edge) mode on Android and setup keyboard callbacks. When `false` - moves app away from [edge-to-edge](https://developer.android.com/training/gestures/edge-to-edge) and removes keyboard listeners.

--- a/docs/docs/api/keyboard-provider.md
+++ b/docs/docs/api/keyboard-provider.md
@@ -21,6 +21,14 @@ By default this library stretches to full screen (`edge-to-edge` mode) and statu
 
 A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design/platform-guidance/android-bars.html#android-navigation-bar) should be translucent on `Android` or not.
 
+### `preserveEdgeToEdge` <div className="label android"></div>
+
+A boolean property indicating whether to keep [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) mode always enabled (even when you disable the module). This is useful if you are using an external library to enable it and don't want this library to disable it.
+
+:::info Good to know
+If you use [`react-native-edge-to-edge`](https://github.com/zoontek/react-native-edge-to-edge), then `statusBarTranslucent`, `navigationBarTranslucent` and `preserveEdgeToEdge` are automatically set to `true`, so you don't need to worry about them.
+:::
+
 ### `enabled`
 
 A boolean prop indicating whether the module is enabled. It indicate only initial state, i. e. if you try to change this prop after component mount it will not have any effect. To change the property in runtime use [useKeyboardController](./hooks/module/use-keyboard-controller.md) hook and `setEnabled` method. Defaults to `true`.

--- a/docs/docs/api/keyboard-provider.md
+++ b/docs/docs/api/keyboard-provider.md
@@ -26,7 +26,7 @@ A boolean prop to indicate whether [NavigationBar](https://m2.material.io/design
 A boolean property indicating whether to keep [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) mode always enabled (even when you disable the module). This is useful if you are using an external library to enable it and don't want this library to disable it.
 
 :::info Good to know
-If you use [`react-native-edge-to-edge`](https://github.com/zoontek/react-native-edge-to-edge), then `statusBarTranslucent`, `navigationBarTranslucent` and `preserveEdgeToEdge` are automatically set to `true`, so you don't need to worry about them.
+If you use [react-native-edge-to-edge](https://github.com/zoontek/react-native-edge-to-edge), then `statusBarTranslucent`, `navigationBarTranslucent` and `preserveEdgeToEdge` are automatically set to `true`, so you don't need to worry about them.
 :::
 
 ### `enabled`

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -69,7 +69,7 @@ type KeyboardProviderProps = {
    */
   navigationBarTranslucent?: boolean;
   /**
-   * Set the value to `true`, if you use edge-to-edge display on Android.
+   * A boolean property indicating whether to keep edge-to-edge mode always enabled (even when you disable the module).
    * Defaults to `false`.
    *
    * @see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/592

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -69,6 +69,14 @@ type KeyboardProviderProps = {
    */
   navigationBarTranslucent?: boolean;
   /**
+   * Set the value to `true`, if you use edge-to-edge display on Android.
+   * Defaults to `false`.
+   *
+   * @see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/592
+   * @platform android
+   */
+  preserveEdgeToEdge?: boolean;
+  /**
    * A boolean prop indicating whether the module is enabled. It indicate only initial state,
    * i. e. if you try to change this prop after component mount it will not have any effect.
    * To change the property in runtime use `useKeyboardController` hook and `setEnabled` method.
@@ -85,6 +93,7 @@ export const KeyboardProvider = ({
   children,
   statusBarTranslucent,
   navigationBarTranslucent,
+  preserveEdgeToEdge,
   enabled: initiallyEnabled = true,
 }: KeyboardProviderProps) => {
   // ref
@@ -202,7 +211,11 @@ export const KeyboardProvider = ({
   }, [enabled]);
 
   if (__DEV__) {
-    controlEdgeToEdgeValues({ statusBarTranslucent, navigationBarTranslucent });
+    controlEdgeToEdgeValues({
+      statusBarTranslucent,
+      navigationBarTranslucent,
+      preserveEdgeToEdge,
+    });
   }
 
   return (
@@ -212,6 +225,7 @@ export const KeyboardProvider = ({
         enabled={enabled}
         navigationBarTranslucent={IS_EDGE_TO_EDGE || navigationBarTranslucent}
         statusBarTranslucent={IS_EDGE_TO_EDGE || statusBarTranslucent}
+        preserveEdgeToEdge={IS_EDGE_TO_EDGE || preserveEdgeToEdge}
         style={styles.container}
         // on*Reanimated prop must precede animated handlers to work correctly
         onKeyboardMoveReanimated={keyboardHandler}

--- a/src/specs/KeyboardControllerViewNativeComponent.ts
+++ b/src/specs/KeyboardControllerViewNativeComponent.ts
@@ -53,6 +53,7 @@ export interface NativeProps extends ViewProps {
   enabled?: boolean;
   statusBarTranslucent?: boolean;
   navigationBarTranslucent?: boolean;
+  preserveEdgeToEdge?: boolean;
   // callbacks
   /// keyboard
   onKeyboardMoveStart?: DirectEventHandler<KeyboardMoveEvent>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export type KeyboardControllerProps = {
   // props
   statusBarTranslucent?: boolean;
   navigationBarTranslucent?: boolean;
+  preserveEdgeToEdge?: boolean;
   enabled?: boolean;
 } & ViewProps;
 


### PR DESCRIPTION
## 📜 Description

Currently, even when `react-native-edge-to-edge` is installed, RNKC is able to disable `edge-to-edge`. For example, if we set `enable={false}` on `KeyboardProvider`, `disable` will be called on `EdgeToEdgeReactViewGroup`, and `WindowCompat.setDecorFitsSystemWindows` too.

This change detect if `react-native-edge-to-edge` is installed. If it is, edge-to-edge is forced and cannot be disabled.

## 💡 Motivation and Context

It fixes an issue that breaks edge-to-edge (not only when enabled with `react-native-edge-to-edge`, but in general).

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/592 (_Toggle enabled to false, observe that the NavigationBar reappears and lifts the content._)

## 📢 Changelog

### Android

- Fixes issue with edge-to-edge when `KeyboardProvider` is used with `enabled={false}`.

## 🤔 How Has This Been Tested?

- Using the example app (`react-native-edge-to-edge` installed). Before, when switching on the "14. Enable / disable" screen, we were able to disable edge-to-edge too, not only keyboard management. Now it stays edge-to-edge.

## 📸 Screenshots (if appropriate):

![Screenshot 2025-01-19 at 22 59 31](https://github.com/user-attachments/assets/de7b9b9d-2b57-45ad-a960-f57ea3e0f43b)

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
