### PR TITLE
fix: crash in `KeyboardMovementObserver` due to incorrect KVO removal

### DIFF
--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -103,6 +103,7 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   private func removeKVObserver() {
+    interactiveKeyboardObserver?.invalidate()
     interactiveKeyboardObserver = nil
   }
 


### PR DESCRIPTION
## 📜 Description

Fixed a crash in `KeyboardMovementObserver` due to incorrect KVO removal.

## 💡 Motivation and Context

Similar to https://github.com/kirillzyusko/react-native-keyboard-controller/pull/768

Instead of using plain KVO we are using block-scoped KVO, mainly to prevent random crashes, when we try to remove a KVO from a view that doesn't have it.

I can not 100% gurantee, that crash will not happen again, because a crash was very random and we can not reproduce it ourself (we just see it in Sentry) - so basically I can not test it.

But I'm pretty confident, that a new approach will fix the issue, since we will not accidentally remove KVO where it doesn't exist (because of block-scoped approach) 🤞 

Also new approach reduces code duplication (such as `if keyPath == "center"`) and reduces a number of code lines 👀 

Fixes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/152#issuecomment-2620518076

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- use block-scoped KVO in `KeyboardMovementObserver`;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro (iOS 17.5).

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/acb009a1-8c25-44c5-93ff-cf1ad0a48dc7

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
