### PR TITLE
docs: updated Expo installation instruction

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -38,6 +38,17 @@ npm install react-native-keyboard-controller --save
 ```
 
 </TabItem>
+<TabItem value="expo" label="EXPO">
+
+```shell
+npx expo install react-native-keyboard-controller
+```
+
+:::note Only Expo Dev client compatible
+This library has native code, so it **does not work** with _Expo Go_ but it's fully compatible with [custom dev client](https://docs.expo.dev/development/getting-started/).
+:::
+
+</TabItem>
 </Tabs>
 
 :::warning Mandatory `react-native-reanimated` dependency
@@ -51,13 +62,9 @@ This package supports [autolinking](https://github.com/react-native-community/cl
 
 :::tip Pods update
 
-Don't forget to re-install `pods` after adding the package and don't forget to re-assemble `android` and `ios` applications, since this library contains native code.
+After adding the package don't forget to **re-install** `pods` and **re-assemble** `android` and `ios` applications, since this library contains native code.
 
 :::
-
-### Expo
-
-This library has native code, so it does not work with _Expo Go_ but you can easily install it using a [custom dev client](https://docs.expo.dev/development/getting-started/).
 
 ## Adding provider
 

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -64,6 +64,7 @@ This package supports [autolinking](https://github.com/react-native-community/cl
 
 After adding the package don't forget to **re-install** `pods` and **re-assemble** `android` and `ios` applications, since this library contains native code.
 
+If you still experience issues like **package doesn't seem to be linked** try performing a [fresh build](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/786#issuecomment-2741464142) to clear any outdated cache.
 :::
 
 ## Adding provider

--- a/docs/versioned_docs/version-1.16.0/installation.mdx
+++ b/docs/versioned_docs/version-1.16.0/installation.mdx
@@ -38,6 +38,17 @@ npm install react-native-keyboard-controller --save
 ```
 
 </TabItem>
+<TabItem value="expo" label="EXPO">
+
+```shell
+npx expo install react-native-keyboard-controller
+```
+
+:::note Only Expo Dev client compatible
+This library has native code, so it **does not work** with _Expo Go_ but it's fully compatible with [custom dev client](https://docs.expo.dev/development/getting-started/).
+:::
+
+</TabItem>
 </Tabs>
 
 :::warning Mandatory `react-native-reanimated` dependency
@@ -51,13 +62,9 @@ This package supports [autolinking](https://github.com/react-native-community/cl
 
 :::tip Pods update
 
-Don't forget to re-install `pods` after adding the package and don't forget to re-assemble `android` and `ios` applications, since this library contains native code.
+After adding the package don't forget to **re-install** `pods` and **re-assemble** `android` and `ios` applications, since this library contains native code.
 
 :::
-
-### Expo
-
-This library has native code, so it does not work with _Expo Go_ but you can easily install it using a [custom dev client](https://docs.expo.dev/development/getting-started/).
 
 ## Adding provider
 

--- a/docs/versioned_docs/version-1.16.0/installation.mdx
+++ b/docs/versioned_docs/version-1.16.0/installation.mdx
@@ -64,6 +64,7 @@ This package supports [autolinking](https://github.com/react-native-community/cl
 
 After adding the package don't forget to **re-install** `pods` and **re-assemble** `android` and `ios` applications, since this library contains native code.
 
+If you still experience issues like **package doesn't seem to be linked** try performing a [fresh build](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/786#issuecomment-2741464142) to clear any outdated cache.
 :::
 
 ## Adding provider


### PR DESCRIPTION
## 📜 Description

Updated installation guide.

## 💡 Motivation and Context

People sometimes complain about the problem when package is not linked, so I decided to improve docs to reduce similar issues in the future.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/786

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- clearly mention expo setup (because expo uses its own installation command);
- mention a problem and solution of build caches;
- move expo note under expo installation tab.

## 🤔 How Has This Been Tested?

Tested locally and via preview.

## 📸 Screenshots (if appropriate):

<img width="989" alt="image" src="https://github.com/user-attachments/assets/223f534f-60fc-4a42-8330-c8ed506f26d3" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
