### PR TITLE
fix: `OverKeyboardView` crash with `a11y`

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardViewGroup.kt
@@ -6,6 +6,7 @@ import android.graphics.PixelFormat
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
+import android.view.accessibility.AccessibilityEvent
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
@@ -82,6 +83,16 @@ class OverKeyboardHostView(
   ) {
     // Do nothing as we are laid out by UIManager
   }
+  // endregion
+
+  // region Accessibility
+  override fun addChildrenForAccessibility(outChildren: ArrayList<View>) {
+    // Don’t let Android try to reach children that are not actual descendants
+  }
+
+  // Explicitly override this to prevent accessibility events being passed down to children
+  // Those will be handled by the `hostView` which lives in the `windowManager`
+  override fun dispatchPopulateAccessibilityEvent(event: AccessibilityEvent): Boolean = false
   // endregion
 
   fun show() {


### PR DESCRIPTION
## 📜 Description

Fixed a crash when `TalkBack` is enabled on Android and you use `OverKeyboardView`.

## 💡 Motivation and Context

The problem comes from the fact that the system tries to traverse the view hierarchy, but overlay views are not part of the main view hierarchy.

`OverKeyboardHostView` **pretends** that the views you pass to it are its own children. From the platform’s point of view those views **are not really descendants** of `OverKeyboardHostView` — they live in a completely different window created with `WindowManager.addView`.

When the Android accessibility framework walks the view-tree it calls `addChildrenForAccessibility()`, iterates over `getChildAt(i)` and finally calls:

```kt
offsetRectBetweenParentAndChild(parent, child);
```

That helper checks that child **is a true descendant** of parent, and if it isn’t it throws the exception you see:

```kt
java.lang.IllegalArgumentException: parameter must be a descendant of this view
```

To solve this I decided to exclude `OverKeyboardHostView` from accessibility traversal, so that inner views handles accessibility on their own (this is how it should work).

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/961

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- don't add `OverKeyboardView` container to an accessibility;

## 🤔 How Has This Been Tested?

Tested manually in Fabric example on Pixel 7 Pro API 35.

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/8e2eff6a-d0cc-4d8d-9e6a-1a7a5a2d8a28

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
