### PR TITLE
Removed left padding on KeyboardToolbar when navigation arrows are hidden

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,7 @@ module.exports = {
       {
         quoteProps: "consistent",
         trailingComma: "all",
+        endOfLine: "auto",
       },
     ],
     // react-hooks

--- a/src/components/KeyboardToolbar/Arrow.tsx
+++ b/src/components/KeyboardToolbar/Arrow.tsx
@@ -45,17 +45,23 @@ const arrowLine: ViewStyle = {
   height: 2,
   borderRadius: 1,
 };
-const arrowUpContainer: ViewStyle = {
+
+const arrowContainer: ViewStyle = {
   width: 30,
   height: 30,
   justifyContent: "center",
   alignItems: "center",
 };
+
 const styles = StyleSheet.create({
-  arrowUpContainer: arrowUpContainer,
+  arrowUpContainer: {
+    ...arrowContainer,
+    marginRight: 2.5,
+  },
   arrowDownContainer: {
-    ...arrowUpContainer,
+    ...arrowContainer,
     transform: [{ rotate: "180deg" }],
+    marginLeft: 2.5,
   },
   arrow: {
     width: 20,

--- a/src/components/KeyboardToolbar/Arrow.tsx
+++ b/src/components/KeyboardToolbar/Arrow.tsx
@@ -46,7 +46,6 @@ const arrowLine: ViewStyle = {
   borderRadius: 1,
 };
 const arrowUpContainer: ViewStyle = {
-  marginHorizontal: 5,
   width: 30,
   height: 30,
   justifyContent: "center",

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -109,9 +109,11 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
       styles.toolbar,
       {
         backgroundColor: `${theme[colorScheme].background}${opacity}`,
+        paddingLeft: showArrows ? 8 : 0,
+        paddingRight: 8,
       },
     ],
-    [colorScheme, opacity, theme],
+    [colorScheme, opacity, theme, showArrows],
   );
   const offset = useMemo(
     () => ({ closed: closed + KEYBOARD_TOOLBAR_HEIGHT, opened }),
@@ -222,7 +224,6 @@ const styles = StyleSheet.create({
     width: "100%",
     flexDirection: "row",
     height: KEYBOARD_TOOLBAR_HEIGHT,
-    paddingHorizontal: 8,
   },
   doneButton: {
     fontWeight: "600",

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -225,7 +225,6 @@ const styles = StyleSheet.create({
   },
   arrowsButton: {
     flexDirection: "row",
-    gap: 5,
     paddingHorizontal: DEFAULT_BUTTON_PADDING,
   },
   doneButton: {

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -64,6 +64,7 @@ const TEST_ID_KEYBOARD_TOOLBAR_DONE = `${TEST_ID_KEYBOARD_TOOLBAR}.done`;
 
 const KEYBOARD_TOOLBAR_HEIGHT = 42;
 const DEFAULT_OPACITY: HEX = "FF";
+const DEFAULT_BUTTON_PADDING = 8;
 
 /**
  * `KeyboardToolbar` is a component that is shown above the keyboard with `Prev`/`Next` and
@@ -109,11 +110,9 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
       styles.toolbar,
       {
         backgroundColor: `${theme[colorScheme].background}${opacity}`,
-        paddingLeft: showArrows ? 8 : 0,
-        paddingRight: 8,
       },
     ],
-    [colorScheme, opacity, theme, showArrows],
+    [colorScheme, opacity, theme],
   );
   const offset = useMemo(
     () => ({ closed: closed + KEYBOARD_TOOLBAR_HEIGHT, opened }),
@@ -158,7 +157,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
       <View {...rest} style={toolbarStyle} testID={TEST_ID_KEYBOARD_TOOLBAR}>
         {blur}
         {showArrows && (
-          <>
+          <View style={styles.arrowsButton}>
             <ButtonContainer
               accessibilityHint="Moves focus to the previous field"
               accessibilityLabel="Previous"
@@ -187,7 +186,7 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
                 type="next"
               />
             </ButtonContainer>
-          </>
+          </View>
         )}
 
         <View style={styles.flex} testID={TEST_ID_KEYBOARD_TOOLBAR_CONTENT}>
@@ -198,7 +197,6 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> = ({
             accessibilityHint="Closes the keyboard"
             accessibilityLabel="Done"
             rippleRadius={28}
-            style={styles.doneButtonContainer}
             testID={TEST_ID_KEYBOARD_TOOLBAR_DONE}
             theme={theme}
             onPress={onPressDone}
@@ -225,12 +223,17 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     height: KEYBOARD_TOOLBAR_HEIGHT,
   },
+  arrowsButton: {
+    flexDirection: "row",
+    gap: 5,
+    paddingHorizontal: DEFAULT_BUTTON_PADDING,
+  },
   doneButton: {
+    alignItems: "center",
+    justifyContent: "center",
     fontWeight: "600",
     fontSize: 15,
-  },
-  doneButtonContainer: {
-    marginRight: 8,
+    paddingHorizontal: DEFAULT_BUTTON_PADDING,
   },
 });
 

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -229,8 +229,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: DEFAULT_BUTTON_PADDING,
   },
   doneButton: {
-    alignItems: "center",
-    justifyContent: "center",
     fontWeight: "600",
     fontSize: 15,
     paddingHorizontal: DEFAULT_BUTTON_PADDING,


### PR DESCRIPTION
## 📜 Description
Remove padding when showArrows={false} on KeyboardToolbar

<!-- Describe your changes in detail -->

The KeyboardToolbar component currently applies a fixed paddingHorizontal of 8px even when showArrows is set to false. This creates an unnecessary left padding gap when arrows are hidden. This PR modifies the toolbar styling to conditionally apply paddingLeft only when arrows are visible.

## 💡 Motivation and Context

When setting showArrows={false}, users expect the whole container to be gone. 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/848

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS
- Removed paddingHorizontal from toolbar styles
- Added conditional paddingLeft based on showArrows prop
- Added paddingRight to maintain right-side spacing
- Added showArrows to toolbarStyle useMemo dependencies

## 🤔 How Has This Been Tested?

Tested manually with both showArrows={true} and showArrows={false} to ensure:
- With arrows visible, padding is properly applied on both sides (8px)
- With arrows hidden, left padding is removed (0px) while right padding is maintained (8px)

## 📸 Screenshots (if appropriate):
Before: 
![Before](https://github.com/user-attachments/assets/c87c7c4e-326f-4fc6-96b0-95786a01bccf)

After:
![After](https://github.com/user-attachments/assets/9f261ce4-8469-49d0-9f16-aab6defc0237)

## 📝 Checklist

- [X] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
