### PR TITLE
fix: rely on screen dimensions instead of window dimensions

### DIFF
--- a/src/hooks/useWindowDimensions/index.ts
+++ b/src/hooks/useWindowDimensions/index.ts
@@ -1,1 +1,53 @@
-export { useWindowDimensions } from "react-native";
+import { useEffect, useState } from "react";
+import { Dimensions } from "react-native";
+
+import type { WindowDimensionsEventData } from "../../types";
+
+const screen = Dimensions.get("screen");
+
+let initialDimensions: WindowDimensionsEventData = {
+  width: screen.width,
+  height: screen.height,
+};
+
+Dimensions.addEventListener("change", (e) => {
+  initialDimensions = {
+    width: e.screen.width,
+    height: e.screen.height,
+  };
+});
+
+/**
+ * On iOS we need to use `screen`, because this property is derived from `mainScreen.bounds.size`
+ * while `window` is based on `[RCTKeyWindowValuesProxy sharedInstance].windowSize`, which can have
+ * out of date values (especially when device gets rotated).
+ *
+ * @returns Window dimension.
+ * @example
+ * ```
+ * const { height, window } = useWindowDimensions();
+ * ```
+ */
+export const useWindowDimensions = () => {
+  const [dimensions, setDimensions] = useState(initialDimensions);
+
+  useEffect(() => {
+    const subscription = Dimensions.addEventListener("change", (e) => {
+      setDimensions({
+        width: e.screen.width,
+        height: e.screen.height,
+      });
+    });
+
+    // we might have missed an update between reading a value in render and
+    // `addListener` in this handler, so we set it here. If there was
+    // no change, React will filter out this update as a no-op.
+    setDimensions(initialDimensions);
+
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+
+  return dimensions;
+};


### PR DESCRIPTION
## 📜 Description

Rely on screen dimensions instead of window dimensions.

## 💡 Motivation and Context

Hook `useWindowDimensions` relies on `window` dimensions. Internally for `window` react-native uses `[RCTKeyWindowValuesProxy sharedInstance].windowSize` which may be not updated when screen gets rotated (in some cases), while `mainScreen.bounds.size` (that is used for `screen` dimensions) gets updated.

So it looks like it's better to rely on `screen` instead of `window` to handle screen rotation cases.

Last, but not least: react-native subscribes to rotation events, but doesn't call `beginGeneratingDeviceOrientationNotifications`. Without invoking this function `useWindowDimensions` will not receive updates when screen is getting rotated. At the moment it works, because other libs (`expo-screen-orientation`, `react-native-screens` are calling this method), but I think it also should be fixed in `react-native` core at some point of time.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/915

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- create custom implementation for `useWindowDimensions` for all platforms except Android;

## 🤔 How Has This Been Tested?

Tested manually in repro app.

Verified additionally be e2e tests 🤞 

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|![image](https://github.com/user-attachments/assets/4d495888-2560-4cb1-afaf-4895feaf3769)|![image](https://github.com/user-attachments/assets/e4802906-5734-4d0c-b0d8-2d64993b82d3)|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
