### PR TITLE
docs: update tip for ninja path

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -98,7 +98,7 @@ If you experience this error on Windows you need to perform next steps:
    - Open `android/app/build.gradle`
    - Inside the `android.defaultConfig` block, add the following code:
 
-   ```json
+   ```kt
    import org.apache.tools.ant.taskdefs.condition.Os
 
    externalNativeBuild {
@@ -114,7 +114,7 @@ If you experience this error on Windows you need to perform next steps:
    ```
 
    :::tip
-   Make sure to update `$YOUR_CMAKE_NINJA_PATH$` with the correct path to your `ninja.exe` file. For example, it might look something like `E:\\SDK\\cmake\\3.22.2\\bin\\ninja.exe` on Windows.
+   This setup automatically builds the correct path to `ninja` based on the CMake version (`3.31.1`) in your Android SDK. If you're using a different version, update `cmakeDir` accordingly.
    :::
 
 3. **Enable Long Path Support in Windows**

--- a/docs/versioned_docs/version-1.17.0/troubleshooting.md
+++ b/docs/versioned_docs/version-1.17.0/troubleshooting.md
@@ -98,7 +98,7 @@ If you experience this error on Windows you need to perform next steps:
    - Open `android/app/build.gradle`
    - Inside the `android.defaultConfig` block, add the following code:
 
-   ```json
+   ```kt
    import org.apache.tools.ant.taskdefs.condition.Os
 
    externalNativeBuild {
@@ -113,7 +113,7 @@ If you experience this error on Windows you need to perform next steps:
    ```
 
    :::tip
-   Make sure to update `$YOUR_CMAKE_NINJA_PATH$` with the correct path to your `ninja.exe` file. For example, it might look something like `E:\\SDK\\cmake\\3.22.2\\bin\\ninja.exe` on Windows.
+   This setup automatically builds the correct path to `ninja` based on the CMake version (`3.31.1`) in your Android SDK. If you're using a different version, update `cmakeDir` accordingly.
    :::
 
 3. **Enable Long Path Support in Windows**


### PR DESCRIPTION
## 📜 Description

Updated tip for ninja setup.

## 💡 Motivation and Context

I removed out-of-date `YOUR_NINJA_PATH` variable, because now the path is build automatically. The only thing to remember is to use proper ninja version.

So I updated tip to reflect these changes and also updated language of the code.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs
- use `kt` for `gradle` config;
- re-word tip to make sure people use correct path.

## 🤔 How Has This Been Tested?

Tested via preview.

## 📸 Screenshots (if appropriate):

<img width="515" alt="image" src="https://github.com/user-attachments/assets/68173e12-7fca-4dee-b75b-b9064d1f0248" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
