### PR TITLE
fix: iOS 26 non-firing `onMove` handler

### DIFF
--- a/ios/extensions/String.swift
+++ b/ios/extensions/String.swift
@@ -6,7 +6,6 @@
 //
 
 public extension String {
-  /// `"<foo".hasAnyPrefix(["<bar", "<foo"])` → true
   func hasAnyPrefix(_ prefixes: [String]) -> Bool {
     prefixes.contains { hasPrefix($0) }
   }

--- a/ios/extensions/String.swift
+++ b/ios/extensions/String.swift
@@ -1,0 +1,13 @@
+//
+//  String.swift
+//  Pods
+//
+//  Created by Kiryl Ziusko on 10/06/2025.
+//
+
+public extension String {
+  /// `"<foo".hasAnyPrefix(["<bar", "<foo"])` → true
+  func hasAnyPrefix(_ prefixes: [String]) -> Bool {
+    prefixes.contains { hasPrefix($0) }
+  }
+}

--- a/ios/traversal/KeyboardView.swift
+++ b/ios/traversal/KeyboardView.swift
@@ -10,15 +10,20 @@ import Foundation
 import UIKit
 
 enum KeyboardView {
+  private static let windowPrefix = "<UITextEffectsWindow"
+  private static let containerPrefixes = ["<UIInputSetContainerView",
+                                          "<UITrackingWindowView"]
+  private static let hostPrefixes = ["<UIInputSetHostView",
+                                     "<UIKeyboardItemContainerView"]
   // inspired by https://stackoverflow.com/questions/32598490/show-uiview-with-buttons-over-keyboard-like-in-skype-viber-messengers-swift-i
   static func find() -> UIView? {
     let windows = UIApplication.shared.windows
     for window in windows {
-      if window.description.hasPrefix("<UITextEffectsWindow") {
+      if window.description.hasPrefix(windowPrefix) {
         for subview in window.subviews {
-          if subview.description.hasPrefix("<UIInputSetContainerView") {
+          if subview.description.hasAnyPrefix(containerPrefixes) {
             for hostView in subview.subviews {
-              if hostView.description.hasPrefix("<UIInputSetHostView"), hostView.frame.height != 0 {
+              if hostView.description.hasAnyPrefix(hostPrefixes), hostView.frame.height != 0 {
                 return hostView
               }
             }

--- a/ios/traversal/KeyboardView.swift
+++ b/ios/traversal/KeyboardView.swift
@@ -11,10 +11,8 @@ import UIKit
 
 enum KeyboardView {
   private static let windowPrefix = "<UITextEffectsWindow"
-  private static let containerPrefixes = ["<UIInputSetContainerView",
-                                          "<UITrackingWindowView"]
-  private static let hostPrefixes = ["<UIInputSetHostView",
-                                     "<UIKeyboardItemContainerView"]
+  private static let containerPrefixes = ["<UIInputSetContainerView", "<UITrackingWindowView"]
+  private static let hostPrefixes = ["<UIInputSetHostView", "<UIKeyboardItemContainerView"]
   // inspired by https://stackoverflow.com/questions/32598490/show-uiview-with-buttons-over-keyboard-like-in-skype-viber-messengers-swift-i
   static func find() -> UIView? {
     let windows = UIApplication.shared.windows


### PR DESCRIPTION
## 📜 Description

Fixed a problem when `onMove` from `useKeyboardHandler` function is not getting fired on iOS 26.

## 💡 Motivation and Context

Yesterday at WWDC 2025 Apple introduced a new iOS redesign. Turns out that redesign break certain features in `react-native-keyboard-controller`. I decided to be pro-active and check what exactly may be working/non-working to be well prepared before a full launch at autumn.

First (and most significant) part is broken `onMove` handler. In iOS 26 this handler simply not getting triggered. It happens because Apple started to use new classes and to keep a backward compatibility they decided to use new classes:

|iOS 18.4|iOS 26.0|
|--------|---------|
|<img width="340" alt="image" src="https://github.com/user-attachments/assets/f200aa7e-b78e-4102-8a96-4c8f527271bb" />|<img width="436" alt="image" src="https://github.com/user-attachments/assets/ab771b4b-7794-4640-8d6e-aa8181306775" />|

So current implementation of `KeyboardView.find()` returns nil and because of that half of the functionality of the library stops to work (literally functionality gets downgraded to version `1.3.0` in terms of position tracking).

In this PR I'm adopting `KeyboardView.find()` to work with latest view hierarchy structure and be more robust across different OS versions. For that I update class names and check both iOS 26+ and iOS < 18 classes.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/970

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- created `hasAnyPrefix` extension for `String`;
- updated traversal algorithm for `KeyboardView.find` function;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 16 Pro (iOS 26).

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/37855f41-274d-481c-b4ae-aca6c5e0cfa6

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
