### PR TITLE
fix: `OverKeyboardView` rotation (fabric)

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -30,7 +30,11 @@ class OverKeyboardHostView(
   private var windowManager: WindowManager = reactContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
   private var hostView: OverKeyboardRootViewGroup = OverKeyboardRootViewGroup(reactContext)
 
-  internal var stateWrapper: StateWrapper? = null
+  var stateWrapper: StateWrapper?
+    get() = hostView.stateWrapper
+    set(stateWrapper) {
+      hostView.stateWrapper = stateWrapper
+    }
 
   init {
     hostView.eventDispatcher = dispatcher
@@ -92,23 +96,13 @@ class OverKeyboardHostView(
         PixelFormat.TRANSLUCENT,
       )
 
-    stretchTo(fullScreen = true)
     windowManager.addView(hostView, layoutParams)
   }
 
   fun hide() {
     if (hostView.isAttached) {
       windowManager.removeView(hostView)
-      stretchTo(fullScreen = false)
     }
-  }
-
-  private fun stretchTo(fullScreen: Boolean) {
-    val displaySize = reactContext.getDisplaySize()
-    val newStateData: WritableMap = WritableNativeMap()
-    newStateData.putDouble("screenWidth", if (fullScreen) displaySize.x.toFloat().dp else 0.0)
-    newStateData.putDouble("screenHeight", if (fullScreen) displaySize.y.toFloat().dp else 0.0)
-    stateWrapper?.updateState(newStateData)
   }
 }
 
@@ -120,6 +114,7 @@ class OverKeyboardRootViewGroup(
   private val jsTouchDispatcher: JSTouchDispatcher = JSTouchDispatcher(this)
   private var jsPointerDispatcher: JSPointerDispatcherCompat? = null
   internal var eventDispatcher: EventDispatcher? = null
+  internal var stateWrapper: StateWrapper? = null
   internal var isAttached = false
 
   init {
@@ -131,13 +126,27 @@ class OverKeyboardRootViewGroup(
   // region life cycles
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
+    val displaySize = reactContext.getDisplaySize()
+    stretchTo(width = displaySize.x, height = displaySize.y)
     isAttached = true
   }
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
+    stretchTo(width = 0, height = 0)
     isAttached = false
   }
+
+  override fun onSizeChanged(
+    w: Int,
+    h: Int,
+    oldw: Int,
+    oldh: Int,
+  ) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    stretchTo(width = w, height = h)
+  }
+
   // endregion
 
   // region Touch events handling
@@ -216,4 +225,14 @@ class OverKeyboardRootViewGroup(
     reactContext.reactApplicationContext.handleException(RuntimeException(t))
   }
   // endregion
+
+  private fun stretchTo(
+    width: Int,
+    height: Int,
+  ) {
+    val newStateData: WritableMap = WritableNativeMap()
+    newStateData.putDouble("screenWidth", width.toFloat().dp)
+    newStateData.putDouble("screenHeight", height.toFloat().dp)
+    stateWrapper?.updateState(newStateData)
+  }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -138,13 +138,13 @@ class OverKeyboardRootViewGroup(
   }
 
   override fun onSizeChanged(
-    w: Int,
-    h: Int,
-    oldw: Int,
-    oldh: Int,
+    width: Int,
+    height: Int,
+    oldWidth: Int,
+    oldHeight: Int,
   ) {
-    super.onSizeChanged(w, h, oldw, oldh)
-    stretchTo(width = w, height = h)
+    super.onSizeChanged(width, height, oldWidth, oldHeight)
+    stretchTo(width, height)
   }
 
   // endregion


### PR DESCRIPTION
## 📜 Description

Fixed wrong dimensions when phone gets rotated.

## 💡 Motivation and Context

We need to update shadow node layout whenever screen dimensions changes, so in this PR I'm doing this. I use `onSizeChanged` method as a lifecycle method for updating layout. Technically I could use `onLayout`, but it's highly undesirable to block `onLayout` method, so it's better to do it in `onSizeChanged`.

Fixes Android issue described in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/915

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- moved state wrapper to `hostView`;
- manage `ShadowNode` layout inside `hostView`.

## 🤔 How Has This Been Tested?

Tested manually on Medium Phone API 35.

## 📸 Screenshots (if appropriate):

[okv-rotation.webm](https://github.com/user-attachments/assets/6b49d0b3-e266-47e7-89af-1a8a3b4de6ce)


## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
