### PR TITLE
fix: remove undesired prop memoization

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -33,8 +33,11 @@ data class KeyboardAnimationCallbackConfig(
   val persistentInsetTypes: Int,
   val deferredInsetTypes: Int,
   val dispatchMode: Int = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP,
-  val hasTranslucentNavigationBar: Boolean = false,
-)
+  private val isNavigationBarTranslucent: () -> Boolean
+) {
+  val hasTranslucentNavigationBar: Boolean
+    get() = isNavigationBarTranslucent()
+}
 
 interface Suspendable {
   var isSuspended: Boolean

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -33,11 +33,8 @@ data class KeyboardAnimationCallbackConfig(
   val persistentInsetTypes: Int,
   val deferredInsetTypes: Int,
   val dispatchMode: Int = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP,
-  private val isNavigationBarTranslucent: () -> Boolean
-) {
-  val hasTranslucentNavigationBar: Boolean
-    get() = isNavigationBarTranslucent()
-}
+  var hasTranslucentNavigationBar: Boolean,
+)
 
 interface Suspendable {
   var isSuspended: Boolean

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
@@ -23,7 +23,7 @@ private val areEventsComingFromOwnWindow = !Keyboard.IS_ANIMATION_EMULATED
 class ModalAttachedWatcher(
   private val view: ReactViewGroup,
   private val reactContext: ThemedReactContext,
-  private val config: () -> KeyboardAnimationCallbackConfig,
+  private val config: KeyboardAnimationCallbackConfig,
   private var callback: () -> KeyboardAnimationCallback?,
 ) : EventDispatcherListener {
   private val archType = if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) UIManagerType.FABRIC else UIManagerType.DEFAULT
@@ -61,7 +61,7 @@ class ModalAttachedWatcher(
           view = rootView,
           eventPropagationView = view,
           context = reactContext,
-          config = config(),
+          config = config,
         )
 
       rootView.addView(eventView)

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -39,17 +39,16 @@ class EdgeToEdgeReactViewGroup(
   private var eventView: ReactViewGroup? = null
   private var wasMounted = false
   private var callback: KeyboardAnimationCallback? = null
-  private val config: KeyboardAnimationCallbackConfig
-    get() =
-      KeyboardAnimationCallbackConfig(
-        persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
-        deferredInsetTypes = WindowInsetsCompat.Type.ime(),
-        dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
-        isNavigationBarTranslucent = { isNavigationBarTranslucent }
-      )
+  private val config =
+    KeyboardAnimationCallbackConfig(
+      persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
+      deferredInsetTypes = WindowInsetsCompat.Type.ime(),
+      dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
+      hasTranslucentNavigationBar = isNavigationBarTranslucent,
+    )
 
   // managers/watchers
-  private val modalAttachedWatcher = ModalAttachedWatcher(this, reactContext, ::config, ::getKeyboardCallback)
+  private val modalAttachedWatcher = ModalAttachedWatcher(this, reactContext, config, ::getKeyboardCallback)
 
   init {
     reactContext.setupWindowDimensionsListener()
@@ -212,6 +211,7 @@ class EdgeToEdgeReactViewGroup(
 
   fun setNavigationBarTranslucent(isNavigationBarTranslucent: Boolean) {
     this.isNavigationBarTranslucent = isNavigationBarTranslucent
+    this.config.hasTranslucentNavigationBar = isNavigationBarTranslucent
   }
 
   fun setPreserveEdgeToEdge(isPreservingEdgeToEdge: Boolean) {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -45,7 +45,7 @@ class EdgeToEdgeReactViewGroup(
         persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
         deferredInsetTypes = WindowInsetsCompat.Type.ime(),
         dispatchMode = WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE,
-        hasTranslucentNavigationBar = isNavigationBarTranslucent,
+        isNavigationBarTranslucent = { isNavigationBarTranslucent }
       )
 
   // managers/watchers


### PR DESCRIPTION
## 📜 Description

Get rid off undesired config memoization.

## 💡 Motivation and Context

When `navigationBarTranslucent` prop is set we may already mount a view and keep default `navigationBarTranslucent` value in `KeyboardAnimationCallback`.

The new approach assures that we have a shared config + we update `hasTranslucentNavigationBar` property when props are updated.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/818

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- don't use getter for `config`;
- update `hasTranslucentNavigationBar` when prop gets changed;

## 🤔 How Has This Been Tested?

Tested in reproduction repository.

## 📸 Screenshots (if appropriate):

<img width="234" alt="image" src="https://github.com/user-attachments/assets/b77bc329-63db-4516-8fa4-a2b76b638cd0" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
