### PR TITLE
docs: remove `nullable` `.state` reference

### DIFF
--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -96,7 +96,7 @@ if (KeyboardController.isVisible()) {
 static state(): KeyboardEventData;
 ```
 
-This method returns the last keyboard state. It returns `null` if keyboard was not shown in the app yet.
+This method returns the last keyboard state.
 
 The `KeyboardEventData` is represented by following structure:
 

--- a/docs/versioned_docs/version-1.17.0/api/keyboard-controller.md
+++ b/docs/versioned_docs/version-1.17.0/api/keyboard-controller.md
@@ -96,7 +96,7 @@ if (KeyboardController.isVisible()) {
 static state(): KeyboardEventData;
 ```
 
-This method returns the last keyboard state. It returns `null` if keyboard was not shown in the app yet.
+This method returns the last keyboard state.
 
 The `KeyboardEventData` is represented by following structure:
 


### PR DESCRIPTION
## 📜 Description

Removed `nulalble` state text.

## 💡 Motivation and Context

Starting from `1.17.x` it's not the case anymore 😎 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- removed `It returns `null` if keyboard was not shown in the app yet.` text;

## 🤔 How Has This Been Tested?

Tested via preview.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
