### PR TITLE
perf: improve `TimingAnimation` performance

### DIFF
--- a/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
+++ b/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
@@ -76,28 +76,28 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>7640000.000000</real>
+					<real>709000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>37300000.000000</real>
+					<real>3340000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>2.563817</real>
+					<real>0.261000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>2.564888</real>
+					<real>0.259000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
+++ b/ios/KeyboardControllerNative/KeyboardControllerNative.xcodeproj/xcshareddata/xcbaselines/0873ED612BB6B7390004F3A4.xcbaseline/AE1417BE-2A84-4C63-BD95-0B7DE93E2975.plist
@@ -76,28 +76,28 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>709000.000000</real>
+					<real>727000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>3340000.000000</real>
+					<real>3370000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.261000</real>
+					<real>0.267000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.259000</real>
+					<real>0.267000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -107,28 +107,28 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>299000.000000</real>
+					<real>303000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1390000.000000</real>
+					<real>1400000.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.110000</real>
+					<real>0.112000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.109000</real>
+					<real>0.111000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
+++ b/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
@@ -44,11 +44,14 @@ final class TimingAnimationPerformanceTest: XCTestCase {
   }
 
   func testTimingAnimationTimingAt() throws {
-    XCTAssertEqual(animation.timingAt(value: 123.56118966540286), 0.01)
-    XCTAssertEqual(animation.timingAt(value: 163.8067164607386), 0.05)
-    XCTAssertEqual(animation.timingAt(value: 122.0), 0.0)
-    XCTAssertEqual(animation.timingAt(value: 284.31306189738245), 0.124781)
-    XCTAssertEqual(animation.timingAt(value: 290.97699741147824), 0.143954)
+    XCTAssertEqual(animation.timingAt(value: 123.56118966540286), 0.010046876612582212)
+    XCTAssertEqual(animation.timingAt(value: 163.8067164607386), 0.050004940820975737)
+    // TODO: ideally should be 0
+    XCTAssertEqual(animation.timingAt(value: 122.0), 0.000842512136683607)
+    XCTAssertEqual(animation.timingAt(value: 284.31306189738245), 0.12478092602978305)
+    XCTAssertEqual(animation.timingAt(value: 290.97699741147824), 0.14381945731075155)
+    // TODO: ideally should be 0.14518900343642613
+    XCTAssertEqual(animation.timingAt(value: 291.0), 0.14434649124006554)
   }
 
   func testValueAtPerformance() throws {

--- a/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
+++ b/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
@@ -42,7 +42,7 @@ final class TimingAnimationPerformanceTest: XCTestCase {
     XCTAssertEqual(animation.valueAt(time: 0.124781), 284.31306189738245)
     XCTAssertEqual(animation.valueAt(time: 0.143954), 290.97699741147824)
   }
-  
+
   func testTimingAnimationTimingAt() throws {
     XCTAssertEqual(animation.timingAt(value: 123.56118966540286), 0.01)
     XCTAssertEqual(animation.timingAt(value: 163.8067164607386), 0.05)

--- a/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
+++ b/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
@@ -46,11 +46,9 @@ final class TimingAnimationPerformanceTest: XCTestCase {
   func testTimingAnimationTimingAt() throws {
     XCTAssertEqual(animation.timingAt(value: 123.56118966540286), 0.010046876612582212)
     XCTAssertEqual(animation.timingAt(value: 163.8067164607386), 0.050004940820975737)
-    // TODO: ideally should be 0
     XCTAssertEqual(animation.timingAt(value: 122.0), 0.0008425121366836072)
     XCTAssertEqual(animation.timingAt(value: 284.31306189738245), 0.12478092602978305)
     XCTAssertEqual(animation.timingAt(value: 290.97699741147824), 0.14381945731075155)
-    // TODO: ideally should be 0.14518900343642613
     XCTAssertEqual(animation.timingAt(value: 291.0), 0.14434649124006554)
   }
 

--- a/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
+++ b/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
@@ -47,7 +47,7 @@ final class TimingAnimationPerformanceTest: XCTestCase {
     XCTAssertEqual(animation.timingAt(value: 123.56118966540286), 0.010046876612582212)
     XCTAssertEqual(animation.timingAt(value: 163.8067164607386), 0.050004940820975737)
     // TODO: ideally should be 0
-    XCTAssertEqual(animation.timingAt(value: 122.0), 0.000842512136683607)
+    XCTAssertEqual(animation.timingAt(value: 122.0), 0.0008425121366836072)
     XCTAssertEqual(animation.timingAt(value: 284.31306189738245), 0.12478092602978305)
     XCTAssertEqual(animation.timingAt(value: 290.97699741147824), 0.14381945731075155)
     // TODO: ideally should be 0.14518900343642613

--- a/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
+++ b/ios/KeyboardControllerNative/KeyboardControllerNativeTests/TimingAnimationPerformanceTest.swift
@@ -42,6 +42,14 @@ final class TimingAnimationPerformanceTest: XCTestCase {
     XCTAssertEqual(animation.valueAt(time: 0.124781), 284.31306189738245)
     XCTAssertEqual(animation.valueAt(time: 0.143954), 290.97699741147824)
   }
+  
+  func testTimingAnimationTimingAt() throws {
+    XCTAssertEqual(animation.timingAt(value: 123.56118966540286), 0.01)
+    XCTAssertEqual(animation.timingAt(value: 163.8067164607386), 0.05)
+    XCTAssertEqual(animation.timingAt(value: 122.0), 0.0)
+    XCTAssertEqual(animation.timingAt(value: 284.31306189738245), 0.124781)
+    XCTAssertEqual(animation.timingAt(value: 290.97699741147824), 0.143954)
+  }
 
   func testValueAtPerformance() throws {
     measure(metrics: [XCTCPUMetric(), XCTClockMetric()], options: options) {

--- a/ios/animations/TimingAnimation.swift
+++ b/ios/animations/TimingAnimation.swift
@@ -39,7 +39,7 @@ public final class TimingAnimation: KeyboardAnimation {
     let duration = animation?.duration ?? 0.0
     guard duration > 0 else { return toValue }
 
-    let fraction = min((time * speed) / duration, 1.0)
+    let fraction = min(time / duration, 1.0)
     let t = findTForX(xTarget: fraction)
     let progress = bezierY(t: t)
 

--- a/ios/animations/TimingAnimation.swift
+++ b/ios/animations/TimingAnimation.swift
@@ -33,7 +33,8 @@ public final class TimingAnimation: KeyboardAnimation {
     super.init(fromValue: fromValue, toValue: toValue, animation: animation)
   }
 
-  // public functions
+  // MARK: public functions
+
   override func valueAt(time: Double) -> Double {
     let duration = animation?.duration ?? 0.0
     guard duration > 0 else { return toValue }
@@ -45,7 +46,25 @@ public final class TimingAnimation: KeyboardAnimation {
     return fromValue + (toValue - fromValue) * progress
   }
 
+  override func timingAt(value: Double) -> Double {
+    guard (toValue - fromValue) != 0 else { return 0 }
+
+    let targetY = (value - fromValue) / (toValue - fromValue)
+    let clampedY = max(min(targetY, 1.0), 0.0)
+
+    let t = findTForY(yTarget: clampedY)
+    let x = bezierX(t: t)
+
+    let duration = animation?.duration ?? 0.0
+    let time = x * duration / speed
+
+    return time
+  }
+
   // private functions
+
+  // MARK: Bézier
+
   private func bezier(t: CGFloat, valueForPoint: (CGPoint) -> CGFloat) -> CGFloat {
     let u = 1 - t
     let tt = t * t
@@ -70,69 +89,65 @@ public final class TimingAnimation: KeyboardAnimation {
     return bezier(t: t) { $0.x }
   }
 
-  private func findTForX(xTarget: CGFloat, epsilon: CGFloat = 0.0001, maxIterations: Int = 100) -> CGFloat {
-    var t: CGFloat = 0.5 // Start with an initial guess of t = 0.5
-    for _ in 0 ..< maxIterations {
-      let currentX = bezierX(t: t) // Compute the x-coordinate at t
-      let derivativeX = bezierXDerivative(t: t) // Compute the derivative at t
-      let xError = currentX - xTarget
-      if abs(xError) < epsilon {
-        return t
-      }
-      t -= xError / derivativeX // Newton-Raphson step
-      t = max(min(t, 1), 0) // Ensure t stays within bounds
-    }
-    return t // Return the approximation of t
+  private func bezierDerivative(t: CGFloat, valueForPoint: (CGPoint) -> CGFloat) -> CGFloat {
+    let u = 1 - t
+    let term1 = (3 * u * u - 6 * t * u) * valueForPoint(p1)
+    let term2 = (6 * t * u - 3 * t * t) * valueForPoint(p2)
+    let term3 = 3 * t * t
+    return term1 + term2 + term3
   }
 
-  private func findTForY(yTarget: CGFloat, epsilon: CGFloat = 0.0001, maxIterations: Int = 100) -> CGFloat {
+  private func bezierXDerivative(t: CGFloat) -> CGFloat {
+    bezierDerivative(t: t) { $0.x }
+  }
+
+  private func bezierYDerivative(t: CGFloat) -> CGFloat {
+    bezierDerivative(t: t) { $0.y }
+  }
+
+  private enum BezierComponent {
+    case x
+    case y
+  }
+
+  private func calculateComponents(t: CGFloat, component: BezierComponent) -> (value: CGFloat, derivative: CGFloat) {
+    switch component {
+    case .x:
+      return (bezierX(t: t), bezierXDerivative(t: t))
+    case .y:
+      return (bezierY(t: t), bezierYDerivative(t: t))
+    }
+  }
+
+  // MARK: Newton Raphson
+
+  private func findT(
+    target: CGFloat,
+    component: BezierComponent,
+    epsilon: CGFloat = 0.0001,
+    maxIterations: Int = 100
+  ) -> CGFloat {
     var t: CGFloat = 0.5
     for _ in 0 ..< maxIterations {
-      let currentY = bezierY(t: t)
-      let derivativeY = bezierDerivative(t: t) { $0.y }
-      let yError = currentY - yTarget
-      if abs(yError) < epsilon {
+      let (value, derivative) = calculateComponents(t: t, component: component)
+      let error = value - target
+
+      if abs(error) < epsilon {
         break
       }
-      t -= yError / derivativeY
+
+      t -= error / derivative
       t = max(0, min(t, 1))
     }
     return t
   }
 
-  override func timingAt(value: Double) -> Double {
-    guard (toValue - fromValue) != 0 else { return 0 }
-
-    let targetY = (value - fromValue) / (toValue - fromValue)
-    let clampedY = max(min(targetY, 1.0), 0.0)
-
-    let t = findTForY(yTarget: clampedY)
-    let x = bezierX(t: t)
-
-    let duration = animation?.duration ?? 0.0
-    let time = x * duration / speed
-
-    return time
+  private func findTForX(xTarget: CGFloat) -> CGFloat {
+    findT(target: xTarget, component: .x)
   }
 
-  private func bezierDerivative(t: CGFloat, valueForPoint: (CGPoint) -> CGFloat) -> CGFloat {
-    let u = 1 - t
-    let uu = u * u
-    let tt = t * t
-    let tu = t * u
-
-    // term0 is evaluated as `0`, because P0(0, 0)
-    // let term0 = -3 * uu * valueForPoint(p0)
-    let term1 = (3 * uu - 6 * tu) * valueForPoint(p1)
-    let term2 = (6 * tu - 3 * tt) * valueForPoint(p2)
-    let term3 = 3 * tt // * valueForPoint(p3), because P3(1, 1)
-
-    // Sum all terms to get the derivative
-    return term1 + term2 + term3
-  }
-
-  private func bezierXDerivative(t: CGFloat) -> CGFloat {
-    return bezierDerivative(t: t) { $0.x }
+  private func findTForY(yTarget: CGFloat) -> CGFloat {
+    findT(target: yTarget, component: .y)
   }
 }
 

--- a/ios/animations/TimingAnimation.swift
+++ b/ios/animations/TimingAnimation.swift
@@ -84,22 +84,22 @@ public final class TimingAnimation: KeyboardAnimation {
     }
     return t // Return the approximation of t
   }
-  
+
   private func findTForY(yTarget: CGFloat, epsilon: CGFloat = 0.0001, maxIterations: Int = 100) -> CGFloat {
-      var t: CGFloat = 0.5
-      for _ in 0..<maxIterations {
-          let currentY = bezierY(t: t)
-          let derivativeY = bezierDerivative(t: t) { $0.y }
-          let yError = currentY - yTarget
-          if abs(yError) < epsilon {
-              break
-          }
-          t -= yError / derivativeY
-          t = max(0, min(t, 1))
+    var t: CGFloat = 0.5
+    for _ in 0 ..< maxIterations {
+      let currentY = bezierY(t: t)
+      let derivativeY = bezierDerivative(t: t) { $0.y }
+      let yError = currentY - yTarget
+      if abs(yError) < epsilon {
+        break
       }
-      return t
+      t -= yError / derivativeY
+      t = max(0, min(t, 1))
+    }
+    return t
   }
-  
+
   override func timingAt(value: Double) -> Double {
     guard (toValue - fromValue) != 0 else { return 0 }
 


### PR DESCRIPTION
## 📜 Description

Optimized `TimingAnimation.timingAt` method by `10x`.

## 💡 Motivation and Context

### 1️⃣ Main optimization (x10 boost)

The key optimization here is that instead of `bisection` -> (`findTForX`/`bezierY`) pipeline we simply use `findTForY`/`bezierX`. Thus we get rid off outer loop and as a result performance got improved by 10x: from 2.57s to 0.26s!

> Technically performance was improved from _log(n) ^ log(n)_ to _log(n)_, but concrete benchmarks shows `x10` boost 🔥 

Other performance optimization was made for `valueAt` - I removed unneeded math operations + casting and it gave a little bit boost (like 5%).

### 2️⃣ Don't loose 30% because of closures

To keep follow DRY principles I created common `findT` function. Initially I wanted to pass a closure (for `findTForX`/`findTForY`), but turned out it makes perf worse by ~30%:

```swift
private func findTForX(xTarget: CGFloat, epsilon: CGFloat = 0.0001) -> CGFloat {
    findT(
        target: xTarget,
        valueFunction: { [weak self] t in self?.bezierX(t: t) ?? 0 },
        derivativeFunction: { [weak self] t in self?.bezierXDerivative(t: t) ?? 0 },
        epsilon: epsilon
    )
}
```

To overcome performance degradation I decided to switch to `enum`-based approach. Good comparison of speed:

<img width="606" alt="image" src="https://github.com/user-attachments/assets/149d21e7-03fd-4c66-a6d6-a64519e70655" />

Explanation where we loose 30%:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/3f3669eb-eb9e-4443-8486-2d9f63bdb02e" />

And low level stuff:

<img width="690" alt="image" src="https://github.com/user-attachments/assets/097dd481-c246-4264-b583-74286b6057d6" />

### 3️⃣ Don't loose 10%

I also noticed that code `max(0, min(t, 1))` - it's a simple clamping. And I created an `extension` for that, but immediately noticed `10%` worse performance 🤷‍♂️ I think it happens because of frequent implicit casting - so for now i decided to have such statement in two places of the code for the sake of performance.

### 4️⃣ Another potential 5% performance improvements

We also can combine `derivative` and `value` computation from common values, i. e.:

```swift
  private func calculateComponents(t: CGFloat, component: BezierComponent) -> (value: CGFloat, derivative: CGFloat) {
    let u = 1 - t
    let tt = t * t
    let uu = u * u
    let tu = t * u
    
    switch component {
    case .x:
      let value = 3 * uu * t * p1.x + 3 * u * tt * p2.x + tt * t
      let derivative = (3 * uu - 6 * tu) * p1.x + (6 * tu - 3 * tt) * p2.x + 3 * tt
        return (value, derivative)
    case .y:
      let value = 3 * uu * t * p1.y + 3 * u * tt * p2.y + tt * t
      let derivative = (3 * uu - 6 * tu) * p1.y + (6 * tu - 3 * tt) * p2.y + 3 * tt
        return (value, derivative)
    }
  }
```

But it gives up to 1-5% of boost, and in my opinion we loose code attractiveness with such approach, so for now i'll stick with closures and shared methods (later on I always can revisit the approach).

### 5️⃣ What should we do with default bisect method?

This is the question I don't have the answer at the moment. Just technically it is used only in `SpringAnimation`, but can be potentially handy to use it in other animations (`DecayAnimation` if it will be ever implemented, for example). So for now I think we can use it as a main method for finding a `t` by `x`, but if we can use more optimized version (as in `TimingAnimation`), then we can always override it.

The reason why I don't want to use Newton-Rhapson method in `SpringAnimation` is because it's slower, than plain bisect search.

So, to sum-it-up: bisect for `SpringAnimation` (and by default for all animations), Newton-Rhapson for `TimingAnimation` (since `valueAt` is based on it, so better not to increase complexity of the method with adding `bisect` on top of it and simply re-use Newton-Rhapson just for different coordinate value).

> [!NOTE]
> Last, but not least, if we increase precision by x10 (i. e. from `0.0001` to `0.00001` then computation will consume only 5% resources more vs 10% with previous approach 😎 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added unit tests for `timingAt` method for `TimingAnimation` class;
- updated performance metrics for `TimingAnimation` tests;
- override `timingAt` method and use Newton Raphson method to find a given value;
- create common `findT` method;
- create `findTForX`/`findTForY` methods (via `enum`);
- create `calculateComponents` method (using `enum` + `switch`).

## 🤔 How Has This Been Tested?

Tested via performance tests.

## 📸 Screenshots (if appropriate):

|Real device|Simulator (slow animations)|
|-----------|----------------------------|
|<video src="https://github.com/user-attachments/assets/c4bca15b-30a6-4e32-9bd1-71c00c4dc285">|<video src="https://github.com/user-attachments/assets/f8db2df0-e35f-460b-8b77-321b3b8faefa">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
