### PR TITLE
fix: `KeyboardExtender` on iOS 26

### DIFF
--- a/ios/views/KeyboardExtenderContainerView.swift
+++ b/ios/views/KeyboardExtenderContainerView.swift
@@ -12,7 +12,8 @@ public class KeyboardExtenderContainerView: UIView {
   @objc public static func create(frame: CGRect, contentView: UIView) -> UIView {
     if #available(iOS 26.0, *) {
       if let glassEffectClass = NSClassFromString("UIGlassEffect") as? UIVisualEffect.Type {
-        let padding = 20.0
+        let paddingHorizontal = 20.0
+        let paddingBottom = 10.0
         let isDark = FocusedInputHolder.shared.get()?.keyboardAppearanceValue == "dark"
 
         let glassEffect = glassEffectClass.init()
@@ -24,20 +25,20 @@ public class KeyboardExtenderContainerView: UIView {
         let wrapperView = UIView(frame: frame)
         wrapperView.backgroundColor = .clear
 
-        let innerWidth = frame.width - padding * 2
+        let innerWidth = frame.width - paddingHorizontal * 2
         let innerHeight = frame.height
 
         let visualEffectView = UIVisualEffectView(effect: glassEffect)
         visualEffectView.overrideUserInterfaceStyle = isDark ? .dark : .light
 
         visualEffectView.frame = CGRect(
-          x: padding,
-          y: -padding,
+          x: paddingHorizontal,
+          y: -paddingBottom,
           width: innerWidth,
           height: innerHeight
         )
         contentView.frame = CGRect(
-          x: -padding,
+          x: -paddingHorizontal,
           y: 0,
           width: innerWidth,
           height: innerHeight

--- a/ios/views/KeyboardExtenderContainerView.swift
+++ b/ios/views/KeyboardExtenderContainerView.swift
@@ -10,29 +10,30 @@ import UIKit
 @objc
 public class KeyboardExtenderContainerView: UIView {
   private var visualEffectView: UIVisualEffectView?
-  
+
   @objc public static func create(frame: CGRect, contentView: UIView) -> UIView {
-    if #available(iOS 26.0, *) {
-      let padding = 20.0
-      let visualEffectView = UIVisualEffectView()
-      let glassEffect = UIGlassEffect()
-      glassEffect.tintColor = UIColor.black.withAlphaComponent(0.3)
-      glassEffect.isInteractive = true
-      visualEffectView.effect = glassEffect
-      visualEffectView.bounds = CGRect(x: 0, y: padding, width: frame.width - (2 * padding), height: frame.height)
-      
-      // visualEffectView.bounds = CGRect(x: padding, y: padding, width: frame.width - 2 * padding, height: frame.height)
-      visualEffectView.overrideUserInterfaceStyle = FocusedInputHolder.shared.get()?.keyboardAppearanceValue == "dark" ? .dark : .light
-      
-      visualEffectView.contentView.addSubview(contentView)
-      // contentView.bounds = visualEffectView.contentView.bounds
-      
-      return visualEffectView
-    } else {
-      let inputView = UIInputView(frame: frame, inputViewStyle: .keyboard)
-      inputView.addSubview(contentView)
-      
-      return inputView
-    }
+    #if compiler(>=6.0)
+      if #available(iOS 26.0, *) {
+        let padding = 20.0
+        let visualEffectView = UIVisualEffectView()
+        let glassEffect = UIGlassEffect()
+        glassEffect.tintColor = UIColor.black.withAlphaComponent(0.3)
+        glassEffect.isInteractive = true
+        visualEffectView.effect = glassEffect
+        visualEffectView.bounds = CGRect(x: 0, y: padding, width: frame.width - (2 * padding), height: frame.height)
+
+        // visualEffectView.bounds = CGRect(x: padding, y: padding, width: frame.width - 2 * padding, height: frame.height)
+        visualEffectView.overrideUserInterfaceStyle = FocusedInputHolder.shared.get()?.keyboardAppearanceValue == "dark" ? .dark : .light
+
+        visualEffectView.contentView.addSubview(contentView)
+        // contentView.bounds = visualEffectView.contentView.bounds
+
+        return visualEffectView
+      }
+    #endif
+    let inputView = UIInputView(frame: frame, inputViewStyle: .keyboard)
+    inputView.addSubview(contentView)
+
+    return inputView
   }
 }

--- a/ios/views/KeyboardExtenderContainerView.swift
+++ b/ios/views/KeyboardExtenderContainerView.swift
@@ -9,8 +9,6 @@ import UIKit
 
 @objc
 public class KeyboardExtenderContainerView: UIView {
-  private var visualEffectView: UIVisualEffectView?
-
   @objc public static func create(frame: CGRect, contentView: UIView) -> UIView {
     #if compiler(>=6.0)
       if #available(iOS 26.0, *) {

--- a/ios/views/KeyboardExtenderContainerView.swift
+++ b/ios/views/KeyboardExtenderContainerView.swift
@@ -1,0 +1,38 @@
+//
+//  KeyboardExtenderContainerView.swift
+//  Pods
+//
+//  Created by Kiryl Ziusko on 11/07/2025.
+//
+
+import UIKit
+
+@objc
+public class KeyboardExtenderContainerView: UIView {
+  private var visualEffectView: UIVisualEffectView?
+  
+  @objc public static func create(frame: CGRect, contentView: UIView) -> UIView {
+    if #available(iOS 26.0, *) {
+      let padding = 20.0
+      let visualEffectView = UIVisualEffectView()
+      let glassEffect = UIGlassEffect()
+      glassEffect.tintColor = UIColor.black.withAlphaComponent(0.3)
+      glassEffect.isInteractive = true
+      visualEffectView.effect = glassEffect
+      visualEffectView.bounds = CGRect(x: 0, y: padding, width: frame.width - (2 * padding), height: frame.height)
+      
+      // visualEffectView.bounds = CGRect(x: padding, y: padding, width: frame.width - 2 * padding, height: frame.height)
+      visualEffectView.overrideUserInterfaceStyle = FocusedInputHolder.shared.get()?.keyboardAppearanceValue == "dark" ? .dark : .light
+      
+      visualEffectView.contentView.addSubview(contentView)
+      // contentView.bounds = visualEffectView.contentView.bounds
+      
+      return visualEffectView
+    } else {
+      let inputView = UIInputView(frame: frame, inputViewStyle: .keyboard)
+      inputView.addSubview(contentView)
+      
+      return inputView
+    }
+  }
+}

--- a/ios/views/KeyboardExtenderContainerView.swift
+++ b/ios/views/KeyboardExtenderContainerView.swift
@@ -10,25 +10,32 @@ import UIKit
 @objc
 public class KeyboardExtenderContainerView: UIView {
   @objc public static func create(frame: CGRect, contentView: UIView) -> UIView {
-    #if compiler(>=6.0)
-      if #available(iOS 26.0, *) {
+    if #available(iOS 26.0, *) {
+      // backward compatibility with old XCode versions
+      if let glassEffectClass = NSClassFromString("UIGlassEffect") as? UIVisualEffect.Type {
+        let glassEffect = glassEffectClass.init()
+        glassEffect.setValue(UIColor.black.withAlphaComponent(0.3), forKey: "tintColor")
+        glassEffect.setValue(true, forKey: "interactive")
+
         let padding = 20.0
         let visualEffectView = UIVisualEffectView()
-        let glassEffect = UIGlassEffect()
-        glassEffect.tintColor = UIColor.black.withAlphaComponent(0.3)
-        glassEffect.isInteractive = true
         visualEffectView.effect = glassEffect
-        visualEffectView.bounds = CGRect(x: 0, y: padding, width: frame.width - (2 * padding), height: frame.height)
+        visualEffectView.bounds = CGRect(
+          x: 0,
+          y: padding,
+          width: frame.width - (2 * padding),
+          height: frame.height
+        )
 
-        // visualEffectView.bounds = CGRect(x: padding, y: padding, width: frame.width - 2 * padding, height: frame.height)
-        visualEffectView.overrideUserInterfaceStyle = FocusedInputHolder.shared.get()?.keyboardAppearanceValue == "dark" ? .dark : .light
+        visualEffectView.overrideUserInterfaceStyle =
+          FocusedInputHolder.shared.get()?.keyboardAppearanceValue == "dark" ? .dark : .light
 
         visualEffectView.contentView.addSubview(contentView)
-        // contentView.bounds = visualEffectView.contentView.bounds
 
         return visualEffectView
       }
-    #endif
+    }
+
     let inputView = UIInputView(frame: frame, inputViewStyle: .keyboard)
     inputView.addSubview(contentView)
 

--- a/ios/views/KeyboardExtenderContainerView.swift
+++ b/ios/views/KeyboardExtenderContainerView.swift
@@ -11,34 +11,48 @@ import UIKit
 public class KeyboardExtenderContainerView: UIView {
   @objc public static func create(frame: CGRect, contentView: UIView) -> UIView {
     if #available(iOS 26.0, *) {
-      // backward compatibility with old XCode versions
       if let glassEffectClass = NSClassFromString("UIGlassEffect") as? UIVisualEffect.Type {
+        let padding = 20.0
+        let isDark = FocusedInputHolder.shared.get()?.keyboardAppearanceValue == "dark"
+
         let glassEffect = glassEffectClass.init()
-        glassEffect.setValue(UIColor.black.withAlphaComponent(0.3), forKey: "tintColor")
+        let color = isDark ? UIColor.black.withAlphaComponent(0.3) : UIColor.gray.withAlphaComponent(0.3)
+        glassEffect.setValue(color, forKey: "tintColor")
         glassEffect.setValue(true, forKey: "interactive")
 
-        let padding = 20.0
-        let visualEffectView = UIVisualEffectView()
-        visualEffectView.effect = glassEffect
-        visualEffectView.bounds = CGRect(
-          x: 0,
-          y: padding,
-          width: frame.width - (2 * padding),
-          height: frame.height
+        // wrapper container will be full frame
+        let wrapperView = UIView(frame: frame)
+        wrapperView.backgroundColor = .clear
+
+        let innerWidth = frame.width - padding * 2
+        let innerHeight = frame.height
+
+        let visualEffectView = UIVisualEffectView(effect: glassEffect)
+        visualEffectView.overrideUserInterfaceStyle = isDark ? .dark : .light
+
+        visualEffectView.frame = CGRect(
+          x: padding,
+          y: -padding,
+          width: innerWidth,
+          height: innerHeight
+        )
+        contentView.frame = CGRect(
+          x: -padding,
+          y: 0,
+          width: innerWidth,
+          height: innerHeight
         )
 
-        visualEffectView.overrideUserInterfaceStyle =
-          FocusedInputHolder.shared.get()?.keyboardAppearanceValue == "dark" ? .dark : .light
-
         visualEffectView.contentView.addSubview(contentView)
+        wrapperView.addSubview(visualEffectView)
 
-        return visualEffectView
+        return wrapperView
       }
     }
 
     let inputView = UIInputView(frame: frame, inputViewStyle: .keyboard)
+    contentView.frame = inputView.bounds
     inputView.addSubview(contentView)
-
     return inputView
   }
 }

--- a/ios/views/KeyboardExtenderManager.mm
+++ b/ios/views/KeyboardExtenderManager.mm
@@ -61,7 +61,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
 @implementation KeyboardExtender {
   UIView *_contentView;
-  UIInputView *_sharedInputAccessoryView;
+  UIView *_sharedInputAccessoryView;
 #ifdef RCT_NEW_ARCH_ENABLED
   RCTSurfaceTouchHandler *_touchHandler;
 #else
@@ -144,17 +144,14 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 - (void)createSharedInputAccessoryView
 {
   CGRect internalFrame = _contentView.subviews[0].frame;
-  _sharedInputAccessoryView = [[UIInputView alloc]
-       initWithFrame:CGRectMake(
-                         0, 0, UIScreen.mainScreen.bounds.size.width, internalFrame.size.height)
-      inputViewStyle:UIInputViewStyleKeyboard];
+  _sharedInputAccessoryView = [KeyboardExtenderContainerView createWithFrame:CGRectMake(
+                                                                                        0, 0, UIScreen.mainScreen.bounds.size.width, internalFrame.size.height) contentView: _contentView];
   _sharedInputAccessoryView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 
   // Attach the contentView to the shared input accessory view
-  _contentView.frame = _sharedInputAccessoryView.bounds;
-  _contentView.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  [_sharedInputAccessoryView addSubview:_contentView];
+  // _contentView.frame = _sharedInputAccessoryView.bounds;
+  // _contentView.autoresizingMask =
+  //    UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 }
 
 - (void)attachInputAccessoryViewTo:(UIView<UITextInput> *)input

--- a/ios/views/KeyboardExtenderManager.mm
+++ b/ios/views/KeyboardExtenderManager.mm
@@ -144,14 +144,10 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 - (void)createSharedInputAccessoryView
 {
   CGRect internalFrame = _contentView.subviews[0].frame;
-  _sharedInputAccessoryView = [KeyboardExtenderContainerView createWithFrame:CGRectMake(
-                                                                                        0, 0, UIScreen.mainScreen.bounds.size.width, internalFrame.size.height) contentView: _contentView];
-  _sharedInputAccessoryView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-
-  // Attach the contentView to the shared input accessory view
-  // _contentView.frame = _sharedInputAccessoryView.bounds;
-  // _contentView.autoresizingMask =
-  //    UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _sharedInputAccessoryView = [KeyboardExtenderContainerView
+      createWithFrame:CGRectMake(
+                          0, 0, UIScreen.mainScreen.bounds.size.width, internalFrame.size.height)
+          contentView:_contentView];
 }
 
 - (void)attachInputAccessoryViewTo:(UIView<UITextInput> *)input


### PR DESCRIPTION
## 📜 Description

Fix UI for `KeyboardExtender` on iOS 26.

## 💡 Motivation and Context

I've created a bug ticket `FB17922439`, but looking how liquid glass gets adopted at whole OS level for me it seems like Apple is not going to go back to old design guidelines and this rounded keyboard with divider above and inability to embed views into it is a new reality. At the moment `KeyboardExtender` looks very bad, so to make sure iOS 26 adaptation gets better on the launch I decided to match style of Settings/Safari and other apps 🤷‍♂️ 

To do that I created `KeyboardExtenderContainerView` that uses liquid glass concept on iOS 26+ and fallbacks to `UIInputView` + `.keyboard` style on earlier versions.

The `UIGlassEffect` is not available on old XCode versions, so I used `NSClassFromString` with runtime checks - this is not perfect solution but the only one I can think of, because all other that I tried didn't make compilation successful using old XCode.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- create `KeyboardExtenderContainerView`;
- use `UIView` instead of `UIInoutView` in `KeyboardExtender`;
- remove f\flexible width and other calculations;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 16 Pro (iOS 26, beat 3, simulator/real device).

## 📸 Screenshots (if appropriate):

|Before|After|Reference 1|Reference 2|
|-------|-----|-----------|------------|
|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/a0b300cf-0899-4939-adbe-deb651718f25" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/105dc864-96d1-4d2e-8ccd-e8d4723f5813" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/3f8b0e12-78c5-43ab-98e8-02a11785db1a" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/92e26fcd-ba5e-4d62-8f20-a2971841644a" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
