### PR TITLE
fix: 2 memory leaks

### DIFF
--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -8,7 +8,6 @@ import com.facebook.react.viewmanagers.KeyboardControllerViewManagerDelegate
 import com.facebook.react.viewmanagers.KeyboardControllerViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
-import com.reactnativekeyboardcontroller.listeners.WindowDimensionListener
 import com.reactnativekeyboardcontroller.managers.KeyboardControllerViewManagerImpl
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
@@ -18,20 +17,14 @@ class KeyboardControllerViewManager(
   KeyboardControllerViewManagerInterface<ReactViewGroup> {
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
   private val mDelegate = KeyboardControllerViewManagerDelegate(this)
-  private var listener: WindowDimensionListener? = null
 
-  // region Lifecycle
   override fun createViewInstance(context: ThemedReactContext): ReactViewGroup {
-    if (listener == null) {
-      listener = WindowDimensionListener(context)
-      listener?.attachListener()
-    }
     return manager.createViewInstance(context)
   }
 
   override fun invalidate() {
     super.invalidate()
-    listener?.detachListener()
+    manager.invalidate()
   }
 
   override fun onAfterUpdateTransaction(view: ReactViewGroup) {
@@ -41,7 +34,7 @@ class KeyboardControllerViewManager(
 
   override fun onDropViewInstance(view: ReactViewGroup) {
     super.onDropViewInstance(view)
-    (view as EdgeToEdgeReactViewGroup).setActive(false)
+    manager.onDropViewInstance(view as EdgeToEdgeReactViewGroup)
   }
   // endregion
 
@@ -71,7 +64,7 @@ class KeyboardControllerViewManager(
   ) = manager.setEnabled(view as EdgeToEdgeReactViewGroup, value)
   // endregion
 
-  // region Constants
+  // region Getters
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
     manager.getExportedCustomDirectEventTypeConstants()
 

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -18,12 +18,9 @@ class KeyboardControllerViewManager(
   KeyboardControllerViewManagerInterface<ReactViewGroup> {
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
   private val mDelegate = KeyboardControllerViewManagerDelegate(this)
-  private var listener : WindowDimensionListener? = null
+  private var listener: WindowDimensionListener? = null
 
-  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup> = mDelegate
-
-  override fun getName(): String = KeyboardControllerViewManagerImpl.NAME
-
+  // region Lifecycle
   override fun createViewInstance(context: ThemedReactContext): ReactViewGroup {
     if (listener == null) {
       listener = WindowDimensionListener(context)
@@ -42,6 +39,14 @@ class KeyboardControllerViewManager(
     manager.setEdgeToEdge(view as EdgeToEdgeReactViewGroup)
   }
 
+  override fun onDropViewInstance(view: ReactViewGroup) {
+    super.onDropViewInstance(view)
+    (view as EdgeToEdgeReactViewGroup).setActive(false)
+    view.removeWindowInsetsListener()
+  }
+  // endregion
+
+  // region Props setters
   @ReactProp(name = "statusBarTranslucent")
   override fun setStatusBarTranslucent(
     view: ReactViewGroup,
@@ -65,13 +70,14 @@ class KeyboardControllerViewManager(
     view: ReactViewGroup,
     value: Boolean,
   ) = manager.setEnabled(view as EdgeToEdgeReactViewGroup, value)
+  // endregion
 
-  override fun onDropViewInstance(view: ReactViewGroup) {
-    super.onDropViewInstance(view)
-    (view as EdgeToEdgeReactViewGroup).setActive(false)
-    view.removeWindowInsetsListener()
-  }
-
+  // region Constants
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
     manager.getExportedCustomDirectEventTypeConstants()
+
+  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup> = mDelegate
+
+  override fun getName(): String = KeyboardControllerViewManagerImpl.NAME
+  // endregion
 }

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -18,6 +18,7 @@ class KeyboardControllerViewManager(
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
   private val mDelegate = KeyboardControllerViewManagerDelegate(this)
 
+  // region Lifecycle
   override fun createViewInstance(context: ThemedReactContext): ReactViewGroup = manager.createViewInstance(context)
 
   override fun invalidate() {
@@ -28,11 +29,6 @@ class KeyboardControllerViewManager(
   override fun onAfterUpdateTransaction(view: ReactViewGroup) {
     super.onAfterUpdateTransaction(view)
     manager.setEdgeToEdge(view as EdgeToEdgeReactViewGroup)
-  }
-
-  override fun onDropViewInstance(view: ReactViewGroup) {
-    super.onDropViewInstance(view)
-    manager.onDropViewInstance(view as EdgeToEdgeReactViewGroup)
   }
   // endregion
 

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -42,7 +42,6 @@ class KeyboardControllerViewManager(
   override fun onDropViewInstance(view: ReactViewGroup) {
     super.onDropViewInstance(view)
     (view as EdgeToEdgeReactViewGroup).setActive(false)
-    view.removeWindowInsetsListener()
   }
   // endregion
 

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -18,9 +18,7 @@ class KeyboardControllerViewManager(
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
   private val mDelegate = KeyboardControllerViewManagerDelegate(this)
 
-  override fun createViewInstance(context: ThemedReactContext): ReactViewGroup {
-    return manager.createViewInstance(context)
-  }
+  override fun createViewInstance(context: ThemedReactContext): ReactViewGroup = manager.createViewInstance(context)
 
   override fun invalidate() {
     super.invalidate()

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
@@ -10,7 +10,6 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
-import com.reactnativekeyboardcontroller.listeners.WindowDimensionListener
 import com.reactnativekeyboardcontroller.log.Logger
 
 fun ThemedReactContext?.dispatchEvent(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
@@ -13,10 +13,6 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.reactnativekeyboardcontroller.listeners.WindowDimensionListener
 import com.reactnativekeyboardcontroller.log.Logger
 
-fun ThemedReactContext.setupWindowDimensionsListener() {
-  WindowDimensionListener(this)
-}
-
 fun ThemedReactContext?.dispatchEvent(
   viewId: Int,
   event: Event<*>,

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
@@ -17,7 +17,7 @@ class WindowDimensionListener(
   private val context: ThemedReactContext?,
 ) {
   private var lastDispatchedDimensions = Dimensions(0.0, 0.0)
-  private var layoutListener : ViewTreeObserver.OnGlobalLayoutListener? = null
+  private var layoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
 
   public fun attachListener() {
     // attach to content view only once per app instance
@@ -28,9 +28,10 @@ class WindowDimensionListener(
 
       updateWindowDimensions(content)
 
-      layoutListener = ViewTreeObserver.OnGlobalLayoutListener {
-        updateWindowDimensions(content)
-      }
+      layoutListener =
+        ViewTreeObserver.OnGlobalLayoutListener {
+          updateWindowDimensions(content)
+        }
 
       content?.viewTreeObserver?.addOnGlobalLayoutListener(layoutListener)
     }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/WindowDimensionListener.kt
@@ -1,6 +1,7 @@
 package com.reactnativekeyboardcontroller.listeners
 
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.uimanager.ThemedReactContext
 import com.reactnativekeyboardcontroller.extensions.content
@@ -16,8 +17,9 @@ class WindowDimensionListener(
   private val context: ThemedReactContext?,
 ) {
   private var lastDispatchedDimensions = Dimensions(0.0, 0.0)
+  private var layoutListener : ViewTreeObserver.OnGlobalLayoutListener? = null
 
-  init {
+  public fun attachListener() {
     // attach to content view only once per app instance
     if (context != null && listenerID != context.hashCode()) {
       listenerID = context.hashCode()
@@ -26,10 +28,16 @@ class WindowDimensionListener(
 
       updateWindowDimensions(content)
 
-      content?.viewTreeObserver?.addOnGlobalLayoutListener {
+      layoutListener = ViewTreeObserver.OnGlobalLayoutListener {
         updateWindowDimensions(content)
       }
+
+      content?.viewTreeObserver?.addOnGlobalLayoutListener(layoutListener)
     }
+  }
+
+  public fun detachListener() {
+    context?.content?.viewTreeObserver?.removeOnGlobalLayoutListener(layoutListener)
   }
 
   private fun updateWindowDimensions(content: ViewGroup?) {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -14,8 +14,7 @@ import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 class KeyboardControllerViewManagerImpl(
   mReactContext: ReactApplicationContext,
 ) {
-
-  private var listener : WindowDimensionListener? = null
+  private var listener: WindowDimensionListener? = null
 
   fun createViewInstance(reactContext: ThemedReactContext): EdgeToEdgeReactViewGroup {
     if (listener == null) {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -7,14 +7,27 @@ import com.reactnativekeyboardcontroller.events.FocusedInputLayoutChangedEvent
 import com.reactnativekeyboardcontroller.events.FocusedInputSelectionChangedEvent
 import com.reactnativekeyboardcontroller.events.FocusedInputTextChangedEvent
 import com.reactnativekeyboardcontroller.events.KeyboardTransitionEvent
+import com.reactnativekeyboardcontroller.listeners.WindowDimensionListener
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
 @Suppress("detekt:UnusedPrivateProperty")
 class KeyboardControllerViewManagerImpl(
   mReactContext: ReactApplicationContext,
 ) {
-  fun createViewInstance(reactContext: ThemedReactContext): EdgeToEdgeReactViewGroup =
-    EdgeToEdgeReactViewGroup(reactContext)
+
+  private var listener : WindowDimensionListener? = null
+
+  fun createViewInstance(reactContext: ThemedReactContext): EdgeToEdgeReactViewGroup {
+    if (listener == null) {
+      listener = WindowDimensionListener(reactContext)
+      listener?.attachListener()
+    }
+    return EdgeToEdgeReactViewGroup(reactContext)
+  }
+
+  fun invalidate() {
+    listener?.detachListener()
+  }
 
   fun setEnabled(
     view: EdgeToEdgeReactViewGroup,
@@ -68,6 +81,11 @@ class KeyboardControllerViewManagerImpl(
       )
 
     return map
+  }
+
+  fun onDropViewInstance(view: EdgeToEdgeReactViewGroup) {
+    view.setActive(false)
+    view.removeWindowInsetsListener()
   }
 
   companion object {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -85,7 +85,6 @@ class KeyboardControllerViewManagerImpl(
 
   fun onDropViewInstance(view: EdgeToEdgeReactViewGroup) {
     view.setActive(false)
-    view.removeWindowInsetsListener()
   }
 
   companion object {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -82,10 +82,6 @@ class KeyboardControllerViewManagerImpl(
     return map
   }
 
-  fun onDropViewInstance(view: EdgeToEdgeReactViewGroup) {
-    view.setActive(false)
-  }
-
   companion object {
     const val NAME = "KeyboardControllerView"
   }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -63,13 +63,13 @@ class EdgeToEdgeReactViewGroup(
       return
     }
 
-    this.setupKeyboardCallbacks()
+    this.activate()
   }
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
 
-    this.removeKeyboardCallbacks()
+    this.deactivate()
   }
 
   override fun onConfigurationChanged(newConfig: Configuration?) {
@@ -187,12 +187,20 @@ class EdgeToEdgeReactViewGroup(
   // region State managers
   private fun enable() {
     this.setupWindowInsets()
-    this.setupKeyboardCallbacks()
-    modalAttachedWatcher.enable()
+    this.activate()
   }
 
   private fun disable() {
     this.setupWindowInsets()
+    this.deactivate()
+  }
+
+  private fun activate() {
+    this.setupKeyboardCallbacks()
+    modalAttachedWatcher.enable()
+  }
+
+  private fun deactivate() {
     this.removeKeyboardCallbacks()
     modalAttachedWatcher.disable()
   }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -122,13 +122,6 @@ class EdgeToEdgeReactViewGroup(
     }
   }
 
-  fun removeWindowInsetsListener() {
-    val rootView = reactContext.rootView
-    if (rootView != null) {
-      ViewCompat.setOnApplyWindowInsetsListener(rootView, null)
-    }
-  }
-
   fun setEdgeToEdge() {
     val nextValue = active || isPreservingEdgeToEdge
 

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -15,7 +15,6 @@ import com.reactnativekeyboardcontroller.extensions.content
 import com.reactnativekeyboardcontroller.extensions.removeSelf
 import com.reactnativekeyboardcontroller.extensions.requestApplyInsetsWhenAttached
 import com.reactnativekeyboardcontroller.extensions.rootView
-import com.reactnativekeyboardcontroller.extensions.setupWindowDimensionsListener
 import com.reactnativekeyboardcontroller.listeners.KeyboardAnimationCallback
 import com.reactnativekeyboardcontroller.listeners.KeyboardAnimationCallbackConfig
 import com.reactnativekeyboardcontroller.log.Logger
@@ -51,7 +50,6 @@ class EdgeToEdgeReactViewGroup(
   private val modalAttachedWatcher = ModalAttachedWatcher(this, reactContext, config, ::getKeyboardCallback)
 
   init {
-    reactContext.setupWindowDimensionsListener()
     tag = VIEW_TAG
   }
 
@@ -121,6 +119,13 @@ class EdgeToEdgeReactViewGroup(
           defaultInsets.systemWindowInsetBottom,
         )
       }
+    }
+  }
+
+  fun removeWindowInsetsListener() {
+    val rootView = reactContext.rootView
+    if (rootView != null) {
+      ViewCompat.setOnApplyWindowInsetsListener(rootView, null)
     }
   }
 

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -37,7 +37,6 @@ class KeyboardControllerViewManager(
   override fun onDropViewInstance(view: ReactViewGroup) {
     super.onDropViewInstance(view)
     (view as EdgeToEdgeReactViewGroup).setActive(false)
-    view.removeWindowInsetsListener()
   }
   // endregion
 

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -5,6 +5,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
+import com.reactnativekeyboardcontroller.listeners.WindowDimensionListener
 import com.reactnativekeyboardcontroller.managers.KeyboardControllerViewManagerImpl
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
@@ -12,17 +13,35 @@ class KeyboardControllerViewManager(
   mReactContext: ReactApplicationContext,
 ) : ReactViewManager() {
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
+  private var listener: WindowDimensionListener? = null
 
-  override fun getName(): String = KeyboardControllerViewManagerImpl.NAME
+  // region Lifecycle
+  override fun createViewInstance(context: ThemedReactContext): ReactViewGroup {
+    if (listener == null) {
+      listener = WindowDimensionListener(context)
+      listener?.attachListener()
+    }
+    return manager.createViewInstance(context)
+  }
 
-  override fun createViewInstance(reactContext: ThemedReactContext): EdgeToEdgeReactViewGroup =
-    manager.createViewInstance(reactContext)
+  override fun invalidate() {
+    super.invalidate()
+    listener?.detachListener()
+  }
 
   override fun onAfterUpdateTransaction(view: ReactViewGroup) {
     super.onAfterUpdateTransaction(view)
     manager.setEdgeToEdge(view as EdgeToEdgeReactViewGroup)
   }
 
+  override fun onDropViewInstance(view: ReactViewGroup) {
+    super.onDropViewInstance(view)
+    (view as EdgeToEdgeReactViewGroup).setActive(false)
+    view.removeWindowInsetsListener()
+  }
+  // endregion
+
+  // region Props setters
   @ReactProp(name = "enabled")
   fun setEnabled(
     view: EdgeToEdgeReactViewGroup,
@@ -54,7 +73,12 @@ class KeyboardControllerViewManager(
   ) {
     manager.setPreserveEdgeToEdge(view, isPreservingEdgeToEdge)
   }
+  // endregion
 
+  // region Constants
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
     manager.getExportedCustomDirectEventTypeConstants()
+
+  override fun getName(): String = KeyboardControllerViewManagerImpl.NAME
+  // endregion
 }

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -13,20 +13,15 @@ class KeyboardControllerViewManager(
   mReactContext: ReactApplicationContext,
 ) : ReactViewManager() {
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
-  private var listener: WindowDimensionListener? = null
 
   // region Lifecycle
   override fun createViewInstance(context: ThemedReactContext): ReactViewGroup {
-    if (listener == null) {
-      listener = WindowDimensionListener(context)
-      listener?.attachListener()
-    }
     return manager.createViewInstance(context)
   }
 
   override fun invalidate() {
     super.invalidate()
-    listener?.detachListener()
+    manager.invalidate()
   }
 
   override fun onAfterUpdateTransaction(view: ReactViewGroup) {
@@ -36,7 +31,7 @@ class KeyboardControllerViewManager(
 
   override fun onDropViewInstance(view: ReactViewGroup) {
     super.onDropViewInstance(view)
-    (view as EdgeToEdgeReactViewGroup).setActive(false)
+    manager.onDropViewInstance(view as EdgeToEdgeReactViewGroup)
   }
   // endregion
 
@@ -74,7 +69,7 @@ class KeyboardControllerViewManager(
   }
   // endregion
 
-  // region Constants
+  // region Getters
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
     manager.getExportedCustomDirectEventTypeConstants()
 

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -5,7 +5,6 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
-import com.reactnativekeyboardcontroller.listeners.WindowDimensionListener
 import com.reactnativekeyboardcontroller.managers.KeyboardControllerViewManagerImpl
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
 
@@ -15,9 +14,7 @@ class KeyboardControllerViewManager(
   private val manager = KeyboardControllerViewManagerImpl(mReactContext)
 
   // region Lifecycle
-  override fun createViewInstance(context: ThemedReactContext): ReactViewGroup {
-    return manager.createViewInstance(context)
-  }
+  override fun createViewInstance(context: ThemedReactContext): ReactViewGroup = manager.createViewInstance(context)
 
   override fun invalidate() {
     super.invalidate()

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerViewManager.kt
@@ -25,11 +25,6 @@ class KeyboardControllerViewManager(
     super.onAfterUpdateTransaction(view)
     manager.setEdgeToEdge(view as EdgeToEdgeReactViewGroup)
   }
-
-  override fun onDropViewInstance(view: ReactViewGroup) {
-    super.onDropViewInstance(view)
-    manager.onDropViewInstance(view as EdgeToEdgeReactViewGroup)
-  }
   // endregion
 
   // region Props setters

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2055,77 +2055,77 @@ SPEC CHECKSUMS:
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
   InputMask: 71d291dc54d2deaeac6512afb6ec2304228c0bb7
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 35b7c1125a01f847fa5905d380e54951132d2450
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  lottie-react-native: 3fd634de5c0cc095d36687d1b92b7c242d6103e8
+  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: b2eecf2d60216df56bc5e6be5f063826d3c1ee35
   RCTRequired: 78522de7dc73b81f3ed7890d145fa341f5bb32ea
   RCTTypeSafety: c135dd2bf50402d87fd12884cbad5d5e64850edd
   React: b229c49ed5898dab46d60f61ed5a0bfa2ee2fadb
   React-callinvoker: 2ac508e92c8bd9cf834cc7d7787d94352e4af58f
-  React-Core: 325b4f6d9162ae8b9a6ff42fe78e260eb124180d
-  React-CoreModules: 558041e5258f70cd1092f82778d07b8b2ff01897
-  React-cxxreact: 8fff17cbe76e6a8f9991b59552e1235429f9c74b
+  React-Core: 13cdd1558d0b3f6d9d5a22e14d89150280e79f02
+  React-CoreModules: b07a6744f48305405e67c845ebf481b6551b712a
+  React-cxxreact: 1055a86c66ac35b4e80bd5fb766aed5f494dfff4
   React-debug: 0a5fcdbacc6becba0521e910c1bcfdb20f32a3f6
-  React-defaultsnativemodule: 618dc50a0fad41b489997c3eb7aba3a74479fd14
-  React-domnativemodule: 7ba599afb6c2a7ec3eb6450153e2efe0b8747e9a
-  React-Fabric: 252112089d2c63308f4cbfade4010b6606db67d1
-  React-FabricComponents: 3c0f75321680d14d124438ab279c64ec2a3d13c4
-  React-FabricImage: 728b8061cdec2857ca885fd605ee03ad43ffca98
+  React-defaultsnativemodule: 4bb28fc97fee5be63a9ebf8f7a435cfe8ba69459
+  React-domnativemodule: b36a11c2597243d7563985028c51ece988d8ae33
+  React-Fabric: afc561718f25b2cd800b709d934101afe376a12c
+  React-FabricComponents: f4e0a4e18a27bf6d39cbf2a0b42f37a92fa4e37f
+  React-FabricImage: 37d8e8b672eda68a19d71143eb65148084efb325
   React-featureflags: 19682e02ef5861d96b992af16a19109c3dfc1200
-  React-featureflagsnativemodule: 23528c7e7d50782b7ef0804168ba40bbaf1e86ab
-  React-graphics: fefe48f71bfe6f48fd037f59e8277b12e91b6be1
-  React-hermes: a9a0c8377627b5506ef9a7b6f60a805c306e3f51
-  React-idlecallbacksnativemodule: 7e2b6a3b70e042f89cd91dbd73c479bb39a72a7e
-  React-ImageManager: e3300996ac2e2914bf821f71e2f2c92ae6e62ae2
-  React-jserrorhandler: fa75876c662e5d7e79d6efc763fc9f4c88e26986
-  React-jsi: f3f51595cc4c089037b536368f016d4742bf9cf7
-  React-jsiexecutor: cca6c232db461e2fd213a11e9364cfa6fdaa20eb
-  React-jsinspector: 2bd4c9fddf189d6ec2abf4948461060502582bef
-  React-jsinspectortracing: a417d8a0ad481edaa415734b4dac81e3e5ee7dc6
-  React-jsitracing: 1ff7172c5b0522cbf6c98d82bdbb160e49b5804e
-  React-logger: 018826bfd51b9f18e87f67db1590bc510ad20664
-  React-Mapbuffer: 3c11cee7737609275c7b66bd0b1de475f094cedf
-  React-microtasksnativemodule: 843f352b32aacbe13a9c750190d34df44c3e6c2c
-  react-native-blur: b06c3fe88680beac622d8d13b8c36ec15c50383b
-  react-native-keyboard-controller: 9c126325928740796e326bed00d493a13fb61a69
-  react-native-safe-area-context: 3e33e7c43c8b74dba436a5a32651cb8d7064c740
-  react-native-text-input-mask: aa3030769aea6abeffbe1f18876454b734cc8051
-  React-NativeModulesApple: 88433b6946778bea9c153e27b671de15411bf225
-  React-perflogger: 9e8d3c0dc0194eb932162812a168aa5dc662f418
-  React-performancetimeline: 5a2d6efef52bdcefac079c7baa30934978acd023
+  React-featureflagsnativemodule: d7cddf6d907b4e5ab84f9e744b7e88461656e48c
+  React-graphics: b0f78580cdaf5800d25437e3d41cc6c3d83b7aea
+  React-hermes: 71186f872c932e4574d5feb3ed754dda63a0b3bd
+  React-idlecallbacksnativemodule: dd2af19cdd3bc55149d17a2409ed72b694dfbe9c
+  React-ImageManager: a77dde8d5aa6a2b6962c702bf3a47695ef0aa32b
+  React-jserrorhandler: 9c14e89f12d5904257a79aaf84a70cd2e5ac07ba
+  React-jsi: 0775a66820496769ad83e629f0f5cce621a57fc7
+  React-jsiexecutor: 2cf5ba481386803f3c88b85c63fa102cba5d769e
+  React-jsinspector: 8052d532bb7a98b6e021755674659802fb140cc5
+  React-jsinspectortracing: bdd8fd0adcb4813663562e7874c5842449df6d8a
+  React-jsitracing: 2bab3bf55de3d04baf205def375fa6643c47c794
+  React-logger: 795cd5055782db394f187f9db0477d4b25b44291
+  React-Mapbuffer: 0502faf46cab8fb89cfc7bf3e6c6109b6ef9b5de
+  React-microtasksnativemodule: 663bc64e3a96c5fc91081923ae7481adc1359a78
+  react-native-blur: 5b2d13981ad6ce3d15339e135377336cb9be2d68
+  react-native-keyboard-controller: 714b7f716270855e814f8ead5676e379b01f9c5b
+  react-native-safe-area-context: 849d7df29ecb2a7155c769c0b76849ba952c2aa3
+  react-native-text-input-mask: 22ca8eeef84d42a896f79428f7d175a5eb8b1c4e
+  React-NativeModulesApple: 16fbd5b040ff6c492dacc361d49e63cba7a6a7a1
+  React-perflogger: ab51b7592532a0ea45bf6eed7e6cae14a368b678
+  React-performancetimeline: bc2e48198ec814d578ac8401f65d78a574358203
   React-RCTActionSheet: 592674cf61142497e0e820688f5a696e41bf16dd
-  React-RCTAnimation: e6d669872f9b3b4ab9527aab283b7c49283236b7
-  React-RCTAppDelegate: 1768f69e774410cbd0716465db9494acc823a63a
-  React-RCTBlob: 3e2dce94c56218becc4b32b627fc2293149f798d
-  React-RCTFabric: 4dd8a0d13c5e15acc48fac2996a7ef76fc7c5e6a
-  React-RCTFBReactNativeSpec: b2aeef7ea8755ddfdf0c6ca1363ff6766a91080f
-  React-RCTImage: dc04b176c022d12a8f55ae7a7279b1e091066ae0
-  React-RCTLinking: 88f5e37fe4f26fbc80791aa2a5f01baf9b9a3fd5
-  React-RCTNetwork: f213693565efbd698b8e9c18d700a514b49c0c8e
-  React-RCTSettings: a2d32a90c45a3575568cad850abc45924999b8a5
-  React-RCTText: 54cdcd1cbf6f6a91dc6317f5d2c2b7fc3f6bf7a0
-  React-RCTVibration: 11dae0e7f577b5807bb7d31e2e881eb46f854fd4
+  React-RCTAnimation: 8fbb8dba757b49c78f4db403133ab6399a4ce952
+  React-RCTAppDelegate: 346f71ef725906ba8fac77c2fe9c6c9b89d09c96
+  React-RCTBlob: f89b162d0fe6b570a18e755eb16cbe356d3c6d17
+  React-RCTFabric: ae3cfd54caf162df6224c841466e4c1220f82b2b
+  React-RCTFBReactNativeSpec: ce1d60e8eae94c0adaa9acae24d26149c7fe181e
+  React-RCTImage: ccac9969940f170503857733f9a5f63578e106e1
+  React-RCTLinking: d82427bbf18415a3732105383dff119131cadd90
+  React-RCTNetwork: 12ad4d0fbde939e00251ca5ca890da2e6825cc3c
+  React-RCTSettings: e7865bf9f455abf427da349c855f8644b5c39afa
+  React-RCTText: 2cdfd88745059ec3202a0842ea75a956c7d6f27d
+  React-RCTVibration: a3a1458e6230dfd64b3768ebc0a4aac430d9d508
   React-rendererconsistency: 64e897e00d2568fd8dfe31e2496f80e85c0aaad1
-  React-rendererdebug: 41ce452460c44bba715d9e41d5493a96de277764
+  React-rendererdebug: a3f6d3ae7d2fa0035885026756281c07ee32479e
   React-rncore: 58748c2aa445f56b99e5118dad0aedb51c40ce9f
-  React-RuntimeApple: 7785ed0d8ae54da65a88736bb63ca97608a6d933
-  React-RuntimeCore: 6029ea70bc77f98cfd43ebe69217f14e93ba1f12
+  React-RuntimeApple: f0fda7bacabd32daa099cfda8f07466c30acd149
+  React-RuntimeCore: 683ee0b6a76d4b4bf6fbf83a541895b4887cc636
   React-runtimeexecutor: a188df372373baf5066e6e229177836488799f80
-  React-RuntimeHermes: a264609c28b796edfffc8ae4cb8fad1773ab948b
-  React-runtimescheduler: 23ec3a1e0fb1ec752d1a9c1fb15258c30bfc7222
+  React-RuntimeHermes: 907c8e9bec13ea6466b94828c088c24590d4d0b6
+  React-runtimescheduler: a2e2a39125dd6426b5d8b773f689d660cd7c5f60
   React-timing: bb220a53a795ed57976a4855c521f3de2f298fe5
-  React-utils: 3b054aaebe658fc710a8d239d0e4b9fd3e0b78f9
-  ReactAppDependencyProvider: a1fb08dfdc7ebc387b2e54cfc9decd283ed821d8
-  ReactCodegen: 008c319179d681a6a00966edfc67fda68f9fbb2e
-  ReactCommon: 0c097b53f03d6bf166edbcd0915da32f3015dd90
-  RNCMaskedView: 2a1adda250c1b71134fa097ae7fc56e0b41ca01e
-  RNGestureHandler: 9f3109e11ed88fe5bed280bf7762b25e4c52f396
-  RNReactNativeHapticFeedback: f9cfb40676f21a52e9e172648d033f539156a5ec
-  RNReanimated: c34bdc579a880e39f6f5588d12cf0c3204eb5aa8
-  RNScreens: 96fe858d87d26c3f46f0696f9e8824ce33a05aa7
+  React-utils: 300d8bbb6555dcffaca71e7a0663201b5c7edbbc
+  ReactAppDependencyProvider: f2e81d80afd71a8058589e19d8a134243fa53f17
+  ReactCodegen: a63a0ab6ae824aef2e8c744981edd718b16eb9f2
+  ReactCommon: 3d39389f8e2a2157d5c999f8fba57bd1c8f226f0
+  RNCMaskedView: 6d4bf14f158d1a93484edf30850cbbd7ccbb8668
+  RNGestureHandler: ebb08ce5dfc9caff34ae9cda3ef0d18daae3a7ef
+  RNReactNativeHapticFeedback: 288ef2881046914e9108441e783f64899807282a
+  RNReanimated: 57dc0c788faad06eaab3109e8024494071888146
+  RNScreens: 92045ed4a8d561352cebaa00a8c9f1a8fb80419b
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: afd04ff05ebe0121a00c468a8a3c8080221cb14c
+  Yoga: 9b7fb56e7b08cde60e2153344fa6afbd88e5d99f
 
 PODFILE CHECKSUM: c51a5e2124b01c5794c41f1f13ee16704466637a
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2055,77 +2055,77 @@ SPEC CHECKSUMS:
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
   InputMask: 71d291dc54d2deaeac6512afb6ec2304228c0bb7
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 3fd634de5c0cc095d36687d1b92b7c242d6103e8
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  lottie-react-native: 35b7c1125a01f847fa5905d380e54951132d2450
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: b2eecf2d60216df56bc5e6be5f063826d3c1ee35
   RCTRequired: 78522de7dc73b81f3ed7890d145fa341f5bb32ea
   RCTTypeSafety: c135dd2bf50402d87fd12884cbad5d5e64850edd
   React: b229c49ed5898dab46d60f61ed5a0bfa2ee2fadb
   React-callinvoker: 2ac508e92c8bd9cf834cc7d7787d94352e4af58f
-  React-Core: 13cdd1558d0b3f6d9d5a22e14d89150280e79f02
-  React-CoreModules: b07a6744f48305405e67c845ebf481b6551b712a
-  React-cxxreact: 1055a86c66ac35b4e80bd5fb766aed5f494dfff4
+  React-Core: 325b4f6d9162ae8b9a6ff42fe78e260eb124180d
+  React-CoreModules: 558041e5258f70cd1092f82778d07b8b2ff01897
+  React-cxxreact: 8fff17cbe76e6a8f9991b59552e1235429f9c74b
   React-debug: 0a5fcdbacc6becba0521e910c1bcfdb20f32a3f6
-  React-defaultsnativemodule: 4bb28fc97fee5be63a9ebf8f7a435cfe8ba69459
-  React-domnativemodule: b36a11c2597243d7563985028c51ece988d8ae33
-  React-Fabric: afc561718f25b2cd800b709d934101afe376a12c
-  React-FabricComponents: f4e0a4e18a27bf6d39cbf2a0b42f37a92fa4e37f
-  React-FabricImage: 37d8e8b672eda68a19d71143eb65148084efb325
+  React-defaultsnativemodule: 618dc50a0fad41b489997c3eb7aba3a74479fd14
+  React-domnativemodule: 7ba599afb6c2a7ec3eb6450153e2efe0b8747e9a
+  React-Fabric: 252112089d2c63308f4cbfade4010b6606db67d1
+  React-FabricComponents: 3c0f75321680d14d124438ab279c64ec2a3d13c4
+  React-FabricImage: 728b8061cdec2857ca885fd605ee03ad43ffca98
   React-featureflags: 19682e02ef5861d96b992af16a19109c3dfc1200
-  React-featureflagsnativemodule: d7cddf6d907b4e5ab84f9e744b7e88461656e48c
-  React-graphics: b0f78580cdaf5800d25437e3d41cc6c3d83b7aea
-  React-hermes: 71186f872c932e4574d5feb3ed754dda63a0b3bd
-  React-idlecallbacksnativemodule: dd2af19cdd3bc55149d17a2409ed72b694dfbe9c
-  React-ImageManager: a77dde8d5aa6a2b6962c702bf3a47695ef0aa32b
-  React-jserrorhandler: 9c14e89f12d5904257a79aaf84a70cd2e5ac07ba
-  React-jsi: 0775a66820496769ad83e629f0f5cce621a57fc7
-  React-jsiexecutor: 2cf5ba481386803f3c88b85c63fa102cba5d769e
-  React-jsinspector: 8052d532bb7a98b6e021755674659802fb140cc5
-  React-jsinspectortracing: bdd8fd0adcb4813663562e7874c5842449df6d8a
-  React-jsitracing: 2bab3bf55de3d04baf205def375fa6643c47c794
-  React-logger: 795cd5055782db394f187f9db0477d4b25b44291
-  React-Mapbuffer: 0502faf46cab8fb89cfc7bf3e6c6109b6ef9b5de
-  React-microtasksnativemodule: 663bc64e3a96c5fc91081923ae7481adc1359a78
-  react-native-blur: 5b2d13981ad6ce3d15339e135377336cb9be2d68
-  react-native-keyboard-controller: 714b7f716270855e814f8ead5676e379b01f9c5b
-  react-native-safe-area-context: 849d7df29ecb2a7155c769c0b76849ba952c2aa3
-  react-native-text-input-mask: 22ca8eeef84d42a896f79428f7d175a5eb8b1c4e
-  React-NativeModulesApple: 16fbd5b040ff6c492dacc361d49e63cba7a6a7a1
-  React-perflogger: ab51b7592532a0ea45bf6eed7e6cae14a368b678
-  React-performancetimeline: bc2e48198ec814d578ac8401f65d78a574358203
+  React-featureflagsnativemodule: 23528c7e7d50782b7ef0804168ba40bbaf1e86ab
+  React-graphics: fefe48f71bfe6f48fd037f59e8277b12e91b6be1
+  React-hermes: a9a0c8377627b5506ef9a7b6f60a805c306e3f51
+  React-idlecallbacksnativemodule: 7e2b6a3b70e042f89cd91dbd73c479bb39a72a7e
+  React-ImageManager: e3300996ac2e2914bf821f71e2f2c92ae6e62ae2
+  React-jserrorhandler: fa75876c662e5d7e79d6efc763fc9f4c88e26986
+  React-jsi: f3f51595cc4c089037b536368f016d4742bf9cf7
+  React-jsiexecutor: cca6c232db461e2fd213a11e9364cfa6fdaa20eb
+  React-jsinspector: 2bd4c9fddf189d6ec2abf4948461060502582bef
+  React-jsinspectortracing: a417d8a0ad481edaa415734b4dac81e3e5ee7dc6
+  React-jsitracing: 1ff7172c5b0522cbf6c98d82bdbb160e49b5804e
+  React-logger: 018826bfd51b9f18e87f67db1590bc510ad20664
+  React-Mapbuffer: 3c11cee7737609275c7b66bd0b1de475f094cedf
+  React-microtasksnativemodule: 843f352b32aacbe13a9c750190d34df44c3e6c2c
+  react-native-blur: b06c3fe88680beac622d8d13b8c36ec15c50383b
+  react-native-keyboard-controller: 9c126325928740796e326bed00d493a13fb61a69
+  react-native-safe-area-context: 3e33e7c43c8b74dba436a5a32651cb8d7064c740
+  react-native-text-input-mask: aa3030769aea6abeffbe1f18876454b734cc8051
+  React-NativeModulesApple: 88433b6946778bea9c153e27b671de15411bf225
+  React-perflogger: 9e8d3c0dc0194eb932162812a168aa5dc662f418
+  React-performancetimeline: 5a2d6efef52bdcefac079c7baa30934978acd023
   React-RCTActionSheet: 592674cf61142497e0e820688f5a696e41bf16dd
-  React-RCTAnimation: 8fbb8dba757b49c78f4db403133ab6399a4ce952
-  React-RCTAppDelegate: 346f71ef725906ba8fac77c2fe9c6c9b89d09c96
-  React-RCTBlob: f89b162d0fe6b570a18e755eb16cbe356d3c6d17
-  React-RCTFabric: ae3cfd54caf162df6224c841466e4c1220f82b2b
-  React-RCTFBReactNativeSpec: ce1d60e8eae94c0adaa9acae24d26149c7fe181e
-  React-RCTImage: ccac9969940f170503857733f9a5f63578e106e1
-  React-RCTLinking: d82427bbf18415a3732105383dff119131cadd90
-  React-RCTNetwork: 12ad4d0fbde939e00251ca5ca890da2e6825cc3c
-  React-RCTSettings: e7865bf9f455abf427da349c855f8644b5c39afa
-  React-RCTText: 2cdfd88745059ec3202a0842ea75a956c7d6f27d
-  React-RCTVibration: a3a1458e6230dfd64b3768ebc0a4aac430d9d508
+  React-RCTAnimation: e6d669872f9b3b4ab9527aab283b7c49283236b7
+  React-RCTAppDelegate: 1768f69e774410cbd0716465db9494acc823a63a
+  React-RCTBlob: 3e2dce94c56218becc4b32b627fc2293149f798d
+  React-RCTFabric: 4dd8a0d13c5e15acc48fac2996a7ef76fc7c5e6a
+  React-RCTFBReactNativeSpec: b2aeef7ea8755ddfdf0c6ca1363ff6766a91080f
+  React-RCTImage: dc04b176c022d12a8f55ae7a7279b1e091066ae0
+  React-RCTLinking: 88f5e37fe4f26fbc80791aa2a5f01baf9b9a3fd5
+  React-RCTNetwork: f213693565efbd698b8e9c18d700a514b49c0c8e
+  React-RCTSettings: a2d32a90c45a3575568cad850abc45924999b8a5
+  React-RCTText: 54cdcd1cbf6f6a91dc6317f5d2c2b7fc3f6bf7a0
+  React-RCTVibration: 11dae0e7f577b5807bb7d31e2e881eb46f854fd4
   React-rendererconsistency: 64e897e00d2568fd8dfe31e2496f80e85c0aaad1
-  React-rendererdebug: a3f6d3ae7d2fa0035885026756281c07ee32479e
+  React-rendererdebug: 41ce452460c44bba715d9e41d5493a96de277764
   React-rncore: 58748c2aa445f56b99e5118dad0aedb51c40ce9f
-  React-RuntimeApple: f0fda7bacabd32daa099cfda8f07466c30acd149
-  React-RuntimeCore: 683ee0b6a76d4b4bf6fbf83a541895b4887cc636
+  React-RuntimeApple: 7785ed0d8ae54da65a88736bb63ca97608a6d933
+  React-RuntimeCore: 6029ea70bc77f98cfd43ebe69217f14e93ba1f12
   React-runtimeexecutor: a188df372373baf5066e6e229177836488799f80
-  React-RuntimeHermes: 907c8e9bec13ea6466b94828c088c24590d4d0b6
-  React-runtimescheduler: a2e2a39125dd6426b5d8b773f689d660cd7c5f60
+  React-RuntimeHermes: a264609c28b796edfffc8ae4cb8fad1773ab948b
+  React-runtimescheduler: 23ec3a1e0fb1ec752d1a9c1fb15258c30bfc7222
   React-timing: bb220a53a795ed57976a4855c521f3de2f298fe5
-  React-utils: 300d8bbb6555dcffaca71e7a0663201b5c7edbbc
-  ReactAppDependencyProvider: f2e81d80afd71a8058589e19d8a134243fa53f17
-  ReactCodegen: a63a0ab6ae824aef2e8c744981edd718b16eb9f2
-  ReactCommon: 3d39389f8e2a2157d5c999f8fba57bd1c8f226f0
-  RNCMaskedView: 6d4bf14f158d1a93484edf30850cbbd7ccbb8668
-  RNGestureHandler: ebb08ce5dfc9caff34ae9cda3ef0d18daae3a7ef
-  RNReactNativeHapticFeedback: 288ef2881046914e9108441e783f64899807282a
-  RNReanimated: 57dc0c788faad06eaab3109e8024494071888146
-  RNScreens: 92045ed4a8d561352cebaa00a8c9f1a8fb80419b
+  React-utils: 3b054aaebe658fc710a8d239d0e4b9fd3e0b78f9
+  ReactAppDependencyProvider: a1fb08dfdc7ebc387b2e54cfc9decd283ed821d8
+  ReactCodegen: 008c319179d681a6a00966edfc67fda68f9fbb2e
+  ReactCommon: 0c097b53f03d6bf166edbcd0915da32f3015dd90
+  RNCMaskedView: 2a1adda250c1b71134fa097ae7fc56e0b41ca01e
+  RNGestureHandler: 9f3109e11ed88fe5bed280bf7762b25e4c52f396
+  RNReactNativeHapticFeedback: f9cfb40676f21a52e9e172648d033f539156a5ec
+  RNReanimated: c34bdc579a880e39f6f5588d12cf0c3204eb5aa8
+  RNScreens: 96fe858d87d26c3f46f0696f9e8824ce33a05aa7
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 9b7fb56e7b08cde60e2153344fa6afbd88e5d99f
+  Yoga: afd04ff05ebe0121a00c468a8a3c8080221cb14c
 
 PODFILE CHECKSUM: c51a5e2124b01c5794c41f1f13ee16704466637a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

This PR fixes 3 memory leaks:
- first is connected to `ModalAttachedWatcher` keeping itself as a listener in `EventDispatcher`, everytime the `EdgeToEdgeReactViewGroup` sets itself to `active`. I fixed it with calling `setActive(false)` in `onDropViewInstance` of its manager.
- second is connected to `EdgeToEdgeReactViewGroup` calling `setupWindowDimensionsListener` and not detaching it ever. It is a singleton listener, so I attach it once when the first `EdgeToEdgeReactViewGroup` instance is created in `createViewInstance` and remove it in `invalidate` of the whole managers module.
- ~~third is connected to `EdgeToEdgeReactViewGroup` also adding a listener on `rootView` each time when calling `setupWindowInsets` and never detaching it, so we detach it in `onDropViewInstance`.~~ <- will be fixed later on in a separate PR

## 💡 Motivation and Context

Fix memory leaks happening e.g. on reload.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 📢 Changelog

### Android
- Add proper detaching on listeners when views or whole modules are destroyed

## 🤔 How Has This Been Tested?

Tested in Expensify with hitting reload.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
