### PR TITLE
fix: crash when pass `dismiss` as event handler

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -19,9 +19,9 @@ KeyboardEvents.addListener("keyboardDidShow", (e) => {
   lastEvent = e;
 });
 
-const dismiss = async (
-  { keepFocus }: DismissOptions = { keepFocus: false },
-): Promise<void> => {
+const dismiss = async (options?: DismissOptions): Promise<void> => {
+  const keepFocus = options?.keepFocus ?? false;
+
   return new Promise((resolve) => {
     if (isClosed) {
       resolve();


### PR DESCRIPTION
## 📜 Description

Allow to pass `onPress={KeyboardController.dismiss}`.

## 💡 Motivation and Context

In https://github.com/kirillzyusko/react-native-keyboard-controller/pull/720 I added an ability to pass `keepFocus` param. To keep a backward compatibility I assigned an empty object by default:

```ts
const dismiss = async (
  { keepFocus }: DismissOptions = { keepFocus: false },
): Promise<void> => {
```

However if we pass touch event - we don't assign our default object. When we try to extract `keepFocus` we get `undefined` and further `undefined` can not be casted to boolean.

In this PR I re-work the approach by combining `?` and `??` operators and passing `false` as default value. In case if `options.keepFocus` is `undefined` I'll pass `false` value by default.

> [!NOTE]
> TS will still complain about incompatible signatures, but I'll try to address it in follow-up PRs.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- specify `keepFocus` as `false` by default;

## 🤔 How Has This Been Tested?

Tested on iPone 15 Pro (iOS 17.5) Fabric example.

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/8d331a8a-04fc-442f-80c7-95314709054d

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
