### PR TITLE
ci: do not clear disk space for build

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -30,13 +30,6 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # force to remove default tools
-          tool-cache: true
-          # preserve Android
-          android: false
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x


### PR DESCRIPTION
## 📜 Description

Removed "Clean up disk" step.

## 💡 Motivation and Context

The "Clean up disk" step takes up to 2.5-3 minutes to complete, but in reality this step is needed only for running e2e tests (because there we run emulator which quickly occupies a lot of storage space). For plain builds we don't use this step and most of the time they can be completed successfully, so I decided to try to remove it.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- remove "Clean up disk" step from android e2e build job;

## 🤔 How Has This Been Tested?

Tested via CI.

## 📸 Screenshots (if appropriate):

<img width="579" alt="image" src="https://github.com/user-attachments/assets/2bb5980d-cc4e-4be7-b05d-6f99ef786270" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
