### PR TITLE
docs: use `keyboard accessory view` as keyword for `KeyboardStickyView`

### DIFF
--- a/docs/docs/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/docs/api/components/keyboard-sticky-view/index.mdx
@@ -3,8 +3,9 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
-    keyboard accessory view,
     keyboard sticky view,
+    keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/docs/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/docs/api/components/keyboard-sticky-view/index.mdx
@@ -3,6 +3,7 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
+    keyboard accessory view,
     keyboard sticky view,
     keyboard sticky footer,
     sticky view,

--- a/docs/versioned_docs/version-1.10.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.10.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,8 +3,9 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
-    keyboard accessory view,
     keyboard sticky view,
+    keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.10.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.10.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,6 +3,7 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
+    keyboard accessory view,
     keyboard sticky view,
     keyboard sticky footer,
     sticky view,

--- a/docs/versioned_docs/version-1.11.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.11.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,8 +3,9 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
-    keyboard accessory view,
     keyboard sticky view,
+    keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.11.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.11.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,6 +3,7 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
+    keyboard accessory view,
     keyboard sticky view,
     keyboard sticky footer,
     sticky view,

--- a/docs/versioned_docs/version-1.12.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.12.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,8 +3,9 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
-    keyboard accessory view,
     keyboard sticky view,
+    keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.12.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.12.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,6 +3,7 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
+    keyboard accessory view,
     keyboard sticky view,
     keyboard sticky footer,
     sticky view,

--- a/docs/versioned_docs/version-1.13.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.13.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,8 +3,9 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
-    keyboard accessory view,
     keyboard sticky view,
+    keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.13.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.13.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,6 +3,7 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
+    keyboard accessory view,
     keyboard sticky view,
     keyboard sticky footer,
     sticky view,

--- a/docs/versioned_docs/version-1.14.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.14.0/api/components/keyboard-sticky-view/index.mdx
@@ -5,6 +5,7 @@ keywords:
     KeyboardStickyView,
     keyboard sticky view,
     keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.14.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.14.0/api/components/keyboard-sticky-view/index.mdx
@@ -4,6 +4,7 @@ keywords:
     react-native-keyboard-controller,
     KeyboardStickyView,
     keyboard sticky view,
+    keyboard accessory view,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.15.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.15.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,8 +3,9 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
-    keyboard accessory view,
     keyboard sticky view,
+    keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.15.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.15.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,6 +3,7 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
+    keyboard accessory view,
     keyboard sticky view,
     keyboard sticky footer,
     sticky view,

--- a/docs/versioned_docs/version-1.16.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.16.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,8 +3,9 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
-    keyboard accessory view,
     keyboard sticky view,
+    keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.16.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.16.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,6 +3,7 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
+    keyboard accessory view,
     keyboard sticky view,
     keyboard sticky footer,
     sticky view,

--- a/docs/versioned_docs/version-1.17.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.17.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,8 +3,9 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
-    keyboard accessory view,
     keyboard sticky view,
+    keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.17.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.17.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,6 +3,7 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
+    keyboard accessory view,
     keyboard sticky view,
     keyboard sticky footer,
     sticky view,

--- a/docs/versioned_docs/version-1.9.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.9.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,8 +3,9 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
-    keyboard accessory view,
     keyboard sticky view,
+    keyboard accessory view,
+    KeyboardAccessoryView,
     keyboard sticky footer,
     sticky view,
     sticky footer,

--- a/docs/versioned_docs/version-1.9.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.9.0/api/components/keyboard-sticky-view/index.mdx
@@ -3,6 +3,7 @@ keywords:
   [
     react-native-keyboard-controller,
     KeyboardStickyView,
+    keyboard accessory view,
     keyboard sticky view,
     keyboard sticky footer,
     sticky view,


### PR DESCRIPTION
## 📜 Description

Added `KeyboardAccessoryView` and `keyboard accessory view` to `KeyboardStickyView` page keywords.

## 💡 Motivation and Context

People are trying to find it, but they can't:

<img width="580" alt="image" src="https://github.com/user-attachments/assets/d5136f62-f347-4b71-98c3-bfab39f1a3d2" />

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added `KeyboardAccessoryView` and `keyboard accessory view` keywords;

## 🤔 How Has This Been Tested?

Tested via preview.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
