### PR TITLE
fix: pending `dismiss` if keyboard wasn't shown in app yet

### DIFF
--- a/FabricExample/src/screens/Examples/Close/index.tsx
+++ b/FabricExample/src/screens/Examples/Close/index.tsx
@@ -1,8 +1,13 @@
 import { useRef, useState } from "react";
 import { Button, StyleSheet, TextInput, View } from "react-native";
-import { KeyboardController } from "react-native-keyboard-controller";
+import {
+  KeyboardController,
+  useResizeMode,
+} from "react-native-keyboard-controller";
 
 function CloseScreen() {
+  useResizeMode();
+
   const ref = useRef<TextInput>(null);
   const [keepFocus, setKeepFocus] = useState(false);
 

--- a/e2e/kit/012-close-keyboard.e2e.ts
+++ b/e2e/kit/012-close-keyboard.e2e.ts
@@ -22,7 +22,9 @@ describe("`KeyboardController.dismiss()` specification", () => {
 
   it("should dismiss keyboard loosing focus", async () => {
     await waitAndTap("close_keyboard_button");
-    await expect(element(by.id("input"))).not.toBeFocused();
+    await waitForExpect(() =>
+      expect(element(by.id("input"))).not.toBeFocused(),
+    );
   });
 
   it("should show keyboard again when input tapped", async () => {

--- a/e2e/kit/012-close-keyboard.e2e.ts
+++ b/e2e/kit/012-close-keyboard.e2e.ts
@@ -22,9 +22,7 @@ describe("`KeyboardController.dismiss()` specification", () => {
 
   it("should dismiss keyboard loosing focus", async () => {
     await waitAndTap("close_keyboard_button");
-    await waitForExpect(() =>
-      expect(element(by.id("input"))).not.toBeFocused(),
-    );
+    await expect(element(by.id("input"))).not.toBeFocused();
   });
 
   it("should show keyboard again when input tapped", async () => {

--- a/example/src/screens/Examples/Close/index.tsx
+++ b/example/src/screens/Examples/Close/index.tsx
@@ -1,8 +1,13 @@
 import { useRef, useState } from "react";
 import { Button, StyleSheet, TextInput, View } from "react-native";
-import { KeyboardController } from "react-native-keyboard-controller";
+import {
+  KeyboardController,
+  useResizeMode,
+} from "react-native-keyboard-controller";
 
 function CloseScreen() {
+  useResizeMode();
+
   const ref = useRef<TextInput>(null);
   const [keepFocus, setKeepFocus] = useState(false);
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,7 +6,7 @@ import type {
   KeyboardEventData,
 } from "./types";
 
-let isClosed = false;
+let isClosed = true;
 let lastEvent: KeyboardEventData | null = null;
 
 KeyboardEvents.addListener("keyboardDidHide", (e) => {


### PR DESCRIPTION
## 📜 Description

Specify `isClosed=true` by default.

## 💡 Motivation and Context

By default when app starts the keyboard is closed. So `isClosed` should be `true` 🙂 

Code that I used for testing:

```tsx
import { StyleSheet, Alert, TextInput, TouchableOpacity, Text } from 'react-native';

import {
  KeyboardAwareScrollView,
  KeyboardController,
  KeyboardProvider,
} from 'react-native-keyboard-controller';

export default function HomeScreen() {
  return (
    <KeyboardProvider>
      <KeyboardAwareScrollView
        bounces={false}
        keyboardDismissMode="interactive"
        keyboardShouldPersistTaps="handled"
        style={styles.container}
      >
        <TextInput editable style={styles.input} />
        <TouchableOpacity onPress={() => KeyboardController.dismiss().then(() => Alert.alert('Dismissed'))}>
          <Text>Press me to dismiss</Text>
        </TouchableOpacity>
      </KeyboardAwareScrollView>
    </KeyboardProvider>
  );
}

const styles = StyleSheet.create({
  input: {
    borderBottomColor: 'black',
    borderBottomWidth: 1,
  },
  container: {
    flex: 1,
    paddingTop: 100,
    backgroundColor: "white",
  },
});
```

> One interesting thing that I discovered is that on Android 9 e2e tests stopped to work. Turned out I had to set `adjustResize` mode to make app working well (on Android 9 `WindowInsetsCallbackCompat` events are not triggered if we are in `adjustPan`). Initially I wanted to fix it by replacing `KeyboardEvents` -> `Keyboard`, but then I realized, that `Keyboard` events may not be synchronized with animation on Android, so decided just add `useResizeMode` hook in example app to make e2e tests green again. But I'll keep in mind this fact.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/854

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- set `isClosed=true` instead of `isClosed=false` as default value;

## 🤔 How Has This Been Tested?

Tested in reproduction example and via e2e tests.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/6a1fa7dc-87ac-4eff-810f-b99a5ab5f95c">|<video src="https://github.com/user-attachments/assets/2ccd11c7-57d2-4e34-890b-1e27163e7f16">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
