### PR TITLE
fix: `RootView` compatibility with RN 0.78

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -163,7 +163,7 @@ class OverKeyboardRootViewGroup(
 
   // region RootView methods
   override fun onChildStartedNativeGesture(
-    childView: View,
+    childView: View?,
     ev: MotionEvent,
   ) {
     eventDispatcher?.let { eventDispatcher ->

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/RootViewCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/RootViewCompat.kt
@@ -12,7 +12,7 @@ interface RootViewCompat : RootView {
     "This method shouldn't be used anymore.",
     ReplaceWith("onChildStartedNativeGesture(View childView, MotionEvent ev)"),
   )
-  override fun onChildStartedNativeGesture(ev: MotionEvent?) {
+  override fun onChildStartedNativeGesture(ev: MotionEvent) {
     onChildStartedNativeGesture(null, ev)
   }
 }


### PR DESCRIPTION
## 📜 Description

Fixed incompatible function signatures after migration some classes in RN 0.78 to kotlin variant.

## 💡 Motivation and Context

It should be backward compatible changes, because I test them on RN 0.77 (and I believe native android build still uses RN 0.77). So we've covered 0.76-0.78 versions, and from what I remember there was no breaking changes between 0.72-0.76 in that class, so it should be fully backward compatible.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/806

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- changed `MotionEvent?` to `MotionEvent` in `onChildStartedNativeGesture` method;
- changed `View` to `View` in `onChildStartedNativeGesture` method.

## 🤔 How Has This Been Tested?

Tested with RN `0.78.0-rc5` version.

## 📸 Screenshots (if appropriate):

Only RNS fails a compilation.

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/20a1659d-cd33-499f-b8f3-08e4b6a12d43" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
