### PR TITLE
fix: set delegate to all `UITextView`

### DIFF
--- a/ios/KeyboardController-Bridging-Header.h
+++ b/ios/KeyboardController-Bridging-Header.h
@@ -1,4 +1,3 @@
 #import <React/RCTTouchHandler.h>
 #import <React/RCTUIManager.h>
-#import <React/RCTUITextView.h>
 #import <React/RCTViewManager.h>

--- a/ios/objc/UITextView+DelegateManager.h
+++ b/ios/objc/UITextView+DelegateManager.h
@@ -1,13 +1,11 @@
 //
-//  RCTTextView+DelegateManager.h
+//  UITextView+DelegateManager.h
 //  react-native-keyboard-controller
 //
 //  Created by Kiryl Ziusko on 24/04/2024.
 //
 
-#import <React/RCTUITextView.h>
-
-@interface RCTUITextView (DelegateManager)
+@interface UITextView (DelegateManager)
 
 - (void)setForceDelegate:(id<UITextViewDelegate>)delegate;
 

--- a/ios/objc/UITextView+DelegateManager.m
+++ b/ios/objc/UITextView+DelegateManager.m
@@ -1,14 +1,14 @@
 //
-//  RCTUITextView+DelegateManager.m
+//  UITextView+DelegateManager.m
 //  react-native-keyboard-controller
 //
 //  Created by Kiryl Ziusko on 24/04/2024.
 //
 
 #import <objc/runtime.h>
-#import "RCTUITextView+DelegateManager.h"
+#import "UITextView+DelegateManager.h"
 
-@implementation RCTUITextView (DelegateManager)
+@implementation UITextView (DelegateManager)
 
 /**
  * We are aware that delegate is set by RN on mount and we can not re-define it

--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -235,7 +235,7 @@ public class FocusedInputObserver: NSObject {
     } else if let textView = input as? UITextView {
       if !(textView.delegate is KCTextInputCompositeDelegate) {
         delegate.setTextViewDelegate(delegate: textView.delegate)
-        (textView as? RCTUITextView)?.setForceDelegate(delegate)
+        textView.setForceDelegate(delegate)
       }
     }
     // dispatch onSelectionChange on focus
@@ -248,7 +248,7 @@ public class FocusedInputObserver: NSObject {
     if let textField = input as? UITextField, let oldDelegate = delegate.activeDelegate as? UITextFieldDelegate {
       textField.delegate = oldDelegate
     } else if let textView = input as? UITextView, let oldDelegate = delegate.activeDelegate as? UITextViewDelegate {
-      (textView as? RCTUITextView)?.setForceDelegate(oldDelegate)
+      textView.setForceDelegate(oldDelegate)
     }
   }
 


### PR DESCRIPTION
## 📜 Description

Set delegate to all `UITextView`s.

## 💡 Motivation and Context

We had a similar problem on Android: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/776

Basically if we caste field to `RCTUITextView` then there is a chance, that we will not be able to cast it if it's a subclass of `UITextView` (i. e. other 3rd party libs).

So the correct solution is to cast current responder to its basic class. The reason why I added this code in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/426 was the fact that only `RCTUITextView` had own delegate setter. However since we operate on `ivar` level we can bypass any setter (not only for a specific class), so I decided to move that extensions to a basic class (UITextView). It'll fix two problems:
- potential incompatibility with other 4rd party libs (the one that we had with Stripe);
- will fix a problem when compilation fails with dynamic frameworks.

The reason why compilation fails is because `RCTUITextView` most likely is not a public class, as per:

> **Static Pods**: When you use static linking (without `use_frameworks!` in your Podfile), the React Native library is compiled directly into your app’s binary. All symbols, including `RCTUITextView`, are included at compile time, making them available to your extension even if they’re not part of the public API.
> **Dynamic Pods**: With dynamic frameworks (enabled by `use_frameworks`!), dependencies like React Native are built as separate frameworks that are linked at runtime. Only symbols exported in the framework’s public interface are accessible to your app. If `RCTUITextView` is an internal class—not exposed in React Native’s public headers—the linker won’t find it, resulting in the undefined symbol error.

So the correct fix would be just move extension to base class level.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/876

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- move `setForceDelegate` from `RCTUITextView` to `UITextView`;

## 🤔 How Has This Been Tested?

Tested manually in FabricExample app with dynamic pods.

## 📸 Screenshots (if appropriate):

<img width="467" alt="image" src="https://github.com/user-attachments/assets/7dc03cc1-11b2-4a39-94c4-157ef9b6ad14" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
