### PR TITLE
fix: findNodeHandle on the web platform

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useCallback, useMemo } from "react";
-import { findNodeHandle } from "react-native";
 import Reanimated, {
   interpolate,
   scrollTo,
@@ -15,6 +14,7 @@ import {
   useReanimatedFocusedInput,
   useWindowDimensions,
 } from "../../hooks";
+import { findNodeHandle } from "../../utils/findNodeHandle";
 
 import { useSmoothKeyboardHandler } from "./useSmoothKeyboardHandler";
 import { debounce, scrollDistanceWithRespectToSnapPoints } from "./utils";

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,7 +1,8 @@
 import { useRef } from "react";
-import { Animated, findNodeHandle } from "react-native";
+import { Animated } from "react-native";
 
 import { registerEventHandler, unregisterEventHandler } from "./event-handler";
+import { findNodeHandle } from "./utils/findNodeHandle";
 
 type EventHandler = (event: never) => void;
 type ComponentOrHandle = Parameters<typeof findNodeHandle>[0];

--- a/src/utils/findNodeHandle/index.native.ts
+++ b/src/utils/findNodeHandle/index.native.ts
@@ -1,0 +1,3 @@
+import { findNodeHandle } from "react-native";
+
+export { findNodeHandle };

--- a/src/utils/findNodeHandle/index.ts
+++ b/src/utils/findNodeHandle/index.ts
@@ -1,0 +1,6 @@
+import type { findNodeHandle as findNodeHandleRN } from "react-native";
+
+type FindNodeHandleRN = typeof findNodeHandleRN;
+
+export const findNodeHandle: FindNodeHandleRN = (componentOrHandle) =>
+  componentOrHandle as number | null;


### PR DESCRIPTION
## 📜 Description

In the new version of `react-native-web` they added an error throw if you try to use findNodeHandle from `react-native` https://github.com/necolas/react-native-web/blob/922c134f2b7c428cc19daaeb3cac4b6a4c8ec6a3/packages/react-native-web/src/exports/findNodeHandle/index.js#L11. So I created a findNodeHandle utility that uses react-native's findNodeHandle for the native platform and returns Node or null for web.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This library should work well on all platforms

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added findNodeHandle util

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested in a web browser


## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

Before:

https://github.com/user-attachments/assets/7056e962-3427-4127-86ad-c204d09df874

After: 

https://github.com/user-attachments/assets/a2593a86-38dd-4f8d-aa73-0be04f1b3227


## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
