### PR TITLE
fix: exclude `StatusBar` height from `useWindowDimensions` if `StatusBar` is not translucent

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
@@ -1,7 +1,6 @@
 package com.reactnativekeyboardcontroller.listeners
 
 import android.view.ViewGroup
-import androidx.core.view.marginTop
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.uimanager.ThemedReactContext
 import com.reactnativekeyboardcontroller.extensions.content

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
@@ -41,7 +41,7 @@ class WindowDimensionListener(
     val newDimensions =
       Dimensions(
         content.width.toFloat().dp,
-        content.height.toFloat().dp + content.marginTop.toFloat().dp,
+        content.height.toFloat().dp,
       )
 
     if (newDimensions != lastDispatchedDimensions) {


### PR DESCRIPTION
## 📜 Description

Exclude `StatusBar` height from `useWindowDimensions` if StatusBar is _**not translucent**_.

## 💡 Motivation and Context

In https://github.com/kirillzyusko/react-native-keyboard-controller/pull/468 I added own implementation of `useWindowDimensions`

I mentioned this:

<img width="821" alt="image" src="https://github.com/user-attachments/assets/d74cdc7f-c0bb-47bf-8a4c-e0b315b251c1" />

And as you can see returned values do not match values returned by `useSafeAreaInsets`. Turns out they should match each other to make components like `KeyboardAvoidingView` to work properly.

So in this PR I'm excluding the `marginTop` to match `useSafeAreaInsets` behavior.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/833

Reproduction code:

```tsx
import React from 'react';
import {
  Button,
  StyleSheet,
  TextInput,
  View,
} from 'react-native';
import { KeyboardAvoidingView, KeyboardProvider } from 'react-native-keyboard-controller';
import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';


function Example (): React.JSX.Element {
  return (
    <SafeAreaView
      edges={['bottom', 'left', 'right', 'top']}
      style={styles.safeContainer}>
      <KeyboardAvoidingView
        behavior="height"
        keyboardVerticalOffset={0}
        style={styles.content}>
        <View style={styles.inner}>
          <TextInput placeholder="Name" style={styles.textInput}  />
          <Button title="Submit" />
        </View>
      </KeyboardAvoidingView>
    </SafeAreaView>
  );
}


function App(): React.JSX.Element {
  return (
    <SafeAreaProvider>
      <KeyboardProvider>
        <Example />
      </KeyboardProvider>
    </SafeAreaProvider>
  );
}

const styles = StyleSheet.create({
  safeAreaView: {
    flex: 1,
  },
  safeContainer: {
    flex: 1,
  },
  content: {
    flex:1,
  },
  container: {
    flex: 1,
  },
  inner: {
    flex: 1,
    justifyContent: 'space-between',
  },
  textInput: {
    borderWidth: 1,
    borderColor: 'red',
  },
});

export default App;
```

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- exclude `marginTop` from `useWindowDimensions`;

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro with Android 15.

## 📸 Screenshots (if appropriate):

### `statusBarTranslucent={false}`

|Before (buggy)|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/e3f14d95-b74c-49c3-9a0f-18583e2af176">|<video src="https://github.com/user-attachments/assets/46e1b6b5-7707-4ee8-a024-4728e391091d">|

### `statusBarTranslucent={true}`

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/f860428b-6928-4b02-8d74-ccb5720eafb4">|<video src="https://github.com/user-attachments/assets/bef88eb2-8098-4048-820d-f101130b2e68">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
