### PR TITLE
ci: fix android e2e tests

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -151,7 +151,7 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.devices.api }}-${{ matrix.devices.target }}
       - name: Run emulator and tests
-        uses: reactivecircus/android-emulator-runner@v2.30.1
+        uses: reactivecircus/android-emulator-runner@v2.33.0
         with:
           working-directory: e2e
           api-level: ${{ matrix.devices.api }}


### PR DESCRIPTION
## 📜 Description

Fixed Android e2e tests.
 
## 💡 Motivation and Context

Fixes this problem https://github.com/ReactiveCircus/android-emulator-runner/issues/400

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI
- bump `android-emulator-runner` action version;

## 🤔 How Has This Been Tested?

Tested via CI.

## 📸 Screenshots (if appropriate):

<img width="863" alt="image" src="https://github.com/user-attachments/assets/62df7eaf-1c8f-4755-b0db-a3f301808125" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
