### PR TITLE
docs: enhance `useKeyboardState` SEO

### DIFF
--- a/docs/docs/api/hooks/keyboard/use-keyboard-state.mdx
+++ b/docs/docs/api/hooks/keyboard/use-keyboard-state.mdx
@@ -1,5 +1,15 @@
 ---
-keywords: [react-native-keyboard-controller, useKeyboardState, react hook]
+keywords:
+  [
+    react-native-keyboard-controller,
+    useKeyboardState,
+    useKeyboardVisible,
+    useKeyboardIsVisible,
+    useIsKeyboardVisible,
+    useKeyboardHeight,
+    useKeyboard,
+    react hook,
+  ]
 sidebar_position: 4
 ---
 

--- a/docs/versioned_docs/version-1.17.0/api/hooks/keyboard/use-keyboard-state.mdx
+++ b/docs/versioned_docs/version-1.17.0/api/hooks/keyboard/use-keyboard-state.mdx
@@ -1,5 +1,15 @@
 ---
-keywords: [react-native-keyboard-controller, useKeyboardState, react hook]
+keywords:
+  [
+    react-native-keyboard-controller,
+    useKeyboardState,
+    useKeyboardVisible,
+    useKeyboardIsVisible,
+    useIsKeyboardVisible,
+    useKeyboardHeight,
+    useKeyboard,
+    react hook,
+  ]
 sidebar_position: 4
 ---
 


### PR DESCRIPTION
## 📜 Description

Improved SEO for `useKeyboardState` hook.

## 💡 Motivation and Context

I found that people use this search:

<img width="572" alt="image" src="https://github.com/user-attachments/assets/adee299b-7897-42e0-b26b-0e5994586e61" />

And don't get results. In reality we have a hook that do that, jsut under a different name: `useKeyboardState`. In this PR I'm fixing it by adding more keywords to this page.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added more `keywords` for `useKeyboardState` page;

## 🤔 How Has This Been Tested?

There is no way to test it until google re-indexes the page.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
