### PR TITLE
fix: crash accessing `nativeId` when it's not available

### DIFF
--- a/ios/extensions/UIResponder.swift
+++ b/ios/extensions/UIResponder.swift
@@ -49,7 +49,11 @@ public extension Optional where Wrapped == UIResponder {
     guard let superview = (self as? UIView)?.superview else { return nil }
 
     #if KEYBOARD_CONTROLLER_NEW_ARCH_ENABLED
-      return (superview as NSObject).value(forKey: "nativeId") as? String
+      if superview.responds(to: Selector(("nativeId"))) == true {
+        return (superview as NSObject).value(forKey: "nativeId") as? String
+      }
+
+      return nil
     #else
       return superview.nativeID
     #endif


### PR DESCRIPTION
## 📜 Description

Fixed a crash when you tap on search input inside a header (native stack).

## 💡 Motivation and Context

When accessing `nativeId` property in classes where it's not available (for example `UISearchBarSearchContainerView`, but I assume other UIKit classes as well), we will get a crash:

> *** Terminating app due to uncaught exception 'NSUnknownKeyException', reason: '[<_UISearchBarSearchContainerView 0x15ac1d880> valueForUndefinedKey:]: this class is not key value coding-compliant for the key nativeId.'***

To overcome this problem I added a check whether this property is defined, and if it is defined, only then we query an actual value.

Tested in `FabricExample` and it resolves a crash 🤞 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/784

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- check if view responds to `nativeId` selector before querying `nativeId` value;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro (iOS 17.5) in native-stack example, with adding next options:

```ts
    headerSearchBarOptions: {
      hideWhenScrolling: false,
      placeholder: "Search",
    },
```

And also tested Interactive keyboard on iOS (Fabric) to make sure it works as before.

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/f7393ec3-1ae7-4500-9fe4-e5857a302ec0

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
