### PR TITLE
fix: selection coordinates in container with static height

### DIFF
--- a/FabricExample/src/screens/Examples/FocusedInputHandlers/index.tsx
+++ b/FabricExample/src/screens/Examples/FocusedInputHandlers/index.tsx
@@ -26,6 +26,7 @@ type MaskedInputState = {
 const TextInputWithMicSelection = (props: TextInputProps) => {
   const ref = useRef<TextInput>(null);
   const tag = useSharedValue(-1);
+  const position0 = useSharedValue({ x: 0, y: 0 });
   const position = useSharedValue({ x: 0, y: 0 });
 
   useEffect(() => {
@@ -39,6 +40,10 @@ const TextInputWithMicSelection = (props: TextInputProps) => {
         "worklet";
 
         if (event.target === tag.value) {
+          position0.value = {
+            x: event.selection.start.x,
+            y: event.selection.start.y,
+          };
           position.value = {
             x: event.selection.end.x,
             y: event.selection.end.y,
@@ -46,6 +51,46 @@ const TextInputWithMicSelection = (props: TextInputProps) => {
         }
       },
     },
+    [],
+  );
+
+  const style0 = useAnimatedStyle(
+    () => ({
+      position: "absolute",
+      width: 100,
+      height: 1,
+      backgroundColor: "red",
+      left: 0,
+      top: 0,
+      transform: [
+        {
+          translateX: position0.value.x,
+        },
+        {
+          translateY: position0.value.y,
+        },
+      ],
+    }),
+    [],
+  );
+
+  const style1 = useAnimatedStyle(
+    () => ({
+      position: "absolute",
+      width: 100,
+      height: 1,
+      backgroundColor: "blue",
+      left: 0,
+      top: 0,
+      transform: [
+        {
+          translateX: position.value.x,
+        },
+        {
+          translateY: position.value.y,
+        },
+      ],
+    }),
     [],
   );
 
@@ -71,6 +116,8 @@ const TextInputWithMicSelection = (props: TextInputProps) => {
   return (
     <View>
       <TextInput ref={ref} {...props} />
+      <Reanimated.View style={style0} />
+      <Reanimated.View style={style1} />
       <Reanimated.View style={style} />
     </View>
   );
@@ -127,6 +174,7 @@ export default function TextInputMaskExample() {
       <TextInputWithMicSelection
         multiline
         style={style.input}
+        testID="multiline_input"
         onChangeText={onChangeText}
         onSelectionChange={({ nativeEvent }) =>
           setOriginalSelection(nativeEvent)
@@ -146,8 +194,10 @@ export default function TextInputMaskExample() {
       </Text>
       <Text style={style.text} testID="selection_text_start_end">
         start: {workletSelection.selection.start.position}, end:{" "}
-        {workletSelection.selection.end.position}, target:{" "}
-        {workletSelection.target}
+        {workletSelection.selection.end.position}
+      </Text>
+      <Text style={style.text} testID="selection_text_target">
+        target: {workletSelection.target}
       </Text>
       <Text style={style.text} testID="selection_text_coordinates_start">
         startX: {Math.round(workletSelection.selection.start.x)}, startY:{" "}
@@ -160,9 +210,12 @@ export default function TextInputMaskExample() {
       <Text style={[style.text, style.bold]} testID="original_selection_text">
         Original selection:
       </Text>
-      <Text style={style.text} testID="selection_text_start_end">
+      <Text style={style.text} testID="original_selection_text_start_end">
         start: {originalSelection?.selection.start}, end:{" "}
-        {originalSelection?.selection.end}, target: {originalSelection?.target}
+        {originalSelection?.selection.end}
+      </Text>
+      <Text style={style.text} testID="original_selection_text_target">
+        target: {originalSelection?.target}
       </Text>
     </View>
   );
@@ -173,7 +226,7 @@ const style = StyleSheet.create({
     marginHorizontal: 12,
   },
   input: {
-    height: 50,
+    height: 100,
     backgroundColor: "#dcdcdc",
     color: "black",
     borderRadius: 8,

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
@@ -180,11 +180,6 @@ class KeyboardControllerSelectionWatcher(
           lastSelectionEnd = end
           lastEditTextHeight = editTextHeight
 
-          val cursorPositionStartX: Float
-          val cursorPositionStartY: Float
-          val cursorPositionEndX: Float
-          val cursorPositionEndY: Float
-
           val realStart = min(start, end)
           val realEnd = max(start, end)
 
@@ -201,24 +196,29 @@ class KeyboardControllerSelectionWatcher(
           val gravity = editText.gravity and Gravity.VERTICAL_GRAVITY_MASK
           val paddingVertical = editText.paddingTop + editText.paddingBottom
           val lineHeightHalfHearted = editText.lineHeight / 2
+          val availableVertical = editTextHeight - paddingVertical
           val verticalOffset =
-            when (gravity) {
-              Gravity.CENTER_VERTICAL ->
-                (editTextHeight - paddingVertical - textHeight) / 2 + editText.paddingTop + lineHeightHalfHearted
-              Gravity.BOTTOM -> editTextHeight - textHeight - editText.paddingBottom + lineHeightHalfHearted
-              // Default to Gravity.TOP or other cases
-              else -> editText.paddingTop + lineHeightHalfHearted
+            if (textHeight <= availableVertical) {
+              when (gravity) {
+                Gravity.CENTER_VERTICAL ->
+                  (availableVertical - textHeight) / 2 + editText.paddingTop + lineHeightHalfHearted
+                Gravity.BOTTOM ->
+                  editText.paddingTop + (availableVertical - textHeight) + lineHeightHalfHearted
+                else -> editText.paddingTop + lineHeightHalfHearted
+              }
+            } else {
+              editText.paddingTop + lineHeightHalfHearted
             }
 
-          cursorPositionStartX = layout.getPrimaryHorizontal(realStart)
-          cursorPositionStartY = (baselineStart + verticalOffset).toFloat()
+          val cursorPositionStartX = layout.getPrimaryHorizontal(realStart)
+          val cursorPositionStartY = (baselineStart + verticalOffset - view.scrollY).toFloat()
 
           val lineEnd = layout.getLineForOffset(realEnd)
           val right = layout.getPrimaryHorizontal(realEnd)
           val bottom = layout.getLineBottom(lineEnd)
 
-          cursorPositionEndX = right + cursorWidth
-          cursorPositionEndY = (bottom + verticalOffset).toFloat()
+          val cursorPositionEndX = right + cursorWidth
+          val cursorPositionEndY = (bottom + verticalOffset - view.scrollY).toFloat()
 
           action(
             start,

--- a/example/src/screens/Examples/FocusedInputHandlers/index.tsx
+++ b/example/src/screens/Examples/FocusedInputHandlers/index.tsx
@@ -28,6 +28,7 @@ type MaskedInputState = {
 const TextInputWithMicSelection = (props: TextInputProps) => {
   const ref = useRef<TextInput>(null);
   const tag = useSharedValue(-1);
+  const position0 = useSharedValue({ x: 0, y: 0 });
   const position = useSharedValue({ x: 0, y: 0 });
 
   useEffect(() => {
@@ -41,6 +42,10 @@ const TextInputWithMicSelection = (props: TextInputProps) => {
         "worklet";
 
         if (event.target === tag.value) {
+          position0.value = {
+            x: event.selection.start.x,
+            y: event.selection.start.y,
+          };
           position.value = {
             x: event.selection.end.x,
             y: event.selection.end.y,
@@ -48,6 +53,46 @@ const TextInputWithMicSelection = (props: TextInputProps) => {
         }
       },
     },
+    [],
+  );
+
+  const style0 = useAnimatedStyle(
+    () => ({
+      position: "absolute",
+      width: 100,
+      height: 1,
+      backgroundColor: "red",
+      left: 0,
+      top: 0,
+      transform: [
+        {
+          translateX: position0.value.x,
+        },
+        {
+          translateY: position0.value.y,
+        },
+      ],
+    }),
+    [],
+  );
+
+  const style1 = useAnimatedStyle(
+    () => ({
+      position: "absolute",
+      width: 100,
+      height: 1,
+      backgroundColor: "blue",
+      left: 0,
+      top: 0,
+      transform: [
+        {
+          translateX: position.value.x,
+        },
+        {
+          translateY: position.value.y,
+        },
+      ],
+    }),
     [],
   );
 
@@ -73,6 +118,8 @@ const TextInputWithMicSelection = (props: TextInputProps) => {
   return (
     <View>
       <TextInput ref={ref} {...props} />
+      <Reanimated.View style={style0} />
+      <Reanimated.View style={style1} />
       <Reanimated.View style={style} />
     </View>
   );
@@ -193,7 +240,7 @@ const style = StyleSheet.create({
     marginHorizontal: 12,
   },
   input: {
-    height: 50,
+    height: 100,
     backgroundColor: "#dcdcdc",
     color: "black",
     borderRadius: 8,


### PR DESCRIPTION
## 📜 Description

Fixed wrong selection coordinates in multiline input with `maxHeight` restriction.

## 💡 Motivation and Context

To fix the issue where the cursor coordinates are incorrect when the EditText has a fixed height and the text content exceeds it, we need to adjust the vertical positioning calculation by considering the available space and the scroll position.

### Key changes:

#### Available Vertical Space Calculation

```kt
val availableVertical = editTextHeight - paddingVertical
```

Computes the space available for the text after accounting for padding

#### Adjusted Vertical Offset Based on Text Height

```kt
val verticalOffset = if (textHeight <= availableVertical) {
    when (gravity) {
        Gravity.CENTER_VERTICAL ->
            (availableVertical - textHeight) / 2 + editText.paddingTop + lineHeightHalfHearted
        Gravity.BOTTOM ->
            editText.paddingTop + (availableVertical - textHeight) + lineHeightHalfHearted
        else -> editText.paddingTop + lineHeightHalfHearted
    }
} else {
    editText.paddingTop + lineHeightHalfHearted
}
```

- When the text fits (`textHeight <= availableVertical`), vertical positioning respects gravity (top, center, bottom).
- When text overflows, gravity is ignored, and positioning starts from `paddingTop` (defaulting to top-aligned scrollable content).

#### Scroll Adjustment

```kt
cursorPositionStartY = (baselineStart + verticalOffset - view.scrollY).toFloat()
cursorPositionEndY = (bottom + verticalOffset - view.scrollY).toFloat()
```

Subtracts view.scrollY to account for scrolling, ensuring the cursor's Y position reflects the visible area.

<hr>

- **Handling Gravity and Overflow**: The vertical offset is computed correctly whether the text fits or overflows. Gravity adjustments are only applied when the text is within the available space.

- **Scroll Consideration**: By incorporating scrollY, the cursor's position adjusts dynamically as the user scrolls, ensuring accurate coordinates relative to the visible portion of the EditText.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- group variable `cursorPosition*` declaration with initialization;
- take `view.scrollY` into consideration;
- compare inner content height with container height to get proper vertical offset.

## 🤔 How Has This Been Tested?

Tested on Medium Phone API 35.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/5b788ea7-8d00-4c2f-b19a-e548520c0e71">|<video src="https://github.com/user-attachments/assets/b3a3a18a-6710-4339-a9a9-2ce728564e76">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
