### PR TITLE
docs: remove useless box style from first animation

### DIFF
--- a/docs/versioned_docs/version-1.16.0/guides/first-animation.md
+++ b/docs/versioned_docs/version-1.16.0/guides/first-animation.md
@@ -38,11 +38,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "flex-end",
   },
-  box: {
-    width: 60,
-    height: 60,
-    marginVertical: 20,
-  },
   row: {
     flexDirection: "row",
   },


### PR DESCRIPTION
## 📜 Description

Fixing this error

```
Unused style detected: styles.boxeslint(react-native/no-unused-styles)
```

## 💡 Motivation and Context

ESLint is yelling at me

![CleanShot 2025-03-21 at 12 30 48](https://github.com/user-attachments/assets/b96d6285-90c8-4e2c-ae75-66761a6f9f8d)

## 🤔 How Has This Been Tested?

Just copy/paste the code example on my codebase.
