### PR TITLE
feat: `KeyboardStickyView` using plain Animated

### DIFF
--- a/src/components/KeyboardStickyView/index.tsx
+++ b/src/components/KeyboardStickyView/index.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useMemo } from "react";
 import { Animated } from "react-native";
 
-import { useKeyboardAnimation } from "react-native-keyboard-controller";
+import { useKeyboardAnimation } from "../../hooks";
 
 import type { View, ViewProps } from "react-native";
 

--- a/src/components/KeyboardStickyView/index.tsx
+++ b/src/components/KeyboardStickyView/index.tsx
@@ -1,10 +1,7 @@
 import React, { forwardRef, useMemo } from "react";
-import Reanimated, {
-  interpolate,
-  useAnimatedStyle,
-} from "react-native-reanimated";
+import { Animated } from "react-native";
 
-import { useReanimatedKeyboardAnimation } from "../../hooks";
+import { useKeyboardAnimation } from "react-native-keyboard-controller";
 
 import type { View, ViewProps } from "react-native";
 
@@ -41,25 +38,29 @@ const KeyboardStickyView = forwardRef<
     },
     ref,
   ) => {
-    const { height, progress } = useReanimatedKeyboardAnimation();
+    const { height, progress } = useKeyboardAnimation();
 
-    const stickyViewStyle = useAnimatedStyle(() => {
-      const offset = interpolate(progress.value, [0, 1], [closed, opened]);
-
-      return {
-        transform: [{ translateY: enabled ? height.value + offset : closed }],
-      };
-    }, [closed, opened, enabled]);
+    const offset = progress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [closed, opened],
+    });
 
     const styles = useMemo(
-      () => [style, stickyViewStyle],
-      [style, stickyViewStyle],
+      () => [
+        {
+          transform: [
+            { translateY: enabled ? Animated.add(height, offset) : closed },
+          ],
+        },
+        style,
+      ],
+      [closed, enabled, height, offset, style],
     );
 
     return (
-      <Reanimated.View ref={ref} style={styles} {...props}>
+      <Animated.View ref={ref} style={styles} {...props}>
         {children}
-      </Reanimated.View>
+      </Animated.View>
     );
   },
 );


### PR DESCRIPTION
## 📜 Description

Fixed a problem when `KeyboardStickyView`/`KeyboardToolbar` changes other component behavior in unpredictable way.

## 💡 Motivation and Context

The original problem comes from that issue: https://github.com/facebook/react-native/issues/49694

And it seems like it's affecting many open-source projects: `react-native-screens`, `react-native-reanimated`, and `react-native-keyboard-controller` as well because I'm heavily relying on reanimated usage.

This PR is rewriting `KeyboardStickyView` to plain `Animated.View`. At the moment it's possible to do that, but in future I'm planning to change interpolation when keyboard gets dismissed interactively.

Again it's not proper fix for a problem, but pipeline react-native fix -> react-native-reanimated fix -> verify fix in this library can take months I believe and will require usage of new libs. So to reduce amount of reported issues I decided temporarily rewrite this component to `Animated` variant. Once the issue will be fixed it'll be a good time to re-write it back and address `interactive`- dismissal interpolation.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/809

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- rewrite `KeyboardStickyView` to `Animated` usage;

## 🤔 How Has This Been Tested?

Tested manuall in example app.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img src="https://github.com/user-attachments/assets/678d3174-40a9-43b6-8b80-9931e6b879c1">|<img src="https://github.com/user-attachments/assets/ce7c7fdb-bf6d-457c-854a-ddd60d63e7d2">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
