### PR TITLE
fix: use reflection for original `StatusBar` implementation discovery

### DIFF
--- a/android/src/base/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
+++ b/android/src/base/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
@@ -7,7 +7,7 @@ import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 import com.reactnativekeyboardcontroller.modules.KeyboardControllerModuleImpl
-import com.reactnativekeyboardcontroller.modules.StatusBarManagerCompatModuleImpl
+import com.reactnativekeyboardcontroller.modules.statusbar.StatusBarManagerCompatModuleImpl
 
 class KeyboardControllerPackage : BaseReactPackage() {
   override fun getModule(

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt
@@ -1,7 +1,7 @@
 package com.reactnativekeyboardcontroller
 
 import com.facebook.react.bridge.ReactApplicationContext
-import com.reactnativekeyboardcontroller.modules.StatusBarManagerCompatModuleImpl
+import com.reactnativekeyboardcontroller.modules.statusbar.StatusBarManagerCompatModuleImpl
 
 class StatusBarManagerCompatModule(
   mReactContext: ReactApplicationContext,

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarManagerCompatModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarManagerCompatModuleImpl.kt
@@ -1,4 +1,4 @@
-package com.reactnativekeyboardcontroller.modules
+package com.reactnativekeyboardcontroller.modules.statusbar
 
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
@@ -9,7 +9,6 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
-import com.facebook.react.modules.statusbar.StatusBarModule
 import com.reactnativekeyboardcontroller.extensions.rootView
 import com.reactnativekeyboardcontroller.log.Logger
 import com.reactnativekeyboardcontroller.views.EdgeToEdgeReactViewGroup
@@ -20,7 +19,7 @@ private val TAG = StatusBarManagerCompatModuleImpl::class.qualifiedName
 class StatusBarManagerCompatModuleImpl(
   private val mReactContext: ReactApplicationContext,
 ) {
-  private var original = StatusBarModule(mReactContext)
+  private var original = StatusBarModuleProxy(mReactContext)
   private var controller: WindowInsetsControllerCompat? = null
   private var lastActivity = WeakReference<Activity?>(null)
 
@@ -49,7 +48,10 @@ class StatusBarManagerCompatModuleImpl(
 
     val activity = mReactContext.currentActivity
     if (activity == null) {
-      Logger.w(TAG, "StatusBarManagerCompatModule: Ignored status bar change, current activity is null.")
+      Logger.w(
+        TAG,
+        "StatusBarManagerCompatModule: Ignored status bar change, current activity is null.",
+      )
       return
     }
 
@@ -90,7 +92,7 @@ class StatusBarManagerCompatModuleImpl(
     }
   }
 
-  fun getConstants(): MutableMap<String, Any>? = original.constants
+  fun getConstants(): MutableMap<String, Any>? = original.getConstants()
 
   private fun getController(): WindowInsetsControllerCompat? {
     val activity = mReactContext.currentActivity

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarModuleProxy.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarModuleProxy.kt
@@ -1,3 +1,5 @@
+@file:Suppress("detekt:TooGenericExceptionCaught")
+
 package com.reactnativekeyboardcontroller.modules.statusbar
 
 import com.facebook.react.bridge.ReactApplicationContext
@@ -75,6 +77,7 @@ class StatusBarModuleProxy(
 
   fun getConstants(): MutableMap<String, Any>? =
     try {
+      @Suppress("UNCHECKED_CAST")
       getConstantsMethod?.invoke(instance) as? MutableMap<String, Any>
     } catch (e: Exception) {
       Logger.w(TAG, "Error invoking StatusBarModule.getConstants method", e)

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarModuleProxy.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarModuleProxy.kt
@@ -1,0 +1,83 @@
+package com.reactnativekeyboardcontroller.modules.statusbar
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.reactnativekeyboardcontroller.log.Logger
+import java.lang.reflect.Method
+
+private val TAG = StatusBarModuleProxy::class.qualifiedName
+
+/**
+ * For the sake of better compatibility with the old/new version of the react-native, we are using reflection
+ * to call the methods of the module. In RN 0.78 the `StatusBarModule` was public, but in RN 0.80
+ * it's internal (kotlin-only). So we are using reflection to call the methods of the module.
+ */
+class StatusBarModuleProxy(
+  reactContext: ReactApplicationContext,
+) {
+  private var instance: Any? = null
+
+  private var setHiddenMethod: Method? = null
+  private var setColorMethod: Method? = null
+  private var setTranslucentMethod: Method? = null
+  private var setStyleMethod: Method? = null
+  private var getConstantsMethod: Method? = null
+
+  init {
+    try {
+      val clazz = Class.forName("com.facebook.react.modules.statusbar.StatusBarModule")
+      val constructor = clazz.getConstructor(ReactApplicationContext::class.java)
+      instance = constructor.newInstance(reactContext)
+
+      setHiddenMethod = clazz.getMethod("setHidden", Boolean::class.java)
+      setColorMethod = clazz.getMethod("setColor", Double::class.java, Boolean::class.java)
+      setTranslucentMethod = clazz.getMethod("setTranslucent", Boolean::class.java)
+      setStyleMethod = clazz.getMethod("setStyle", String::class.java)
+      getConstantsMethod = clazz.getMethod("getConstants")
+    } catch (e: Exception) {
+      Logger.w(TAG, "Failed to initialize StatusBarModule via reflection", e)
+    }
+  }
+
+  fun setHidden(hidden: Boolean) {
+    try {
+      setHiddenMethod?.invoke(instance, hidden)
+    } catch (e: Exception) {
+      Logger.w(TAG, "Error invoking StatusBarModule.setHidden method", e)
+    }
+  }
+
+  fun setColor(
+    color: Double,
+    animated: Boolean,
+  ) {
+    try {
+      setColorMethod?.invoke(instance, color, animated)
+    } catch (e: Exception) {
+      Logger.w(TAG, "Error invoking StatusBarModule.setColor method", e)
+    }
+  }
+
+  fun setTranslucent(translucent: Boolean) {
+    try {
+      setTranslucentMethod?.invoke(instance, translucent)
+    } catch (e: Exception) {
+      Logger.w(TAG, "Error invoking StatusBarModule.setTranslucent method", e)
+    }
+  }
+
+  fun setStyle(style: String) {
+    try {
+      setStyleMethod?.invoke(instance, style)
+    } catch (e: Exception) {
+      Logger.w(TAG, "Error invoking StatusBarModule.setStyle method", e)
+    }
+  }
+
+  fun getConstants(): MutableMap<String, Any>? =
+    try {
+      getConstantsMethod?.invoke(instance) as? MutableMap<String, Any>
+    } catch (e: Exception) {
+      Logger.w(TAG, "Error invoking StatusBarModule.getConstants method", e)
+      null
+    }
+}

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt
@@ -5,7 +5,7 @@ import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import com.reactnativekeyboardcontroller.modules.StatusBarManagerCompatModuleImpl
+import com.reactnativekeyboardcontroller.modules.statusbar.StatusBarManagerCompatModuleImpl
 
 class StatusBarManagerCompatModule(
   mReactContext: ReactApplicationContext,

--- a/android/src/turbo/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
+++ b/android/src/turbo/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
@@ -7,7 +7,7 @@ import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 import com.reactnativekeyboardcontroller.modules.KeyboardControllerModuleImpl
-import com.reactnativekeyboardcontroller.modules.StatusBarManagerCompatModuleImpl
+import com.reactnativekeyboardcontroller.modules.statusbar.StatusBarManagerCompatModuleImpl
 
 class KeyboardControllerPackage : TurboReactPackage() {
   override fun getModule(


### PR DESCRIPTION
## 📜 Description

Use reflection for `StatusBarModule` usage.

## 💡 Motivation and Context

It seems like in RN 0.80+ the `StatusBarModule` is `internal` now (kotlin). So we can't use ir directly anymore - moreover the usage of `internal` class will lead to compilation errors.

An ideal fix is to make it public again in react-native framework, but it'll take some time and some RN versions will still use `internal` modificator. So in order to assure better compatibility across different RN versions I decided to use reflection. We can not use the approach with Java's `protected` classes (where we create the same package name and export public wrapper), because kotlin has a stricter policy. So we have two options how to fix it:
- reflection
- copy-paste original code

We already use reflection in 2 places (though they will be removed in the future) I decided to add more usage and create `StatusBarModuleProxy`.

In this PR I also re-structured the fs and created `statusbar` folder where placed proxy + module implementations.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- created `StatusBarModuleProxy` based on reflection;
- created `statusbar` folder;
- update imports that use `StatusBarModuleCompat`;

## 🤔 How Has This Been Tested?

Tested on Pixel 3A (API 33, emulator).

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/6581bb89-6e57-445b-afb8-6a080773e2aa

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
