### PR TITLE
refactor: use `nativeFabricUIManager` instead of `IS_FABRIC` to detect new architecture in JS

### DIFF
--- a/src/architecture.ts
+++ b/src/architecture.ts
@@ -1,0 +1,1 @@
+export const IS_FABRIC = "nativeFabricUIManager" in global;

--- a/src/views/OverKeyboardView/index.tsx
+++ b/src/views/OverKeyboardView/index.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from "react";
 import { Platform, StyleSheet, View } from "react-native";
 
+import { IS_FABRIC } from "../../architecture";
 import { RCTOverKeyboardView } from "../../bindings";
 import { useWindowDimensions } from "../../hooks";
-import { IS_FABRIC } from "../../architecture";
 
 import type { OverKeyboardViewProps } from "../../types";
 import type { PropsWithChildren } from "react";

--- a/src/views/OverKeyboardView/index.tsx
+++ b/src/views/OverKeyboardView/index.tsx
@@ -3,6 +3,7 @@ import { Platform, StyleSheet, View } from "react-native";
 
 import { RCTOverKeyboardView } from "../../bindings";
 import { useWindowDimensions } from "../../hooks";
+import { IS_FABRIC } from "../../architecture";
 
 import type { OverKeyboardViewProps } from "../../types";
 import type { PropsWithChildren } from "react";
@@ -18,8 +19,7 @@ const OverKeyboardView = ({
       styles.absolute,
       // On iOS - stretch view to full window dimensions to make yoga work
       // On Android Fabric we temporarily use the same approach
-      // @ts-expect-error `_IS_FABRIC` is injected by REA
-      Platform.OS === "ios" || global._IS_FABRIC ? inner : undefined,
+      Platform.OS === "ios" || IS_FABRIC ? inner : undefined,
     ],
     [inner],
   );


### PR DESCRIPTION
## 📜 Description

Replace `global._IS_FABRIC` check with `global.nativeFabricUIManager` check.

## 💡 Motivation and Context

`_IS_FABRIC` is injected by reanimated, and it seems like they may change the variable name and don't treat it as a breaking change.

To avoid further incompatibility I decided to re-work that piece and rely on presence of fabric manager provided by RN.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- rely on `global.nativeFabricUIManager` instead of `global._IS_FABRIC`;

## 🤔 How Has This Been Tested?

Tested on iOS in paper/fabric example projects.

## 📸 Screenshots (if appropriate):

<img width="176" alt="image" src="https://github.com/user-attachments/assets/33622eee-020c-43eb-b0e2-89a91d216719" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
