### PR TITLE
fix: build errors for Fabric on RN 78

### DIFF
--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -18,7 +18,7 @@ class KeyboardControllerViewManager(
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
   private val mDelegate = KeyboardControllerViewManagerDelegate(this)
 
-  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup?> = mDelegate
+  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup> = mDelegate
 
   override fun getName(): String = KeyboardControllerViewManagerImpl.NAME
 

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardGestureAreaViewManager.kt
@@ -18,7 +18,7 @@ class KeyboardGestureAreaViewManager(
   private val manager = KeyboardGestureAreaViewManagerImpl(mReactContext)
   private val mDelegate = KeyboardGestureAreaManagerDelegate(this)
 
-  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup?> = mDelegate
+  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup> = mDelegate
 
   override fun getName(): String = KeyboardGestureAreaViewManagerImpl.NAME
 

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/OverKeyboardViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/OverKeyboardViewManager.kt
@@ -19,7 +19,7 @@ class OverKeyboardViewManager(
   private val manager = OverKeyboardViewManagerImpl(mReactContext)
   private val mDelegate = OverKeyboardViewManagerDelegate(this)
 
-  override fun getDelegate(): ViewManagerDelegate<OverKeyboardHostView?> = mDelegate
+  override fun getDelegate(): ViewManagerDelegate<OverKeyboardHostView> = mDelegate
 
   override fun getName(): String = OverKeyboardViewManagerImpl.NAME
 


### PR DESCRIPTION
## 📜 Description

Removed nullability of delegates.

## 💡 Motivation and Context

It was auto generated code by Android studio when original classes (from react-native) had java classes.

Now they are defined in Kotlin and explicitly are marked as non-nullable, so it conflicts with the code.

So in this PR I remove "nullability" of delegates - it still will be compatible with older RN versions and new RN 0.78 will be supported too 🤞 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/826

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- removed nullability of delegates;

## 🤔 How Has This Been Tested?

Tested in RN 0.78 branch.

## 📸 Screenshots (if appropriate):

<img width="716" alt="image" src="https://github.com/user-attachments/assets/cac7f148-725e-4c24-a89a-777c49e1c915" />

<img width="651" alt="image" src="https://github.com/user-attachments/assets/9327ddb5-129d-4a18-b7b1-ff613e99ce48" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
