### PR TITLE
fix: set shared values in layout effects

### DIFF
--- a/src/components/KeyboardAvoidingView/hooks.ts
+++ b/src/components/KeyboardAvoidingView/hooks.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useLayoutEffect } from "react";
 import { Platform } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 
@@ -10,14 +10,21 @@ const OS = Platform.OS;
 export const useKeyboardAnimation = () => {
   const { reanimated } = useKeyboardContext();
 
-  // calculate it only once on mount, to avoid `SharedValue` reads during a render
-  const [initialHeight] = useState(() => -reanimated.height.value);
-  const [initialProgress] = useState(() => reanimated.progress.value);
+  const heightWhenOpened = useSharedValue(0);
+  const height = useSharedValue(0);
+  const progress = useSharedValue(0);
+  const isClosed = useSharedValue(true);
 
-  const heightWhenOpened = useSharedValue(initialHeight);
-  const height = useSharedValue(initialHeight);
-  const progress = useSharedValue(initialProgress);
-  const isClosed = useSharedValue(initialProgress === 0);
+  useLayoutEffect(() => {
+    const initialHeight = -reanimated.height.value;
+    const initialProgress = reanimated.progress.value;
+
+    // eslint-disable-next-line react-compiler/react-compiler
+    heightWhenOpened.value = initialHeight;
+    height.value = initialHeight;
+    progress.value = initialProgress;
+    isClosed.value = initialProgress === 0;
+  }, []);
 
   useKeyboardHandler(
     {
@@ -25,7 +32,6 @@ export const useKeyboardAnimation = () => {
         "worklet";
 
         if (e.height > 0) {
-          // eslint-disable-next-line react-compiler/react-compiler
           isClosed.value = false;
           heightWhenOpened.value = e.height;
         }
@@ -59,11 +65,13 @@ export const useKeyboardAnimation = () => {
 export const useTranslateAnimation = () => {
   const { reanimated } = useKeyboardContext();
 
-  // calculate it only once on mount, to avoid `SharedValue` reads during a render
-  const [initialProgress] = useState(() => reanimated.progress.value);
-
-  const padding = useSharedValue(initialProgress);
+  const padding = useSharedValue(0);
   const translate = useSharedValue(0);
+
+  useLayoutEffect(() => {
+    // eslint-disable-next-line react-compiler/react-compiler
+    padding.value = reanimated.progress.value;
+  }, []);
 
   useKeyboardHandler(
     {
@@ -71,7 +79,6 @@ export const useTranslateAnimation = () => {
         "worklet";
 
         if (e.height === 0) {
-          // eslint-disable-next-line react-compiler/react-compiler
           padding.value = 0;
         }
         if (OS === "ios") {


### PR DESCRIPTION
## 📜 Description

Fixed `KeyboardAvoidingView` not updating if the keyboard closes before binding event handlers.

## 💡 Motivation and Context

There’s a short timing gap after `KeyboardAvoidingView` initializes and before it listens for keyboard changes. If the keyboard closes during this gap, it isn’t aware that the keyboard has already closed.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/836.

Related to:
$ https://github.com/Expensify/App/issues/56156
PROPOSAL: https://github.com/Expensify/App/issues/56156#issuecomment-2656597451

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- set shared values in useLayoutEffect

## 🤔 How Has This Been Tested?

Tested locally on OnePlus 8 Pro Android 13.

## 📸 Screenshots (if appropriate):

| Before | After |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/9e476052-79cc-4c5d-a0de-33bafd04951a" alt="Before" /> | <video src="https://github.com/user-attachments/assets/0b88d132-463e-4adf-aabe-ff988345d910" alt="After" /> |

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
