### PR TITLE
feat: set only one active arch for CI android e2e build

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -73,6 +73,8 @@ jobs:
           key: ${{ runner.os }}-e2e-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-e2e-gradle-
+      - name: Set app active arch
+        run: sed -i.bak 's/reactNativeArchitectures=.*/reactNativeArchitectures=x86_64/' example/gradle.properties      
       - name: Build app
         working-directory: e2e
         run: yarn build-example:android

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -73,8 +73,8 @@ jobs:
           key: ${{ runner.os }}-e2e-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-e2e-gradle-
-      - name: Set app active arch
-        run: sed -i.bak 's/reactNativeArchitectures=.*/reactNativeArchitectures=x86_64/' example/android/gradle.properties
+      # - name: Set app active arch
+      #   run: sed -i.bak 's/reactNativeArchitectures=.*/reactNativeArchitectures=x86_64/' example/android/gradle.properties
       - name: Build app
         working-directory: e2e
         run: yarn build-example:android

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -74,7 +74,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-e2e-gradle-
       - name: Set app active arch
-        run: sed -i.bak 's/reactNativeArchitectures=.*/reactNativeArchitectures=x86_64/' example/android/gradle.properties      
+        run: sed -i.bak 's/reactNativeArchitectures=.*/reactNativeArchitectures=x86_64/' example/android/gradle.properties
       - name: Build app
         working-directory: e2e
         run: yarn build-example:android

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -74,7 +74,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-e2e-gradle-
       - name: Set app active arch
-        run: sed -i.bak 's/reactNativeArchitectures=.*/reactNativeArchitectures=x86_64/' example/gradle.properties      
+        run: sed -i.bak 's/reactNativeArchitectures=.*/reactNativeArchitectures=x86_64/' example/android/gradle.properties      
       - name: Build app
         working-directory: e2e
         run: yarn build-example:android

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -73,8 +73,8 @@ jobs:
           key: ${{ runner.os }}-e2e-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-e2e-gradle-
-      # - name: Set app active arch
-      #   run: sed -i.bak 's/reactNativeArchitectures=.*/reactNativeArchitectures=x86_64/' example/android/gradle.properties
+      - name: Set app active arch
+        run: sed -i.bak 's/reactNativeArchitectures=.*/reactNativeArchitectures=x86_64/' example/android/gradle.properties
       - name: Build app
         working-directory: e2e
         run: yarn build-example:android


### PR DESCRIPTION
## 📜 Description

For our E2E testing, we don’t need to generate a universal APK that includes all architectures. Since the tests are executed on an x86_64 emulator, there is no practical advantage in bundling support for other architectures like arm64-v8a or armeabi-v7a. Given that the testing environment is stable and unlikely to change in the foreseeable future, maintaining a universal APK only adds unnecessary complexity.

By limiting the build to x86_64 only, we achieve a significant reduction in build time since we no longer need to compile the app for multiple architectures. This optimization not only speeds up our CI.

Before: 6m 10s

After: 3m 28s

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

it speeds up the build for CI

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested on CI

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

#### before

<img width="1340" alt="Screenshot 2025-02-19 at 15 55 04" src="https://github.com/user-attachments/assets/e9302e01-f12f-4bfd-bb43-81e41edbe001" />

#### after

<img width="1322" alt="Screenshot 2025-02-19 at 15 25 29" src="https://github.com/user-attachments/assets/ce1c192c-d4cd-4122-9c2a-7b062785283d" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
