### PR TITLE
fix: duplicated events on Fabric

### DIFF
--- a/.github/workflows/build-android-fabric.yml
+++ b/.github/workflows/build-android-fabric.yml
@@ -10,6 +10,7 @@ on:
       - "FabricExample/android/**"
       - "yarn.lock"
       - "FabricExample/yarn.lock"
+      - "FabricExample/patches/**"
       - "src/specs/**"
   pull_request:
     paths:
@@ -18,6 +19,7 @@ on:
       - "FabricExample/android/**"
       - "yarn.lock"
       - "FabricExample/yarn.lock"
+      - "FabricExample/patches/**"
       - "src/specs/**"
 
 jobs:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -10,6 +10,7 @@ on:
       - "example/android/**"
       - "yarn.lock"
       - "example/yarn.lock"
+      - "example/patches/**"
   pull_request:
     paths:
       - ".github/workflows/build-android.yml"
@@ -17,6 +18,7 @@ on:
       - "example/android/**"
       - "yarn.lock"
       - "example/yarn.lock"
+      - "example/patches/**"
 
 jobs:
   build:

--- a/.github/workflows/build-ios-fabric.yml
+++ b/.github/workflows/build-ios-fabric.yml
@@ -11,6 +11,7 @@ on:
       - "FabricExample/ios/**"
       - "yarn.lock"
       - "FabricExample/yarn.lock"
+      - "FabricExample/patches/**"
       - "src/specs/**"
   pull_request:
     branches:
@@ -22,6 +23,7 @@ on:
       - "FabricExample/ios/**"
       - "yarn.lock"
       - "FabricExample/yarn.lock"
+      - "FabricExample/patches/**"
       - "src/specs/**"
 
 jobs:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -11,6 +11,7 @@ on:
       - "example/ios/**"
       - "yarn.lock"
       - "example/yarn.lock"
+      - "example/patches/**"
   pull_request:
     branches:
       - main
@@ -21,6 +22,7 @@ on:
       - "example/ios/**"
       - "yarn.lock"
       - "example/yarn.lock"
+      - "example/patches/**"
 
 jobs:
   build:

--- a/FabricExample/patches/react-native-reanimated+3.16.7.patch
+++ b/FabricExample/patches/react-native-reanimated+3.16.7.patch
@@ -1,0 +1,63 @@
+diff --git a/node_modules/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java b/node_modules/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+index f380575..327b763 100644
+--- a/node_modules/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
++++ b/node_modules/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+@@ -30,6 +30,7 @@ import com.facebook.react.uimanager.UIManagerModule;
+ import com.facebook.react.uimanager.UIManagerReanimatedHelper;
+ import com.facebook.react.uimanager.common.UIManagerType;
+ import com.facebook.react.uimanager.events.Event;
++import com.facebook.react.uimanager.events.EventDispatcher;
+ import com.facebook.react.uimanager.events.EventDispatcherListener;
+ import com.facebook.react.uimanager.events.RCTEventEmitter;
+ import com.swmansion.reanimated.layoutReanimation.AnimationsManager;
+@@ -109,6 +110,7 @@ public class NodesManager implements EventDispatcherListener {
+   public Set<String> uiProps = Collections.emptySet();
+   public Set<String> nativeProps = Collections.emptySet();
+   private ReaCompatibility compatibility;
++  private @Nullable Runnable mUnsubscribe = null;
+ 
+   public NativeProxy getNativeProxy() {
+     return mNativeProxy;
+@@ -129,6 +131,11 @@ public class NodesManager implements EventDispatcherListener {
+       mNativeProxy.invalidate();
+       mNativeProxy = null;
+     }
++
++    if (mUnsubscribe != null) {
++      mUnsubscribe.run();
++      mUnsubscribe = null;
++    }
+   }
+ 
+   public void initWithContext(
+@@ -174,16 +181,20 @@ public class NodesManager implements EventDispatcherListener {
+           }
+         };
+ 
+-    // We register as event listener at the end, because we pass `this` and we haven't finished
+-    // constructing an object yet.
+-    // This lead to a crash described in
+-    // https://github.com/software-mansion/react-native-reanimated/issues/604 which was caused by
+-    // Nodes Manager being constructed on UI thread and registering for events.
+-    // Events are handled in the native modules thread in the `onEventDispatch()` method.
+-    // This method indirectly uses `mChoreographerCallback` which was created after event
+-    // registration, creating race condition
+-    Objects.requireNonNull(UIManagerHelper.getEventDispatcher(context, uiManagerType))
+-        .addListener(this);
++    if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
++      // We register as event listener at the end, because we pass `this` and we haven't finished
++      // constructing an object yet.
++      // This lead to a crash described in
++      // https://github.com/software-mansion/react-native-reanimated/issues/604 which was caused by
++      // Nodes Manager being constructed on UI thread and registering for events.
++      // Events are handled in the native modules thread in the `onEventDispatch()` method.
++      // This method indirectly uses `mChoreographerCallback` which was created after event
++      // registration, creating race condition
++      EventDispatcher eventDispatcher =
++        Objects.requireNonNull(UIManagerHelper.getEventDispatcher(context, uiManagerType));
++      eventDispatcher.addListener(this);
++      mUnsubscribe = () -> eventDispatcher.removeListener(this);
++    }
+ 
+     mAnimationManager = new AnimationsManager(mContext, mUIManager);
+   }


### PR DESCRIPTION
## 📜 Description

Patch reanimated lib to avoid double events.

## 💡 Motivation and Context

I get many requests, so while we are waiting for a new release let's temporary patch the underlying lib to show how to overcome with this problem.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/822 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/753

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- patched reanimated in fabric example app;

### CI

- build example apps if patches were changed

## 🤔 How Has This Been Tested?

Tested locally.

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/c7de4c02-e970-4e6c-a8da-7a13da11fdcf

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
