### PR TITLE
fix: exclude android unit tests from being published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "jest",
     "!lib/typescript/example",
     "!android/build",
+    "!android/src/test",
     "!android/.gradle",
     "!android/gradle",
     "!android/gradlew",


### PR DESCRIPTION
## 📜 Description

Exclude `tests` folder on `android` on `npm`.

## 💡 Motivation and Context

The original size of this folder is about ~7kb and may be bigger in the future:

<img width="794" alt="image" src="https://github.com/user-attachments/assets/c9b26db7-b191-4afd-88a9-c117c09e3be8" />

But in a reality those files are not used when devs add the package to their projects. So for sake of the optimization let's exclude those files from publishing to npm 🤞 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- exclude `android/src/test` path;

## 🤔 How Has This Been Tested?

There is no way to test that everything will work, but `size-diff` shows that folder was excluded (because size has been decreased).

## 📸 Screenshots (if appropriate):

<img width="921" alt="image" src="https://github.com/user-attachments/assets/1d162529-c016-4f59-b5d3-3eefe6dd824b" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
