### PR TITLE
feat: preload

### DIFF
--- a/FabricExample/src/App.tsx
+++ b/FabricExample/src/App.tsx
@@ -4,7 +4,10 @@ import { NavigationContainer } from "@react-navigation/native";
 import * as React from "react";
 import { ActivityIndicator, StatusBar, StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { KeyboardProvider } from "react-native-keyboard-controller";
+import {
+  KeyboardController,
+  KeyboardProvider,
+} from "react-native-keyboard-controller";
 import {
   SafeAreaProvider,
   initialWindowMetrics,
@@ -35,6 +38,8 @@ const linking = {
   },
 };
 const spinner = <ActivityIndicator color="blue" size="large" />;
+
+KeyboardController.preload();
 
 export default function App() {
   return (

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A universal keyboard handling solution for React Native — lightweight, fully c
 
 - 🧬 Map keyboard movement to animated values
 - 🧪 `keyboardWillShow` / `keyboardWillHide` events now available on Android
-- ⚡ Change soft input mode on Android
+- 🔮 Change soft input mode on Android
+- ⚡ Preload keyboard to avoid first-time focus lag
 - 🚀 Reanimated support
 - 📱 Interactive keyboard dismissing 👆📱
 - 📚 Prebuilt components (`KeyboardStickyView`, `KeyboardAwareScrollView`, reworked `KeyboardAvoidingView`)

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerModule.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/KeyboardControllerModule.kt
@@ -18,6 +18,10 @@ class KeyboardControllerModule(
     module.setDefaultMode()
   }
 
+  override fun preload() {
+    module.preload()
+  }
+
   override fun dismiss(keepFocus: Boolean) {
     module.dismiss(keepFocus)
   }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
@@ -22,6 +22,10 @@ class KeyboardControllerModuleImpl(
     setSoftInputMode(mDefaultMode)
   }
 
+  fun preload() {
+    // no-op on Android
+  }
+
   fun dismiss(keepFocus: Boolean) {
     val activity = mReactContext.currentActivity
     val view: View? = FocusedInputHolder.get()

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerModule.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/KeyboardControllerModule.kt
@@ -23,6 +23,11 @@ class KeyboardControllerModule(
   }
 
   @ReactMethod
+  fun preload() {
+    module.preload()
+  }
+
+  @ReactMethod
   fun dismiss(keepFocus: Boolean) {
     module.dismiss(keepFocus)
   }

--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -52,6 +52,18 @@ This method is used to restore the default `windowSoftInputMode` (`softwareKeybo
 KeyboardController.setDefaultMode();
 ```
 
+### `preload` <div className="label ios"></div>
+
+```ts
+static preload(): void;
+```
+
+This method is used to preload the keyboard, so that users will not see a significant delay when they focus a first input since app has been opened.
+
+```ts
+KeyboardController.preload();
+```
+
 ### `dismiss`
 
 ```ts

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,7 +4,10 @@ import { NavigationContainer } from "@react-navigation/native";
 import * as React from "react";
 import { ActivityIndicator, StatusBar, StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { KeyboardProvider } from "react-native-keyboard-controller";
+import {
+  KeyboardController,
+  KeyboardProvider,
+} from "react-native-keyboard-controller";
 import {
   SafeAreaProvider,
   initialWindowMetrics,
@@ -35,6 +38,8 @@ const linking = {
   },
 };
 const spinner = <ActivityIndicator color="blue" size="large" />;
+
+KeyboardController.preload();
 
 export default function App() {
   return (

--- a/ios/KeyboardControllerModule.mm
+++ b/ios/KeyboardControllerModule.mm
@@ -68,6 +68,15 @@ RCT_EXPORT_METHOD(setInputMode : (nonnull NSNumber *)mode)
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
+- (void)preload
+#else
+RCT_EXPORT_METHOD(preload)
+#endif
+{
+  [UIResponder preloadKeyboardIfNeeded];
+}
+
+#ifdef RCT_NEW_ARCH_ENABLED
 - (void)dismiss:(BOOL)keepFocus
 #else
 RCT_EXPORT_METHOD(dismiss : (BOOL)keepFocus)

--- a/ios/extensions/UIResponder.swift
+++ b/ios/extensions/UIResponder.swift
@@ -67,14 +67,17 @@ public extension Optional where Wrapped: UIResponder {
 @objc
 public extension UIResponder {
   private static var hasPreloadedKeyboard = false
+  static var isKeyboardPreloading = false
 
   /// Preloads the keyboard UI to reduce first-time lag when showing a keyboard.
   /// https://stackoverflow.com/questions/9357026/super-slow-lag-delay-on-initial-keyboard-animation-of-uitextfield/20436797#20436797
   static func preloadKeyboardIfNeeded() {
     guard !hasPreloadedKeyboard else { return }
     hasPreloadedKeyboard = true
+    isKeyboardPreloading = true
 
     DispatchQueue.main.async {
+      defer { isKeyboardPreloading = false }
       guard let window = UIApplication.shared.activeWindow else { return }
 
       let lagFreeField = UITextField(frame: .zero)

--- a/ios/extensions/UIResponder.swift
+++ b/ios/extensions/UIResponder.swift
@@ -75,15 +75,7 @@ public extension UIResponder {
     hasPreloadedKeyboard = true
 
     DispatchQueue.main.async {
-      guard
-        let window = UIApplication.shared
-        .connectedScenes
-        .compactMap({ $0 as? UIWindowScene })
-        .flatMap(\.windows)
-        .first(where: { $0.isKeyWindow })
-      else {
-        return
-      }
+      guard let window = UIApplication.shared.activeWindow else { return }
 
       let lagFreeField = UITextField(frame: .zero)
       lagFreeField.isHidden = true

--- a/ios/extensions/UIResponder.swift
+++ b/ios/extensions/UIResponder.swift
@@ -77,10 +77,10 @@ public extension UIResponder {
     DispatchQueue.main.async {
       guard
         let window = UIApplication.shared
-          .connectedScenes
-          .compactMap({ $0 as? UIWindowScene })
-          .flatMap({ $0.windows })
-          .first(where: { $0.isKeyWindow })
+        .connectedScenes
+        .compactMap({ $0 as? UIWindowScene })
+        .flatMap(\.windows)
+        .first(where: { $0.isKeyWindow })
       else {
         return
       }

--- a/ios/extensions/UIResponder.swift
+++ b/ios/extensions/UIResponder.swift
@@ -63,3 +63,35 @@ public extension Optional where Wrapped: UIResponder {
     return -1
   }
 }
+
+@objc
+public extension UIResponder {
+  private static var hasPreloadedKeyboard = false
+
+  /// Preloads the keyboard UI to reduce first-time lag when showing a keyboard.
+  /// https://stackoverflow.com/questions/9357026/super-slow-lag-delay-on-initial-keyboard-animation-of-uitextfield/20436797#20436797
+  static func preloadKeyboardIfNeeded() {
+    guard !hasPreloadedKeyboard else { return }
+    hasPreloadedKeyboard = true
+
+    DispatchQueue.main.async {
+      guard
+        let window = UIApplication.shared
+          .connectedScenes
+          .compactMap({ $0 as? UIWindowScene })
+          .flatMap({ $0.windows })
+          .first(where: { $0.isKeyWindow })
+      else {
+        return
+      }
+
+      let lagFreeField = UITextField(frame: .zero)
+      lagFreeField.isHidden = true
+      window.addSubview(lagFreeField)
+
+      lagFreeField.becomeFirstResponder()
+      lagFreeField.resignFirstResponder()
+      lagFreeField.removeFromSuperview()
+    }
+  }
+}

--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -120,7 +120,7 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   private func keyboardDidMoveInteractively(changeValue: CGPoint) {
-    if (UIResponder.isKeyboardPreloading) {
+    if UIResponder.isKeyboardPreloading {
       return
     }
     // if we are currently animating keyboard -> we need to ignore values from KVO

--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -120,6 +120,9 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   private func keyboardDidMoveInteractively(changeValue: CGPoint) {
+    if (UIResponder.isKeyboardPreloading) {
+      return
+    }
     // if we are currently animating keyboard -> we need to ignore values from KVO
     if !displayLink.isPaused {
       return
@@ -165,7 +168,7 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   @objc func keyboardWillAppear(_ notification: Notification) {
-    guard !KeyboardEventsIgnorer.shared.shouldIgnore else { return }
+    guard !KeyboardEventsIgnorer.shared.shouldIgnore, !UIResponder.isKeyboardPreloading else { return }
 
     let (duration, frame) = notification.keyboardMetaData()
     if let keyboardFrame = frame {
@@ -185,6 +188,7 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   @objc func keyboardWillDisappear(_ notification: Notification) {
+    guard !UIResponder.isKeyboardPreloading else { return }
     let (duration, _) = notification.keyboardMetaData()
     tag = UIResponder.current.reactViewTag
     self.duration = duration
@@ -199,6 +203,7 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   @objc func keyboardDidAppear(_ notification: Notification) {
+    guard !UIResponder.isKeyboardPreloading else { return }
     let timestamp = Date.currentTimeStamp
     let (duration, frame) = notification.keyboardMetaData()
     if let keyboardFrame = frame {
@@ -229,6 +234,7 @@ public class KeyboardMovementObserver: NSObject {
   }
 
   @objc func keyboardDidDisappear(_ notification: Notification) {
+    guard !UIResponder.isKeyboardPreloading else { return }
     let (duration, _) = notification.keyboardMetaData()
     tag = UIResponder.current.reactViewTag
 

--- a/jest/index.js
+++ b/jest/index.js
@@ -67,6 +67,7 @@ const mock = {
   KeyboardController: {
     setInputMode: jest.fn(),
     setDefaultMode: jest.fn(),
+    preload: jest.fn(),
     dismiss: jest.fn().mockReturnValue(Promise.resolve()),
     setFocusTo: jest.fn(),
     isVisible: jest.fn().mockReturnValue(false),

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -18,6 +18,7 @@ const NOOP = () => {};
 export const KeyboardControllerNative: KeyboardControllerNativeModule = {
   setDefaultMode: NOOP,
   setInputMode: NOOP,
+  preload: NOOP,
   dismiss: NOOP,
   setFocusTo: NOOP,
   addListener: NOOP,

--- a/src/module.ts
+++ b/src/module.ts
@@ -54,6 +54,7 @@ export const KeyboardController: KeyboardControllerModule = {
   setDefaultMode: KeyboardControllerNative.setDefaultMode,
   setInputMode: KeyboardControllerNative.setInputMode,
   setFocusTo: KeyboardControllerNative.setFocusTo,
+  preload: KeyboardControllerNative.preload,
   dismiss,
   isVisible,
   state,

--- a/src/specs/NativeKeyboardController.ts
+++ b/src/specs/NativeKeyboardController.ts
@@ -8,6 +8,7 @@ export interface Spec extends TurboModule {
   // methods
   setInputMode(mode: number): void;
   setDefaultMode(): void;
+  preload(): void;
   dismiss(keepFocus: boolean): void;
   setFocusTo(direction: string): void;
 

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -59,13 +59,25 @@ export type KeyboardControllerModule = {
   /**
    * Sets default `windowSoftInputMode` (the one that declared in `AndroidManifest.xml`).
    *
+   * @platform android
    * @see {@link https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/keyboard-controller#setdefaultmode-|docs} page for more details.
    */
   setDefaultMode: () => void;
   /**
-   * Changes `windowSoftInputMode` on Android. @see AndroidSoftInputModes for all possible values and {@link https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/keyboard-controller#setinputmode-|docs} page for more details.
+   * Changes `windowSoftInputMode` on Android.
+   *
+   * @platform android
+   * @see AndroidSoftInputModes for all possible values and {@link https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/keyboard-controller#setinputmode-|docs} page for more details.
    */
   setInputMode: (mode: number) => void;
+  // ios only
+  /**
+   * A method that preloads the keyboard. It's useful when you want to avoid a delay when the user focuses the first input.
+   *
+   * @platform ios
+   * @see {@link https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/keyboard-controller#preload-|docs} page for more details.
+   */
+  preload: () => void;
   // all platforms
   /**
    * Dismisses the active keyboard. Removes a focus by default, but allows to pass `{keepFocus: true}` to keep focus.
@@ -96,6 +108,8 @@ export type KeyboardControllerNativeModule = {
   // android only
   setDefaultMode: () => void;
   setInputMode: (mode: number) => void;
+  // ios only
+  preload: () => void;
   // all platforms
   dismiss: (keepFocus: boolean) => void;
   setFocusTo: (direction: Direction) => void;


### PR DESCRIPTION
## 📜 Description

Added new `KeyboardController.preload()` method.

## 💡 Motivation and Context

Originally discovered in [this tweet](https://x.com/_jsmth/status/1943659768956023172) and later discovered in [StackOverflow](https://stackoverflow.com/questions/9108245/ios-how-can-i-preload-the-keyboard) and [GitHub lib](https://github.com/mbrandonw/UIResponder-KeyboardCache) it seems like this problem is actually present for long time in iOS ecosystem. To be honest I also noticed time-to-time that in some cases the TTI can be very big if you set focus for the first time since you opened a keyboard. I thought it could be a problem of `react-native` framework itself, but turns out it's the problem of iOS (not a particular framework).

So in this PR I decided to bring this native fix to `react-native-keyboard-controller` codebase and introduce new `KeyboardController.preload()` method which aims to eliminate that first lag.

I've been thinking whether to add a similar fix to Android, but I think on Android everything is trickier:

> On Android the system keyboard (the “IME”) lives outside your app process and is managed by the system’s input‐method service, so you don’t really get the same “first‐show UI initialisation” penalty that you see on iOS (where the entire keyboard UI is bundled into your app).

We could use something like that on Android:

```kt
fun preloadKeyboard(context: Context) {
    val dummy = EditText(context).apply {
        visibility = View.GONE
        isFocusable = true
        isFocusableInTouchMode = true
    }

    val decorView = (context as? Activity)?.window?.decorView as? ViewGroup ?: return
    decorView.addView(dummy)

    dummy.requestFocus()
    val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
    imm.showSoftInput(dummy, InputMethodManager.SHOW_IMPLICIT)

    // Immediately hide and remove
    Handler(Looper.getMainLooper()).postDelayed({
        imm.hideSoftInputFromWindow(dummy.windowToken, 0)
        decorView.removeView(dummy)
    }, 100)
}
```

But from my research it seems like:
- such technique is not used commonly on Android;
- such code may lead to situations when keyboard will be shown even though the field has been completely removed 🤯 

So I decided to keep this method no-op on Android (at least for now).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- add documentation for `KeyboardController.preload`;

### JS

- added `preload` method to `KeyboardController`;
- added mock for `KeyboardController.preload`;
- specify `platform` in jsdoc for `KeyboardController` methods;

### iOS

- added `preloadKeyboardIfNeeded` method for `UIResponder`;
- ignore events if `isKeyboardPreloading == true`;

## 🤔 How Has This Been Tested?

Tested manually on:
- iPhone 16 Pro (iOS 26, real device)
- iPhone 15 Pro (iOS 17.5, simulator)
- iPhone 6s (iOS 15.8, real device)

Always tested release app.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/a27ec1a1-8545-4605-b207-30dd8cf2c6c1">|<video src="https://github.com/user-attachments/assets/118afb12-8838-4f49-b6ea-600b9b392bde">|

> Tested on iPhone 6s (iOS 15, low end device), after device re-boot and app cold start to see freeze clearer. Release app.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
