### PR TITLE
docs: `forwardRef` for `FlashList`+`renderScrollComponent`

### DIFF
--- a/docs/docs/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/docs/api/components/keyboard-aware-scroll-view.mdx
@@ -124,7 +124,8 @@ Unlike original [react-native-keyboard-aware-scroll-view](https://github.com/APS
 If you want to integrate it with your custom virtualization list, you can pass `renderScrollComponent` prop like:
 
 ```tsx
-import { FlatList } from "react-native";
+import React from "react";
+import { FlatList, ScrollView, ScrollViewProps } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 
 <FlatList
@@ -135,9 +136,11 @@ import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 
 import { FlashList } from "@shopify/flash-list";
 
-<FlashList
-  renderScrollComponent={(props) => <KeyboardAwareScrollView {...props} />}
-/>;
+const RenderScrollComponent = React.forwardRef<ScrollView, ScrollViewProps>(
+  (props, ref) => <KeyboardAwareScrollView {...props} ref={ref} />,
+);
+
+<FlashList renderScrollComponent={RenderScrollComponent} />;
 ```
 
 <details>

--- a/docs/versioned_docs/version-1.16.0/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/versioned_docs/version-1.16.0/api/components/keyboard-aware-scroll-view.mdx
@@ -124,7 +124,8 @@ Unlike original [react-native-keyboard-aware-scroll-view](https://github.com/APS
 If you want to integrate it with your custom virtualization list, you can pass `renderScrollComponent` prop like:
 
 ```tsx
-import { FlatList } from "react-native";
+import React from "react";
+import { FlatList, ScrollView, ScrollViewProps } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 
 <FlatList
@@ -135,9 +136,11 @@ import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 
 import { FlashList } from "@shopify/flash-list";
 
-<FlashList
-  renderScrollComponent={(props) => <KeyboardAwareScrollView {...props} />}
-/>;
+const RenderScrollComponent = React.forwardRef<ScrollView, ScrollViewProps>(
+  (props, ref) => <KeyboardAwareScrollView {...props} ref={ref} />,
+);
+
+<FlashList renderScrollComponent={RenderScrollComponent} />;
 ```
 
 <details>

--- a/docs/versioned_docs/version-1.17.0/api/components/keyboard-aware-scroll-view.mdx
+++ b/docs/versioned_docs/version-1.17.0/api/components/keyboard-aware-scroll-view.mdx
@@ -124,7 +124,8 @@ Unlike original [react-native-keyboard-aware-scroll-view](https://github.com/APS
 If you want to integrate it with your custom virtualization list, you can pass `renderScrollComponent` prop like:
 
 ```tsx
-import { FlatList } from "react-native";
+import React from "react";
+import { FlatList, ScrollView, ScrollViewProps } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 
 <FlatList
@@ -135,9 +136,11 @@ import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 
 import { FlashList } from "@shopify/flash-list";
 
-<FlashList
-  renderScrollComponent={(props) => <KeyboardAwareScrollView {...props} />}
-/>;
+const RenderScrollComponent = React.forwardRef<ScrollView, ScrollViewProps>(
+  (props, ref) => <KeyboardAwareScrollView {...props} ref={ref} />,
+);
+
+<FlashList renderScrollComponent={RenderScrollComponent} />;
 ```
 
 <details>


### PR DESCRIPTION
## 📜 Description

Updated documentation for `FlashList`.

## 💡 Motivation and Context

Seems like in recent versions of `FlashList` ref-forwarding has changed, so now we need to wrap the callback in `forwardRef`. Funny thing - such wrapper doesn't work for `FlatList`. So I separated instructions 🤷‍♂️ 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/888

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- updated `FlashList` + `KeybaordAwareScrollView` integrations ection.

## 🤔 How Has This Been Tested?

Tested in example app.

## 📸 Screenshots (if appropriate):

<img width="985" alt="image" src="https://github.com/user-attachments/assets/5185dced-1fbd-42d5-8b31-25e903066f8b" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
