### PR TITLE
perf: optimize animations (~5-20% win)

### DIFF
--- a/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
+++ b/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
@@ -11,28 +11,28 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>692279.864500</real>
+					<real>573165.754200</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>2497477.878400</real>
+					<real>1829389.715600</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.223160</real>
+					<real>0.210782</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.251555</real>
+					<real>0.210333</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -42,28 +42,28 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>11784.023400</real>
+					<real>10023.700400</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>52409.916600</real>
+					<real>46197.360400</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.003792</real>
+					<real>0.003686</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.003172</real>
+					<real>0.003241</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
+++ b/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
@@ -18,21 +18,21 @@
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1829389.715600</real>
+					<real>1810000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.210782</real>
+					<real>0.210000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.210333</real>
+					<real>0.210000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -42,28 +42,28 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>10023.700400</real>
+					<real>9790.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>46197.360400</real>
+					<real>46000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.003686</real>
+					<real>0.003600</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.003241</real>
+					<real>0.003220</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
+++ b/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
@@ -11,28 +11,28 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>573165.754200</real>
+					<real>509000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1810000.000000</real>
+					<real>1720000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.210000</real>
+					<real>0.187000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.210000</real>
+					<real>0.187000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -42,7 +42,7 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>9790.000000</real>
+					<real>9480.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -56,14 +56,14 @@
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.003600</real>
+					<real>0.003490</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.003220</real>
+					<real>0.003050</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -76,14 +76,14 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>8198357.543500</real>
+					<real>7640000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>39224511.178500</real>
+					<real>37300000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -107,28 +107,28 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>316000.000000</real>
+					<real>299000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1460000.000000</real>
+					<real>1390000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.097500</real>
+					<real>0.110000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.108737</real>
+					<real>0.109000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/Info.plist
+++ b/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>runDestinationsByUUID</key>
 	<dict>
-		<key>1A32030D-32A5-4C54-9D19-E5D6E86658C9</key>
+		<key>AE1417BE-2A84-4C63-BD95-0B7DE93E2975</key>
 		<dict>
 			<key>localComputer</key>
 			<dict>
@@ -30,7 +30,7 @@
 			<key>targetDevice</key>
 			<dict>
 				<key>modelCode</key>
-				<string>iPhone16,2</string>
+				<string>iPhone16,1</string>
 				<key>platformIdentifier</key>
 				<string>com.apple.platform.iphonesimulator</string>
 			</dict>

--- a/ios/animations/KeyboardAnimation.swift
+++ b/ios/animations/KeyboardAnimation.swift
@@ -23,14 +23,14 @@ public class KeyboardAnimation: KeyboardAnimationProtocol {
   // constructor variables
   let fromValue: Double
   let toValue: Double
-  let speed: Float
+  let speed: Double
   let timestamp: CFTimeInterval
 
   init(fromValue: Double, toValue: Double, animation: CAMediaTiming) {
     self.fromValue = fromValue
     self.toValue = toValue
     self.animation = animation
-    speed = animation.speed
+    speed = Double(animation.speed)
     timestamp = CACurrentMediaTime()
   }
 
@@ -63,7 +63,7 @@ public class KeyboardAnimation: KeyboardAnimationProtocol {
 
     while (upperBound - lowerBound) > tolerance {
       tGuess = (lowerBound + upperBound) / 2
-      let currentValue = valueAt(time: tGuess / Double(speed))
+      let currentValue = valueAt(time: tGuess / speed)
 
       // Adjust the condition to account for the direction of animation
       if (currentValue < value && isIncreasing) || (currentValue > value && !isIncreasing) {
@@ -73,6 +73,6 @@ public class KeyboardAnimation: KeyboardAnimationProtocol {
       }
     }
 
-    return tGuess / Double(speed)
+    return tGuess / speed
   }
 }

--- a/ios/animations/SpringAnimation.swift
+++ b/ios/animations/SpringAnimation.swift
@@ -69,9 +69,7 @@ public final class SpringAnimation: KeyboardAnimation {
       // Under damped
       let envelope = exp(-zeta * omega0 * t)
       let angle = omega1 * t
-      let sinAngle = sin(angle)
-      let cosAngle = cos(angle)
-      y = toValue - envelope * (aUnder * sinAngle + bUnder * cosAngle)
+      y = toValue - envelope * (aUnder * sin(angle) + bUnder * cos(angle))
     } else {
       // Critically damped
       let envelope = exp(-omega0 * t)

--- a/ios/animations/SpringAnimation.swift
+++ b/ios/animations/SpringAnimation.swift
@@ -18,6 +18,7 @@ public final class SpringAnimation: KeyboardAnimation {
   private let v0: Double // Initial velocity
   // pre-computed values
   private let x0: Double
+  private let isUnderDamped: Bool
   private let aUnder: Double
   private let bUnder: Double
   private let aCritical: Double
@@ -40,8 +41,9 @@ public final class SpringAnimation: KeyboardAnimation {
     omega1 = omega0 * sqrt(1.0 - zeta * zeta) // Exponential decay
     v0 = -initialVelocity
     x0 = toValue - fromValue
+    isUnderDamped = zeta < 1
 
-    if zeta < 1 {
+    if isUnderDamped {
       // Under damped
       aCritical = 0
       bCritical = 0
@@ -63,7 +65,7 @@ public final class SpringAnimation: KeyboardAnimation {
     let t = time * Double(speed)
 
     var y: Double
-    if zeta < 1 {
+    if isUnderDamped {
       // Under damped
       let envelope = exp(-zeta * omega0 * t)
       let angle = omega1 * t

--- a/ios/animations/SpringAnimation.swift
+++ b/ios/animations/SpringAnimation.swift
@@ -18,10 +18,10 @@ public final class SpringAnimation: KeyboardAnimation {
   private let v0: Double // Initial velocity
   // pre-computed values
   private let x0: Double
-  private let A_under: Double
-  private let B_under: Double
-  private let A_crit: Double
-  private let B_crit: Double
+  private let aUnder: Double
+  private let bUnder: Double
+  private let aCritical: Double
+  private let bCritical: Double
 
   // constructor variables
   private let stiffness: Double
@@ -42,15 +42,17 @@ public final class SpringAnimation: KeyboardAnimation {
     x0 = toValue - fromValue
 
     if zeta < 1 {
-      A_crit = 0
-      B_crit = 0
-      A_under = (v0 + zeta * omega0 * x0) / omega1
-      B_under = x0
+      // Under damped
+      aCritical = 0
+      bCritical = 0
+      aUnder = (v0 + zeta * omega0 * x0) / omega1
+      bUnder = x0
     } else {
-      A_crit = x0
-      B_crit = (v0 + omega0 * x0)
-      A_under = 0
-      B_under = 0
+      // Critically damped
+      aCritical = x0
+      bCritical = (v0 + omega0 * x0)
+      aUnder = 0
+      bUnder = 0
     }
 
     super.init(fromValue: fromValue, toValue: toValue, animation: animation)
@@ -62,14 +64,16 @@ public final class SpringAnimation: KeyboardAnimation {
 
     var y: Double
     if zeta < 1 {
+      // Under damped
       let envelope = exp(-zeta * omega0 * t)
       let angle = omega1 * t
       let sinAngle = sin(angle)
       let cosAngle = cos(angle)
-      y = toValue - envelope * (A_under * sinAngle + B_under * cosAngle)
+      y = toValue - envelope * (aUnder * sinAngle + bUnder * cosAngle)
     } else {
+      // Critically damped
       let envelope = exp(-omega0 * t)
-      y = toValue - envelope * (A_crit + B_crit * t)
+      y = toValue - envelope * (aCritical + bCritical * t)
     }
 
     return y

--- a/ios/animations/SpringAnimation.swift
+++ b/ios/animations/SpringAnimation.swift
@@ -40,18 +40,18 @@ public final class SpringAnimation: KeyboardAnimation {
     omega1 = omega0 * sqrt(1.0 - zeta * zeta) // Exponential decay
     v0 = -initialVelocity
     x0 = toValue - fromValue
-    
+
     if zeta < 1 {
       A_crit = 0
       B_crit = 0
-            A_under = (v0 + zeta * omega0 * x0) / omega1
-            B_under = x0
-        } else {
-            A_crit = x0
-            B_crit = (v0 + omega0 * x0)
-          A_under = 0
-          B_under = 0
-        }
+      A_under = (v0 + zeta * omega0 * x0) / omega1
+      B_under = x0
+    } else {
+      A_crit = x0
+      B_crit = (v0 + omega0 * x0)
+      A_under = 0
+      B_under = 0
+    }
 
     super.init(fromValue: fromValue, toValue: toValue, animation: animation)
   }
@@ -62,14 +62,14 @@ public final class SpringAnimation: KeyboardAnimation {
 
     var y: Double
     if zeta < 1 {
-        let envelope = exp(-zeta * omega0 * t)
-        let angle = omega1 * t
-        let sinAngle = sin(angle)
-        let cosAngle = cos(angle)
-        y = toValue - envelope * (A_under * sinAngle + B_under * cosAngle)
+      let envelope = exp(-zeta * omega0 * t)
+      let angle = omega1 * t
+      let sinAngle = sin(angle)
+      let cosAngle = cos(angle)
+      y = toValue - envelope * (A_under * sinAngle + B_under * cosAngle)
     } else {
-        let envelope = exp(-omega0 * t)
-        y = toValue - envelope * (A_crit + B_crit * t)
+      let envelope = exp(-omega0 * t)
+      y = toValue - envelope * (A_crit + B_crit * t)
     }
 
     return y

--- a/ios/animations/SpringAnimation.swift
+++ b/ios/animations/SpringAnimation.swift
@@ -62,7 +62,7 @@ public final class SpringAnimation: KeyboardAnimation {
 
   // public functions
   override func valueAt(time: Double) -> Double {
-    let t = time * Double(speed)
+    let t = time * speed
 
     var y: Double
     if isUnderDamped {

--- a/ios/animations/TimingAnimation.swift
+++ b/ios/animations/TimingAnimation.swift
@@ -35,7 +35,7 @@ public final class TimingAnimation: KeyboardAnimation {
 
   // public functions
   override func valueAt(time: Double) -> Double {
-    let x = time * Double(speed)
+    let x = time * speed
     let frames = (animation?.duration ?? 0.0) * Double(speed)
     let fraction = min(x / frames, 1)
     let t = findTForX(xTarget: fraction)


### PR DESCRIPTION
## 📜 Description

Slightly optimized performance of `SpringAnimation` and `TimingAnimation`.

## 💡 Motivation and Context

I didn't change any implementation details. Just re-factored the code and found places that can be optimized, for example:
- pre-compute re-usable variables;
- pre-compute conditions;
- avoid unnecessary types conversion

As a result it gave ~5% boost for `TimingAnimation` and about 10-20% (depend on metric) for `SpringAnimation`.

Pretty cool to have performance tests in the project to see which change gives you which boost.

> On CI turns out after runner re-deploy (in the past) it has a different CPU than my laptop, so it seems like it always create its own baseline (so there is no ability to run perf benchmarks there).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- convert `speed` to `Double` in `KeyboardAnimation` and avoid additional conversions in frequently called methods;
- pre-compute `isUnderDamped` condition (very small boost, but still);
- pre-compute `aUnder`, `bUnder` and `aCritical`, `bCritical`.

## 🤔 How Has This Been Tested?

Tested via performance tests.

## 📸 Screenshots (if appropriate):

Took results on target branch, then switched to `main` and run tests again:

<img width="604" alt="image" src="https://github.com/user-attachments/assets/31ebac9f-a9d8-4c51-8c80-c8d51659b284" />

<img width="610" alt="image" src="https://github.com/user-attachments/assets/ec402a67-b024-4578-a408-09329c0533e3" />

And on this branch:

<img width="597" alt="image" src="https://github.com/user-attachments/assets/5868db1b-f240-4c16-b618-f8441a619ec6" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
