### PR TITLE
fix: CI for docs

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -154,7 +154,8 @@
     "DCMAKE",
     "HKLM",
     "xcassets",
-    "appiconset"
+    "appiconset",
+    "taskdefs"
   ],
   "ignorePaths": [
     "node_modules",

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -100,7 +100,7 @@ If you experience this error on Windows you need to perform next steps:
 
    ```json
    import org.apache.tools.ant.taskdefs.condition.Os
-   
+
    externalNativeBuild {
       cmake {
          def cmakeDir = "${android.sdkDirectory}/cmake/3.31.1/bin"

--- a/docs/versioned_docs/version-1.17.0/troubleshooting.md
+++ b/docs/versioned_docs/version-1.17.0/troubleshooting.md
@@ -100,7 +100,7 @@ If you experience this error on Windows you need to perform next steps:
 
    ```json
    import org.apache.tools.ant.taskdefs.condition.Os
-   
+
    externalNativeBuild {
        cmake {
            def cmakeDir = "${android.sdkDirectory}/cmake/3.31.1/bin"


### PR DESCRIPTION
## 📜 Description

Fixed CI after merging https://github.com/kirillzyusko/react-native-keyboard-controller/pull/933 https://github.com/kirillzyusko/react-native-keyboard-controller/pull/932

## 💡 Motivation and Context

Probably a right decision would be to fix CI in corresponding PRs, but I felt like it can be a double work, so I merged them with failed CI and in this follow-up PR I'm fixing CI to make it green again.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added spellcheck exception;
- fixed prettier.

## 🤔 How Has This Been Tested?

Tested via CI on this PR.

## 📸 Screenshots (if appropriate):

<img width="931" alt="image" src="https://github.com/user-attachments/assets/ef4298e5-94b2-4693-a48d-632b0e8da30c" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
