### PR TITLE
fix: Square payment SDK integration

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -149,7 +149,8 @@
     "componentregistry",
     "mapbuffer",
     "nativemodule",
-    "reactnative"
+    "reactnative",
+    "SQIP"
   ],
   "ignorePaths": [
     "node_modules",

--- a/ios/delegates/KCTextInputCompositeDelegate.swift
+++ b/ios/delegates/KCTextInputCompositeDelegate.swift
@@ -50,6 +50,8 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
   // delegates
   weak var textViewDelegate: UITextViewDelegate?
   weak var textFieldDelegate: UITextFieldDelegate?
+  // state
+  private var isCheckingRespondsTo = false
 
   // Keep track of which textField we’re observing (iOS < 13 only)
   private weak var observedTextFieldForSelection: UITextField?
@@ -194,6 +196,10 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
   // MARK: call forwarding
 
   override func responds(to aSelector: Selector!) -> Bool {
+    guard !isCheckingRespondsTo else { return false }
+    isCheckingRespondsTo = true
+    defer { isCheckingRespondsTo = false }
+
     if super.responds(to: aSelector) {
       return true
     }

--- a/ios/delegates/KCTextInputCompositeDelegate.swift
+++ b/ios/delegates/KCTextInputCompositeDelegate.swift
@@ -99,11 +99,12 @@ class KCTextInputCompositeDelegate: NSObject, UITextViewDelegate, UITextFieldDel
   public func canSubstituteTextFieldDelegate(delegate: UITextFieldDelegate?) -> Bool {
     let type = String(describing: delegate)
     if type.range(of: "SQIPTextFieldInputModifier") != nil {
-      // SQIPTextFieldInputModifier is a private class used by Square
-      // and it forwards all calls to the keyboard-controller delegate.
-      // To avoid infinite loop, we will not set our delegate
-      // Theirs inputs have their own keyboard handling and components
-      // from keyboard-controller can't be used there so it's safe to skip it
+      // SQIPTextFieldInputModifier is a private class used internally by Square.
+      // It forwards input events to the keyboard-controller delegate.
+      // To prevent an infinite loop, we avoid setting our delegate in this case.
+      // Since Square's SDK is used imperatively and doesn't allow adding custom components,
+      // keyboard-controller components cannot be used in this context,
+      // so it's safe to skip replacing the delegate.
       return false
     }
 

--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -228,7 +228,9 @@ public class FocusedInputObserver: NSObject {
 
   private func substituteDelegate(_ input: UIResponder?) {
     if let textField = input as? UITextField {
-      if !(textField.delegate is KCTextInputCompositeDelegate) {
+      if !(textField.delegate is KCTextInputCompositeDelegate),
+         delegate.canSubstituteTextFieldDelegate(delegate: textField.delegate)
+      {
         delegate.setTextFieldDelegate(delegate: textField.delegate, textField: textField)
         textField.delegate = delegate
       }


### PR DESCRIPTION
## 📜 Description

Fixed an integration with Square SDK.

## 💡 Motivation and Context

The current problem is that `SQIPTextFieldInputModifier` always redirects call to an injected (`KCCompositeDelegate`) delegate - and it causes infinite loop that eventually leads to a crash 🤷‍♂️ 

I've tried to find source code of `SQIPTextFieldInputModifier` but it's closed, and I can not read it.

So far I had two approaches to fix it:

### 1️⃣ Add state variable and prevent infinite calls

While it solves the problem, it produces other problems - it looks like original delegate methods never gets called and in this case we break Square SDK, so it's not really an option.

### 2️⃣ Don't set delegate for `SQIPTextFieldInputModifier`

While it breaks the principle that any focused input will intercept events it makes certain sense:
- seems like Square did such "protection" intentionally;
- Square handler keyboard appearance on their own and it's not possible to use `react-native-keyboard-controller` component there.

So after thinking a while I decided that we **shouldn't inject** our delegate for `Square` SDK inputs. The solution may be not perfect, but for now it totally works. If it causes more issues, then I'll be glad to re-consider the solution with new info in mind.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/896

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- don't substitute delegate for Square inputs;

## 🤔 How Has This Been Tested?

tested manually on iPhone 15 Pro (iOS 17.5) in repro example.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

https://github.com/user-attachments/assets/e2ef6a65-9a09-4615-8ef1-c8310f56dcb6

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
