### PR TITLE
fix: keep shadow nodes in sync

### DIFF
--- a/FabricExample/src/screens/Examples/AwareScrollViewStickyFooter/index.tsx
+++ b/FabricExample/src/screens/Examples/AwareScrollViewStickyFooter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Text, View } from "react-native";
+import { Alert, Button, Text, View } from "react-native";
 import {
   KeyboardAwareScrollView,
   KeyboardStickyView,
@@ -82,7 +82,7 @@ export default function AwareScrollViewStickyFooter({ navigation }: Props) {
           <View style={styles.footer} onLayout={handleLayout}>
             <Text style={styles.footerText}>A mocked sticky footer</Text>
             <TextInput placeholder="Amount" style={styles.inputInFooter} />
-            <Button title="Click me" />
+            <Button title="Click me" onPress={() => Alert.alert("Clicked")} />
           </View>
         </KeyboardStickyView>
       )}

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
@@ -2,6 +2,7 @@ package com.reactnativekeyboardcontroller.extensions
 
 import android.content.Context
 import android.os.Build
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
@@ -35,6 +36,25 @@ fun ThemedReactContext?.emitEvent(
     ?.emit(event, params)
 
   Logger.i("ThemedReactContext", event)
+}
+
+fun ThemedReactContext?.keepShadowNodesInSync(viewId: Int) {
+  // originally by viewId we should lookup all connected nodes
+  // and send them to JS
+  // but at the moment JS side broadcasts events to all ViewType
+  // instances, so we can send even empty array
+  val tags = intArrayOf(viewId)
+
+  val tagsArray = Arguments.createArray()
+  for (tag in tags) {
+    tagsArray.pushInt(tag)
+  }
+
+  // emit the event to JS to re-sync the trees
+  val onAnimationEndedData = Arguments.createMap()
+  onAnimationEndedData.putArray("tags", tagsArray)
+
+  this?.reactApplicationContext?.emitDeviceEvent("onUserDrivenAnimationEnded", onAnimationEndedData)
 }
 
 val ThemedReactContext?.appearance: String

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -8,7 +8,6 @@ import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsAnimationCompat
 import androidx.core.view.WindowInsetsCompat
-import com.facebook.react.animated.NativeAnimatedNodesManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.ThemedReactContext
@@ -21,12 +20,12 @@ import com.reactnativekeyboardcontroller.extensions.dispatchEvent
 import com.reactnativekeyboardcontroller.extensions.dp
 import com.reactnativekeyboardcontroller.extensions.emitEvent
 import com.reactnativekeyboardcontroller.extensions.isKeyboardAnimation
+import com.reactnativekeyboardcontroller.extensions.keepShadowNodesInSync
 import com.reactnativekeyboardcontroller.extensions.keyboardType
 import com.reactnativekeyboardcontroller.interactive.InteractiveKeyboardProvider
 import com.reactnativekeyboardcontroller.log.Logger
 import com.reactnativekeyboardcontroller.traversal.FocusedInputHolder
 import kotlin.math.abs
-
 
 private val TAG = KeyboardAnimationCallback::class.qualifiedName
 private val isResizeHandledInCallbackMethods = Keyboard.IS_ANIMATION_EMULATED
@@ -330,7 +329,7 @@ class KeyboardAnimationCallback(
         // reset to initial state
         duration = 0
 
-        keepShadowNodesInSync()
+        context.keepShadowNodesInSync(eventPropagationView.id)
       }
 
     if (isKeyboardInteractive) {
@@ -405,6 +404,7 @@ class KeyboardAnimationCallback(
       )
     }
     context.emitEvent("KeyboardController::keyboardDidShow", getEventParams(keyboardHeight))
+    context.keepShadowNodesInSync(eventPropagationView.id)
 
     this.persistentKeyboardHeight = keyboardHeight
   }
@@ -439,30 +439,5 @@ class KeyboardAnimationCallback(
     params.putString("appearance", context.appearance)
 
     return params
-  }
-
-  private fun keepShadowNodesInSync() {
-
-    // ask to the Node Manager for all the native nodes listening to OnScroll event
-    // val nodeManager: NativeAnimatedNodesManager = mNodesManager.get() ?: return
-    // nodeManager.getTagsOfConnectedNodes(eventPropagationView.id, "topScrollEnded")
-
-    val tags = intArrayOf(eventPropagationView.id)
-
-    if (tags.isEmpty()) {
-      return
-    }
-
-    val tagsArray = Arguments.createArray()
-    for (tag in tags) {
-      tagsArray.pushInt(tag)
-    }
-
-
-    // emit the event to JS to re-sync the trees
-    val onAnimationEndedData = Arguments.createMap()
-    onAnimationEndedData.putArray("tags", tagsArray)
-
-    context?.reactApplicationContext?.emitDeviceEvent("onUserDrivenAnimationEnded", onAnimationEndedData)
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -8,6 +8,7 @@ import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsAnimationCompat
 import androidx.core.view.WindowInsetsCompat
+import com.facebook.react.animated.NativeAnimatedNodesManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.ThemedReactContext
@@ -25,6 +26,7 @@ import com.reactnativekeyboardcontroller.interactive.InteractiveKeyboardProvider
 import com.reactnativekeyboardcontroller.log.Logger
 import com.reactnativekeyboardcontroller.traversal.FocusedInputHolder
 import kotlin.math.abs
+
 
 private val TAG = KeyboardAnimationCallback::class.qualifiedName
 private val isResizeHandledInCallbackMethods = Keyboard.IS_ANIMATION_EMULATED
@@ -327,6 +329,8 @@ class KeyboardAnimationCallback(
 
         // reset to initial state
         duration = 0
+
+        keepShadowNodesInSync()
       }
 
     if (isKeyboardInteractive) {
@@ -435,5 +439,30 @@ class KeyboardAnimationCallback(
     params.putString("appearance", context.appearance)
 
     return params
+  }
+
+  private fun keepShadowNodesInSync() {
+
+    // ask to the Node Manager for all the native nodes listening to OnScroll event
+    // val nodeManager: NativeAnimatedNodesManager = mNodesManager.get() ?: return
+    // nodeManager.getTagsOfConnectedNodes(eventPropagationView.id, "topScrollEnded")
+
+    val tags = intArrayOf(eventPropagationView.id)
+
+    if (tags.isEmpty()) {
+      return
+    }
+
+    val tagsArray = Arguments.createArray()
+    for (tag in tags) {
+      tagsArray.pushInt(tag)
+    }
+
+
+    // emit the event to JS to re-sync the trees
+    val onAnimationEndedData = Arguments.createMap()
+    onAnimationEndedData.putArray("tags", tagsArray)
+
+    context?.reactApplicationContext?.emitDeviceEvent("onUserDrivenAnimationEnded", onAnimationEndedData)
   }
 }

--- a/example/src/screens/Examples/AwareScrollViewStickyFooter/index.tsx
+++ b/example/src/screens/Examples/AwareScrollViewStickyFooter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Text, View } from "react-native";
+import { Alert, Button, Text, View } from "react-native";
 import {
   KeyboardAwareScrollView,
   KeyboardStickyView,
@@ -82,7 +82,7 @@ export default function AwareScrollViewStickyFooter({ navigation }: Props) {
           <View style={styles.footer} onLayout={handleLayout}>
             <Text style={styles.footerText}>A mocked sticky footer</Text>
             <TextInput placeholder="Amount" style={styles.inputInFooter} />
-            <Button title="Click me" />
+            <Button title="Click me" onPress={() => Alert.alert("Clicked")} />
           </View>
         </KeyboardStickyView>
       )}


### PR DESCRIPTION
## 📜 Description

Fixed a problem when `Pressable` doesn't trigger `onPress` callback if it's located in `KeyboardStickyView` (`KeyboardToolbar`).

## 💡 Motivation and Context

The problem stems from the fact that C++ shadow nodes do not know about changes caused by `useKeyboardAnimation` hook (we drive animation by native driver, so C++ thinks that view hasn't changed its position).

I found out that `ScrollView` had the same problem: https://github.com/facebook/react-native/issues/36504#issuecomment-2898068182

Basically the fix is next:
- after finishing the animation we dispatch `onUserDrivenAnimationEnded`;
- in `useAnimatedProps`:

```ts
  NativeAnimatedHelper.nativeEventEmitter.addListener(
    'onUserDrivenAnimationEnded',
    data => {
      node.update();
    },
  );
```

Where:

```ts
  new AnimatedProps(
    props,
    () => onUpdateRef.current?.(),
    allowlistIfEnabled,
  ),
```

Which in turns calls:

```ts
  const isFabricNode = isFabricInstance(instance);
  if (node.__isNative) {
    // Check 2: this is an animation driven by native.
    // In native driven animations, this callback is only called once the animation completes.
    if (isFabricNode) {
      // Call `scheduleUpdate` to synchronise Fiber and Shadow tree.
      // Must not be called in Paper.
      scheduleUpdate();
    }
    return;
  }
```

And it triggers re-render and synchronizes C++ state with latest react state.

Probably not the best solution, but it fixes the problem. Also we have to gather all connected nodes that depends on animated value, but at the moment this data is unused:

```ts
  data => {
    node.update();
  },
```

So for now it's safe to skip connected nodes 🙃 (maybe later I'll revisit this)

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/947 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/916 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/588

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added `keepShadowNodesInSync` function extension for `ThemedReactContext`;
- call `keepShadowNodesInSync` in the end of keyboard animation.

## 🤔 How Has This Been Tested?

Tested manually in FabricExample.

## 📸 Screenshots (if appropriate):

|KeyboardStickyView|KeyboardToolbar|
|---------------------|----------------|
|<video src="https://github.com/user-attachments/assets/3950ec69-338e-4f2e-9301-b5c64efb808e">|<video src="https://github.com/user-attachments/assets/291e846e-3bf8-46fd-9f64-d53ec30c452b">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
