### PR TITLE
feat: add ability to turn off adding extra padding for keyboard

### DIFF
--- a/docs/docs/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/docs/api/components/keyboard-aware-scroll-view.mdx
@@ -115,6 +115,10 @@ If you have _**sticky elements**_ above the keyboard and want to extend the keyb
 This property acts as [extraScrollHeight](https://github.com/APSL/react-native-keyboard-aware-scroll-view/tree/9eee405f7b3e261faf86a0fc8e495288d91c853e?tab=readme-ov-file#props) from original [react-native-keyboard-aware-scroll-view](https://github.com/APSL/react-native-keyboard-aware-scroll-view) package.
 :::
 
+### `withKeyboardHeightPadding`
+
+Specifies whether to add padding equal to the keyboard height. This is useful when working with components like a bottom sheet, where the bottom sheet manages the position of the modal above the keyboard. In such cases, adding extra padding for the keyboard is unnecessary.
+
 ## Integration with 3rd party components
 
 ### `FlatList`/`FlashList`/`SectionList` etc.

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -39,6 +39,8 @@ export type KeyboardAwareScrollViewProps = {
   enabled?: boolean;
   /** Adjusting the bottom spacing of KeyboardAwareScrollView. Default is `0` */
   extraKeyboardSpace?: number;
+  /** Specifies whether to add padding equal to the keyboard height. This is useful when working with components like a bottom sheet, where the bottom sheet manages the position of the modal above the keyboard. In such cases, adding extra padding for the keyboard is unnecessary. */
+  withKeyboardHeightPadding?: boolean;
   /** Custom component for `ScrollView`. Default is `ScrollView` */
   ScrollViewComponent?: React.ComponentType<ScrollViewProps>;
 } & ScrollViewProps;
@@ -95,6 +97,7 @@ const KeyboardAwareScrollView = forwardRef<
       extraKeyboardSpace = 0,
       ScrollViewComponent = Reanimated.ScrollView,
       snapToOffsets,
+      withKeyboardHeightPadding = true,
       ...rest
     },
     ref,
@@ -383,7 +386,7 @@ const KeyboardAwareScrollView = forwardRef<
         onLayout={onScrollViewLayout}
       >
         {children}
-        <Reanimated.View style={view} />
+        {withKeyboardHeightPadding && <Reanimated.View style={view} />}
       </ScrollViewComponent>
     );
   },


### PR DESCRIPTION
## 📜 Description

Added an option to specify whether to include keyboard height padding. This is particularly useful for scenarios like bottom sheets, where the position of the modal is already managed relative to the keyboard, and additional padding is unnecessary.

## 💡 Motivation and Context

This change resolves the issue of redundant keyboard padding in components like bottom sheets, which already handle modal positioning relative to the keyboard. By providing an option to disable the keyboard height padding, developers have more control over the layout and can avoid unwanted spacing.

## 📢 Changelog

### JS

- Added a new property to control whether to add keyboard height padding.

### iOS

- No platform-specific changes.

### Android

- No platform-specific changes.

## 🤔 How Has This Been Tested?

Tested by integrating the new property with a bottom sheet component to ensure that keyboard height padding is correctly applied or excluded based on the property value. Checked the behavior on both iOS and Android devices.

## 📸 Screenshots (if appropriate):

### Before:

https://github.com/user-attachments/assets/fb4a5a38-d410-42b7-b34c-e174ac421c23

### After:

https://github.com/user-attachments/assets/5e3c89d4-f001-4b13-a4bb-276e51c8c2c1
<!-- No visual changes introduced by this feature. -->

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed



