### PR TITLE
fix: stripe crash on Android

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/FocusedInputObserver.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/FocusedInputObserver.kt
@@ -101,7 +101,12 @@ class FocusedInputObserver(
       // unfocused or focus was changed
       if (newFocus == null || oldFocus != null) {
         lastFocusedInput?.removeOnLayoutChangeListener(layoutListener)
-        lastFocusedInput?.removeTextChangedListener(textWatcher)
+        lastFocusedInput?.let { input ->
+          val watcher = textWatcher // Capture the current textWatcher reference
+          input.post {
+            input.removeTextChangedListener(watcher)
+          }
+        }
         selectionSubscription?.invoke()
         lastFocusedInput = null
       }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/FocusedInputObserver.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/FocusedInputObserver.kt
@@ -102,7 +102,9 @@ class FocusedInputObserver(
       if (newFocus == null || oldFocus != null) {
         lastFocusedInput?.removeOnLayoutChangeListener(layoutListener)
         lastFocusedInput?.let { input ->
-          val watcher = textWatcher // Capture the current textWatcher reference
+          val watcher = textWatcher
+          // remove it asynchronously to avoid crash in stripe input
+          // see https://github.com/stripe/stripe-android/issues/10178
           input.post {
             input.removeTextChangedListener(watcher)
           }


### PR DESCRIPTION
## 📜 Description

Fixes a crash after entering date expiry in stripe input on Android.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/807 https://github.com/stripe/stripe-android/issues/10178

The detailed explanation of the problem can be found here: https://github.com/stripe/stripe-android/issues/10178#issuecomment-2667270028

We decided that both frameworks (stripe and keyboard-controller) should implement a fix, so I'm adding asynchronous removal in this PR. Screenshots proving that it works as expected:

#### When we call remove:

<img width="877" alt="image" src="https://github.com/user-attachments/assets/eea4ccb8-4873-4fd0-8794-6f10edb285af" />

#### Async (holds the same references):

<img width="871" alt="image" src="https://github.com/user-attachments/assets/2481ffa8-e610-4d2b-953c-1c9b96c60e3a" />

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- remove text watcher asynchronously (via `.post`) with capturing `TextWatcher` into a closure (to remove correct watcher);

## 🤔 How Has This Been Tested?

Tested manually in example app (with added Stripe SDK).

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/123b72c4-ad48-41ae-88ed-d94645bf2c7d

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
