### PR TITLE
fix: `OverKeyboardView` crash

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -18,6 +18,9 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.extensions.dp
 import com.reactnativekeyboardcontroller.extensions.getDisplaySize
+import com.reactnativekeyboardcontroller.log.Logger
+
+private val TAG = OverKeyboardHostView::class.qualifiedName
 
 @SuppressLint("ViewConstructor")
 class OverKeyboardHostView(
@@ -140,8 +143,12 @@ class OverKeyboardRootViewGroup(
   // region Touch events handling
   override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let { eventDispatcher ->
-      jsTouchDispatcher.handleTouchEvent(event, eventDispatcher)
-      jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, true)
+      try {
+        jsTouchDispatcher.handleTouchEvent(event, eventDispatcher)
+        jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, true)
+      } catch (@Suppress("detekt:TooGenericExceptionCaught") e: RuntimeException) {
+        Logger.w(TAG, "Can not handle touch event", e)
+      }
     }
     return super.onInterceptTouchEvent(event)
   }
@@ -149,8 +156,12 @@ class OverKeyboardRootViewGroup(
   @SuppressLint("ClickableViewAccessibility")
   override fun onTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let { eventDispatcher ->
-      jsTouchDispatcher.handleTouchEvent(event, eventDispatcher)
-      jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, false)
+      try {
+        jsTouchDispatcher.handleTouchEvent(event, eventDispatcher)
+        jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, false)
+      } catch (@Suppress("detekt:TooGenericExceptionCaught") e: RuntimeException) {
+        Logger.w(TAG, "Can not handle touch event", e)
+      }
     }
     super.onTouchEvent(event)
     // In case when there is no children interested in handling touch event, we return true from

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -146,7 +146,9 @@ class OverKeyboardRootViewGroup(
       try {
         jsTouchDispatcher.handleTouchEvent(event, eventDispatcher)
         jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, true)
-      } catch (@Suppress("detekt:TooGenericExceptionCaught") e: RuntimeException) {
+      } catch (
+        @Suppress("detekt:TooGenericExceptionCaught") e: RuntimeException,
+      ) {
         Logger.w(TAG, "Can not handle touch event", e)
       }
     }
@@ -159,7 +161,9 @@ class OverKeyboardRootViewGroup(
       try {
         jsTouchDispatcher.handleTouchEvent(event, eventDispatcher)
         jsPointerDispatcher?.handleMotionEventCompat(event, eventDispatcher, false)
-      } catch (@Suppress("detekt:TooGenericExceptionCaught") e: RuntimeException) {
+      } catch (
+        @Suppress("detekt:TooGenericExceptionCaught") e: RuntimeException,
+      ) {
         Logger.w(TAG, "Can not handle touch event", e)
       }
     }


### PR DESCRIPTION
## 📜 Description

Wrapped touch events in `try`/`catch`.

## 💡 Motivation and Context

The problem stems from the fact, that we are trying to cast `ViewRootImpl` to `ViewGroup` (viewrootimpl cannot be cast to android.view.viewgroup). Basically it happens when touch gets propagated until `RootView` and wasn't handled earlier. Such thing can happen when:
- view is not fully laid out but it already handles a touch;
- view is not stretched to full screen and you touch area that doesn't belong to `OverKeyboardView` (fixed in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/863)

I was aware about that issue (especially on Fabric) and decided not to fix it - the main motivation was to stretch view to full screen on Fabric. However now, when view gets stretched we still have a small race condition when users click fast (i. e. view is not laid out but user already pass a touch).

I don't know a proper fix for this problem, and for me it looks like it can be OS scheduling/management which can not be fixed because I don't have an access to it 😅 

So in this PR I simply wrap the touch handling in `try`/`catch`. If touch can not be handled then it's better to silently fail instead of crashing the app.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/884

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- wrapped `handleTouchEvent` calls inside `try`/`catch` block to prevent a crash;

## 🤔 How Has This Been Tested?

Tested manually on Medium Phone API 35.

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/9ffa684d-ddb7-46e5-b143-d526ab680d28

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
