### PR TITLE
feat: ability to hide "Done" button in `KeyboardToolbar`

### DIFF
--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -72,7 +72,7 @@ const DEFAULT_OPACITY: HEX = "FF";
 const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
   content,
   theme = colors,
-  doneText,
+  doneText = "Done",
   button,
   icon,
   showArrows = true,
@@ -191,19 +191,21 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
         <View style={styles.flex} testID={TEST_ID_KEYBOARD_TOOLBAR_CONTENT}>
           {content}
         </View>
-        <ButtonContainer
-          accessibilityHint="Closes the keyboard"
-          accessibilityLabel="Done"
-          rippleRadius={28}
-          style={styles.doneButtonContainer}
-          testID={TEST_ID_KEYBOARD_TOOLBAR_DONE}
-          theme={theme}
-          onPress={onPressDone}
-        >
-          <Text maxFontSizeMultiplier={1.3} style={doneStyle}>
-            {doneText || "Done"}
-          </Text>
-        </ButtonContainer>
+        {doneText && (
+          <ButtonContainer
+            accessibilityHint="Closes the keyboard"
+            accessibilityLabel="Done"
+            rippleRadius={28}
+            style={styles.doneButtonContainer}
+            testID={TEST_ID_KEYBOARD_TOOLBAR_DONE}
+            theme={theme}
+            onPress={onPressDone}
+          >
+            <Text maxFontSizeMultiplier={1.3} style={doneStyle}>
+              {doneText}
+            </Text>
+          </ButtonContainer>
+        )}
       </View>
     </KeyboardStickyView>
   );


### PR DESCRIPTION
## 📜 Description

Don't show "Done" button, if text is empty.

## 💡 Motivation and Context

If people want to hide "Done" button it may be intuitive guess that `doneText` should be empty text.

I don't want to introduce more props, because `KeyboardToolbar` already has a plenty of them, so let's make `doneText` behavior more predictable.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/847

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- assign "Done" as default `doneText` instead of using `||` operator.

## 🤔 How Has This Been Tested?

Tested on iPhone 15 Pro (iOS 17.5), fabric.

## 📸 Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/7edc3be9-77c0-4d22-9855-038452c1adc5)

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
