### PR TITLE
docs: use documentation installation page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check out the [installation](https://kirillzyusko.github.io/react-native-keyboar
 
 ## Documentation
 
-Check out our dedicated documentation page for info about this library, API reference and more: [https://kirillzyusko.github.io/react-native-keyboard-controller/](https://kirillzyusko.github.io/react-native-keyboard-controller/)
+Check out the dedicated documentation page for information about this library, API reference and more: [https://kirillzyusko.github.io/react-native-keyboard-controller/](https://kirillzyusko.github.io/react-native-keyboard-controller/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,7 @@ Keyboard manager which works in identical way on both iOS and Android.
 
 ## Installation
 
-Install `react-native-keyboard-controller` package from npm:
-
-```shell
-yarn add react-native-keyboard-controller
-# or
-npm install react-native-keyboard-controller --save
-```
+Check out the [installation](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/installation) section of docs for the detailed installation instructions.
 
 ## Documentation
 


### PR DESCRIPTION
## 📜 Description

Replace installation instructions with a docs guide.

## 💡 Motivation and Context

We still ahve to keep people aware, that reanimated is a mandatory dependency, that people need to wrap app in Provider, separate instructions for Expo, etc.

So let's use a single source of truth in documentation and just use link to docs in README.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/877

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- use link to docs for installation step;
- removed "our" in documentation details;
- use "information" instead of "info";

## 🤔 How Has This Been Tested?

Tested via preview.

## 📸 Screenshots (if appropriate):

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/77043ef7-5034-4653-8f63-672d6c251214" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
