### PR TITLE
fix: universal kotlin/java `onEventDispatch` method signature

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
@@ -30,8 +30,8 @@ class ModalAttachedWatcher(
   private val uiManager = UIManagerHelper.getUIManager(reactContext.reactApplicationContext, archType)
   private val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext.reactApplicationContext, archType)
 
-  override fun onEventDispatch(event: Event<out Event<*>>?) {
-    if (event?.eventName != MODAL_SHOW_EVENT) {
+  override fun onEventDispatch(event: Event<*>) {
+    if (event.eventName != MODAL_SHOW_EVENT) {
       return
     }
 


### PR DESCRIPTION
## 📜 Description

Changed `onEventDispatch` signature and made it universal for kotlin/java codebase (should be compatible with RN 0.77 and RN 0.78).

## 💡 Motivation and Context

Resolves one compilation error mentioned in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/806

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- change `onEventDispatch` signature;

## 🤔 How Has This Been Tested?

Tested on CI 🤞 

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
