### PR TITLE
perf: pause `CADisplayLink` instead of re-creation

### DIFF
--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -57,15 +57,15 @@ public class KeyboardMovementObserver: NSObject {
     self.onNotify = onNotify
     self.onRequestAnimation = onRequestAnimation
     self.onCancelAnimation = onCancelAnimation
-    
+
     super.init()
-    
+
     displayLink = CADisplayLink(target: self, selector: #selector(updateKeyboardFrame))
     displayLink.preferredFramesPerSecond = 120 // will fallback to 60 fps for devices without Pro Motion display
     displayLink.add(to: .main, forMode: .common)
     displayLink.isPaused = true
   }
-  
+
   deinit {
     displayLink.invalidate()
     displayLink = nil


### PR DESCRIPTION
## 📜 Description

Pause `DisplayLink` instead of re-creating it before any keyboard movement.

## 💡 Motivation and Context

This is a known fact, that pausing `CADisplayLink` is faster operation rather than re-creating it and attaching to the thread. I decided to make some benchamrkes, and it seems like it takes `1ms` for `10` runs:

<img width="516" alt="image" src="https://github.com/user-attachments/assets/b6bb5c28-bffa-46d0-b499-4855ebb3454f" />

I tried to re-run test 40 times, and the function wasn't in a stack trace - that means that the time was so insignificant. I also measure function execution:
- pausing: 1.5-2e^-6
- re-creating: 7-10e-6

So roughly speaking this is 5x improvement, but we measure only creating instances of new object (most likely we don't track what happens underhood).

Anyway, this is an optimization and I don't think it introduces any breaking changes, so let's keep it.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- pause `DisplayLink` instead of re-creating it;

## 🤔 How Has This Been Tested?

Tested via Profiler. Also tested functionality manually and via e2e tests.

## 📸 Screenshots (if appropriate):

<img width="965" alt="image" src="https://github.com/user-attachments/assets/395b4511-4195-49e2-84fb-9beef91dfb4f" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
