### PR TITLE
fix: double synchronization

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/events/KeyboardTransitionEvent.kt
@@ -16,8 +16,7 @@ class KeyboardTransitionEvent(
 ) : Event<KeyboardTransitionEvent>(surfaceId, viewId) {
   override fun getEventName() = event.value
 
-  // All events for a given view can be coalesced?
-  override fun getCoalescingKey(): Short = 0
+  override fun canCoalesce() = false
 
   override fun getEventData(): WritableMap? =
     Arguments.createMap().apply {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -51,6 +51,7 @@ class KeyboardAnimationCallback(
   val view: View,
   val context: ThemedReactContext?,
   private val config: KeyboardAnimationCallbackConfig,
+  private val source: KeyboardAnimationCallback? = null,
 ) : WindowInsetsAnimationCompat.Callback(config.dispatchMode),
   OnApplyWindowInsetsListener,
   Suspendable {
@@ -67,6 +68,13 @@ class KeyboardAnimationCallback(
   private val isKeyboardInteractive: Boolean
     get() = duration == -1
   override var isSuspended: Boolean = false
+
+  init {
+    if (source != null) {
+      this.persistentKeyboardHeight = source.persistentKeyboardHeight
+      this.prevKeyboardHeight = source.prevKeyboardHeight
+    }
+  }
 
   // listeners
   private val focusListener =
@@ -166,13 +174,13 @@ class KeyboardAnimationCallback(
       return insets
     }
 
-    // always verify insets, because sometimes default lifecycles may not be invoked
-    // (when we press "Share" on Android 16, for example)
+    // always verify insets, because sometimes default lifecycle methods may not be invoked
+    // (when we press "Share" on Android 16, when Modal closes keyboard, etc.)
     val newHeight = getCurrentKeyboardHeight(insets)
-    if (prevKeyboardHeight != newHeight && !isTransitioning) {
+    if (prevKeyboardHeight != newHeight && !isMoving && !isSuspended) {
       Logger.w(
         TAG,
-        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight"
+        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight. Modal ${this.source}",
       )
       this.syncKeyboardPosition(newHeight, newHeight > 0)
     }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -51,7 +51,6 @@ class KeyboardAnimationCallback(
   val view: View,
   val context: ThemedReactContext?,
   private val config: KeyboardAnimationCallbackConfig,
-  private val source: KeyboardAnimationCallback? = null,
 ) : WindowInsetsAnimationCompat.Callback(config.dispatchMode),
   OnApplyWindowInsetsListener,
   Suspendable {
@@ -173,7 +172,7 @@ class KeyboardAnimationCallback(
     if (prevKeyboardHeight != newHeight && !isMoving && !isSuspended) {
       Logger.w(
         TAG,
-        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight. Attached: ${view.isAttachedToWindow} EVA: ${this.eventPropagationView.isAttachedToWindow} Modal ${this.source}",
+        "detected desynchronized state - force updating it.",
       )
       this.syncKeyboardPosition(newHeight, newHeight > 0)
     }
@@ -183,8 +182,6 @@ class KeyboardAnimationCallback(
 
   override fun onPrepare(animation: WindowInsetsAnimationCompat) {
     super.onPrepare(animation)
-
-    println("desynchronized - onPrepare")
 
     if (!animation.isKeyboardAnimation || isSuspended) {
       return

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -162,9 +162,32 @@ class KeyboardAnimationCallback(
       Logger.i(TAG, "onApplyWindowInsets: ${this.persistentKeyboardHeight} -> $keyboardHeight")
       layoutObserver?.syncUpLayout()
       this.onKeyboardResized(keyboardHeight)
+
+      return insets
+    }
+
+    // always verify insets, because sometimes default lifecycles may not be invoked
+    // (when we press "Share" on Android 16, for example)
+    val newHeight = getCurrentKeyboardHeight(insets)
+    if (prevKeyboardHeight != newHeight && !isTransitioning) {
+      Logger.w(
+        TAG,
+        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight"
+      )
+      this.syncKeyboardPosition(newHeight, newHeight > 0)
     }
 
     return insets
+  }
+
+  override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+    super.onPrepare(animation)
+
+    if (!animation.isKeyboardAnimation || isSuspended) {
+      return
+    }
+
+    isTransitioning = true
   }
 
   @Suppress("detekt:ReturnCount")
@@ -176,7 +199,6 @@ class KeyboardAnimationCallback(
       return bounds
     }
 
-    isTransitioning = true
     isKeyboardVisible = isKeyboardVisible()
     duration = animation.durationMillis.toInt()
     val keyboardHeight = getCurrentKeyboardHeight()
@@ -416,14 +438,15 @@ class KeyboardAnimationCallback(
     return insets?.isVisible(WindowInsetsCompat.Type.ime()) ?: false
   }
 
-  private fun getCurrentKeyboardHeight(): Double {
-    val insets = ViewCompat.getRootWindowInsets(view)
-    val keyboardHeight = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
+  private fun getCurrentKeyboardHeight(insets: WindowInsetsCompat? = null): Double {
+    val root = ViewCompat.getRootWindowInsets(view)
+    val final = insets ?: root
+    val keyboardHeight = final?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
     val navigationBar =
       if (config.hasTranslucentNavigationBar) {
         0
       } else {
-        insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
+        root?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
       }
 
     // on hide it will be negative value, so we are using max function

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -58,8 +58,8 @@ class KeyboardAnimationCallback(
   private val surfaceId = UIManagerHelper.getSurfaceId(eventPropagationView)
 
   // state variables
-  private var persistentKeyboardHeight = 0.0
-  private var prevKeyboardHeight = 0.0
+  private var persistentKeyboardHeight = getCurrentKeyboardHeight()
+  private var prevKeyboardHeight = getCurrentKeyboardHeight()
   private var isKeyboardVisible = false
   private var isTransitioning = false
   private var duration = 0
@@ -68,13 +68,6 @@ class KeyboardAnimationCallback(
   private val isKeyboardInteractive: Boolean
     get() = duration == -1
   override var isSuspended: Boolean = false
-
-  init {
-    if (source != null) {
-      this.persistentKeyboardHeight = source.persistentKeyboardHeight
-      this.prevKeyboardHeight = source.prevKeyboardHeight
-    }
-  }
 
   // listeners
   private val focusListener =
@@ -180,7 +173,7 @@ class KeyboardAnimationCallback(
     if (prevKeyboardHeight != newHeight && !isMoving && !isSuspended) {
       Logger.w(
         TAG,
-        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight. Modal ${this.source}",
+        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight. Attached: ${view.isAttachedToWindow} EVA: ${this.eventPropagationView.isAttachedToWindow} Modal ${this.source}",
       )
       this.syncKeyboardPosition(newHeight, newHeight > 0)
     }
@@ -190,6 +183,8 @@ class KeyboardAnimationCallback(
 
   override fun onPrepare(animation: WindowInsetsAnimationCompat) {
     super.onPrepare(animation)
+
+    println("desynchronized - onPrepare")
 
     if (!animation.isKeyboardAnimation || isSuspended) {
       return

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -175,7 +175,7 @@ class KeyboardAnimationCallback(
     }
 
     // always verify insets, because sometimes default lifecycle methods may not be invoked
-    // (when we press "Share" on Android 16, when Modal closes keyboard, etc.)
+    // (when we press "Share" on Android 16, when Modal closes keyboard, when permission Alert presented etc.)
     val newHeight = getCurrentKeyboardHeight(insets)
     if (prevKeyboardHeight != newHeight && !isMoving && !isSuspended) {
       Logger.w(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -65,8 +65,8 @@ class KeyboardAnimationCallback(
   private val surfaceId = UIManagerHelper.getSurfaceId(eventPropagationView)
 
   // state variables
-  private var persistentKeyboardHeight = 0.0
-  private var prevKeyboardHeight = 0.0
+  private var persistentKeyboardHeight = getCurrentKeyboardHeight()
+  private var prevKeyboardHeight = getCurrentKeyboardHeight()
   private var isKeyboardVisible = false
   private var isTransitioning = false
   private var duration = 0
@@ -76,13 +76,6 @@ class KeyboardAnimationCallback(
   private val isKeyboardInteractive: Boolean
     get() = duration == -1
   override var isSuspended: Boolean = false
-
-  init {
-    if (source != null) {
-      this.persistentKeyboardHeight = source.persistentKeyboardHeight
-      this.prevKeyboardHeight = source.prevKeyboardHeight
-    }
-  }
 
   // listeners
   private val focusListener =
@@ -188,7 +181,7 @@ class KeyboardAnimationCallback(
     if (prevKeyboardHeight != newHeight && !isMoving && !isSuspended) {
       Logger.w(
         TAG,
-        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight. Modal ${this.source}",
+        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight. Attached: ${view.isAttachedToWindow} EVA: ${this.eventPropagationView.isAttachedToWindow} Modal ${this.source}",
       )
       this.syncKeyboardPosition(newHeight, newHeight > 0)
     }
@@ -198,6 +191,8 @@ class KeyboardAnimationCallback(
 
   override fun onPrepare(animation: WindowInsetsAnimationCompat) {
     super.onPrepare(animation)
+
+    println("desynchronized - onPrepare")
 
     if (!animation.isKeyboardAnimation || isSuspended) {
       return

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -180,7 +180,7 @@ class KeyboardAnimationCallback(
     if (prevKeyboardHeight != newHeight && !isMoving && !isSuspended) {
       Logger.w(
         TAG,
-        "detected desynchronized state - force updating it.",
+        "detected desynchronized state - force updating it: $newHeight",
       )
       this.syncKeyboardPosition(newHeight, newHeight > 0)
     }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -170,9 +170,32 @@ class KeyboardAnimationCallback(
       Logger.i(TAG, "onApplyWindowInsets: ${this.persistentKeyboardHeight} -> $keyboardHeight")
       layoutObserver?.syncUpLayout()
       this.onKeyboardResized(keyboardHeight)
+
+      return insets
+    }
+
+    // always verify insets, because sometimes default lifecycles may not be invoked
+    // (when we press "Share" on Android 16, for example)
+    val newHeight = getCurrentKeyboardHeight(insets)
+    if (prevKeyboardHeight != newHeight && !isTransitioning) {
+      Logger.w(
+        TAG,
+        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight"
+      )
+      this.syncKeyboardPosition(newHeight, newHeight > 0)
     }
 
     return insets
+  }
+
+  override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+    super.onPrepare(animation)
+
+    if (!animation.isKeyboardAnimation || isSuspended) {
+      return
+    }
+
+    isTransitioning = true
   }
 
   @Suppress("detekt:ReturnCount")
@@ -184,7 +207,6 @@ class KeyboardAnimationCallback(
       return bounds
     }
 
-    isTransitioning = true
     pendingStartEvent = null
     isKeyboardVisible = isKeyboardVisible()
     duration = animation.durationMillis.toInt()
@@ -431,14 +453,15 @@ class KeyboardAnimationCallback(
     return insets?.isVisible(WindowInsetsCompat.Type.ime()) ?: false
   }
 
-  private fun getCurrentKeyboardHeight(): Double {
-    val insets = ViewCompat.getRootWindowInsets(view)
-    val keyboardHeight = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
+  private fun getCurrentKeyboardHeight(insets: WindowInsetsCompat? = null): Double {
+    val root = ViewCompat.getRootWindowInsets(view)
+    val final = insets ?: root
+    val keyboardHeight = final?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
     val navigationBar =
       if (config.hasTranslucentNavigationBar) {
         0
       } else {
-        insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
+        root?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
       }
 
     // on hide it will be negative value, so we are using max function

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -58,7 +58,6 @@ class KeyboardAnimationCallback(
   val view: View,
   val context: ThemedReactContext?,
   private val config: KeyboardAnimationCallbackConfig,
-  private val source: KeyboardAnimationCallback? = null,
 ) : WindowInsetsAnimationCompat.Callback(config.dispatchMode),
   OnApplyWindowInsetsListener,
   Suspendable {
@@ -181,7 +180,7 @@ class KeyboardAnimationCallback(
     if (prevKeyboardHeight != newHeight && !isMoving && !isSuspended) {
       Logger.w(
         TAG,
-        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight. Attached: ${view.isAttachedToWindow} EVA: ${this.eventPropagationView.isAttachedToWindow} Modal ${this.source}",
+        "detected desynchronized state - force updating it.",
       )
       this.syncKeyboardPosition(newHeight, newHeight > 0)
     }
@@ -191,8 +190,6 @@ class KeyboardAnimationCallback(
 
   override fun onPrepare(animation: WindowInsetsAnimationCompat) {
     super.onPrepare(animation)
-
-    println("desynchronized - onPrepare")
 
     if (!animation.isKeyboardAnimation || isSuspended) {
       return

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -58,6 +58,7 @@ class KeyboardAnimationCallback(
   val view: View,
   val context: ThemedReactContext?,
   private val config: KeyboardAnimationCallbackConfig,
+  private val source: KeyboardAnimationCallback? = null,
 ) : WindowInsetsAnimationCompat.Callback(config.dispatchMode),
   OnApplyWindowInsetsListener,
   Suspendable {
@@ -75,6 +76,13 @@ class KeyboardAnimationCallback(
   private val isKeyboardInteractive: Boolean
     get() = duration == -1
   override var isSuspended: Boolean = false
+
+  init {
+    if (source != null) {
+      this.persistentKeyboardHeight = source.persistentKeyboardHeight
+      this.prevKeyboardHeight = source.prevKeyboardHeight
+    }
+  }
 
   // listeners
   private val focusListener =
@@ -174,13 +182,13 @@ class KeyboardAnimationCallback(
       return insets
     }
 
-    // always verify insets, because sometimes default lifecycles may not be invoked
-    // (when we press "Share" on Android 16, for example)
+    // always verify insets, because sometimes default lifecycle methods may not be invoked
+    // (when we press "Share" on Android 16, when Modal closes keyboard, etc.)
     val newHeight = getCurrentKeyboardHeight(insets)
-    if (prevKeyboardHeight != newHeight && !isTransitioning) {
+    if (prevKeyboardHeight != newHeight && !isMoving && !isSuspended) {
       Logger.w(
         TAG,
-        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight"
+        "detected desynchronized state - force updating it. $prevKeyboardHeight -> $newHeight. Modal ${this.source}",
       )
       this.syncKeyboardPosition(newHeight, newHeight > 0)
     }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
@@ -33,7 +33,6 @@ class ModalAttachedWatcher(
       return
     }
 
-    val cb = this.callback()
     val modal =
       try {
         uiManager?.resolveView(event.viewTag) as? ReactModalHostView
@@ -43,9 +42,6 @@ class ModalAttachedWatcher(
       }
 
     if (modal == null) {
-      return
-    }
-    if (cb == null) {
       return
     }
 
@@ -64,7 +60,6 @@ class ModalAttachedWatcher(
           eventPropagationView = view,
           context = reactContext,
           config = config,
-          source = cb,
         )
 
       rootView.addView(eventView)
@@ -73,10 +68,9 @@ class ModalAttachedWatcher(
         // on Android < 12 all events for `WindowInsetsAnimationCallback`
         // go through main `rootView`, so we don't need to stop main
         // callback - otherwise keyboard transitions will not be animated
-        cb.suspend(true)
+        this.callback()?.suspend(true)
         // attaching callback to Modal on Android < 12 can cause ghost animations, see: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/718
-        // and overall attaching additional callbacks (if animation events go through the main window)
-        // is not necessary
+        // and overall attaching additional callbacks (if animation events go through the main window) is not necessary
         ViewCompat.setWindowInsetsAnimationCallback(rootView, callback)
         ViewCompat.setOnApplyWindowInsetsListener(eventView, callback)
       }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
@@ -33,6 +33,7 @@ class ModalAttachedWatcher(
       return
     }
 
+    val cb = this.callback()
     val modal =
       try {
         uiManager?.resolveView(event.viewTag) as? ReactModalHostView
@@ -42,6 +43,9 @@ class ModalAttachedWatcher(
       }
 
     if (modal == null) {
+      return
+    }
+    if (cb == null) {
       return
     }
 
@@ -60,6 +64,7 @@ class ModalAttachedWatcher(
           eventPropagationView = view,
           context = reactContext,
           config = config,
+          source = cb,
         )
 
       rootView.addView(eventView)
@@ -68,28 +73,21 @@ class ModalAttachedWatcher(
         // on Android < 12 all events for `WindowInsetsAnimationCallback`
         // go through main `rootView`, so we don't need to stop main
         // callback - otherwise keyboard transitions will not be animated
-        this.callback()?.suspend(true)
+        cb.suspend(true)
         // attaching callback to Modal on Android < 12 can cause ghost animations, see: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/718
         // and overall attaching additional callbacks (if animation events go through the main window) is not necessary
         ViewCompat.setWindowInsetsAnimationCallback(rootView, callback)
         ViewCompat.setOnApplyWindowInsetsListener(eventView, callback)
-
-        // when modal is shown then keyboard will be hidden by default
-        //
-        // - if events are coming from main window - then keyboard position
-        //   will be synchronized from main window callback
-        // - if events are coming from modal window - then we need to update
-        //   position ourself, because callback can be attached after keyboard
-        //   auto-dismissal and we may miss some events and keyboard position
-        //   will be outdated
-        callback.syncKeyboardPosition(0.0, false)
       }
 
       dialog?.setOnDismissListener {
         callback.syncKeyboardPosition()
         callback.destroy()
         eventView.removeSelf()
-        this.callback()?.suspend(false)
+        // un-pause it in next frame because straight away `onApplyWindowInsets` will be called
+        view.post {
+          this.callback()?.suspend(false)
+        }
       }
 
       // imitating edge-to-edge mode behavior

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
@@ -75,7 +75,8 @@ class ModalAttachedWatcher(
         // callback - otherwise keyboard transitions will not be animated
         cb.suspend(true)
         // attaching callback to Modal on Android < 12 can cause ghost animations, see: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/718
-        // and overall attaching additional callbacks (if animation events go through the main window) is not necessary
+        // and overall attaching additional callbacks (if animation events go through the main window)
+        // is not necessary
         ViewCompat.setWindowInsetsAnimationCallback(rootView, callback)
         ViewCompat.setOnApplyWindowInsetsListener(eventView, callback)
       }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modal/ModalAttachedWatcher.kt
@@ -73,6 +73,18 @@ class ModalAttachedWatcher(
         // and overall attaching additional callbacks (if animation events go through the main window) is not necessary
         ViewCompat.setWindowInsetsAnimationCallback(rootView, callback)
         ViewCompat.setOnApplyWindowInsetsListener(eventView, callback)
+
+        // when modal is shown then keyboard will be hidden by default
+        //
+        // - if events are coming from main window - then keyboard position
+        //   will be synchronized from main window callback
+        // - if events are coming from modal window - then we need to update
+        //   position ourself, because callback can be attached after keyboard
+        //   auto-dismissal and we may miss some events and keyboard position
+        //   will be outdated
+        view.post {
+          callback.syncKeyboardPosition(0.0, false)
+        }
       }
 
       dialog?.setOnDismissListener {

--- a/cspell.json
+++ b/cspell.json
@@ -195,7 +195,8 @@
     "lottiefiles",
     "dotlottie",
     "legendapp",
-    "kortix"
+    "kortix",
+    "desynchronized"
   ],
   "ignorePaths": [
     "node_modules",

--- a/cspell.json
+++ b/cspell.json
@@ -196,7 +196,8 @@
     "dotlottie",
     "legendapp",
     "kortix",
-    "MACCATALYST"
+    "MACCATALYST",
+    "desynchronized"
   ],
   "ignorePaths": [
     "node_modules",


### PR DESCRIPTION
## 📜 Description

Fixed an issue when system windows (share bottom sheet, Modals, etc.) closes keyboard and these events are not propagated to JS.

## 💡 Motivation and Context

On Android 16 callback methods, such as `onStart`/`onMove`/`onEnd` may not be invoked at all, when system sheet (Share, Permissions etc.) closes a keyboard:


```tsx
<uses-permission android:name="android.permission.CAMERA" />

    PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, {
      title: "Cool Photo App Camera Permission",
      message:
        "Cool Photo App needs access to your camera " +
        "so you can take awesome pictures.",
      buttonNeutral: "Ask Me Later",
      buttonNegative: "Cancel",
      buttonPositive: "OK",
    });
```

https://github.com/user-attachments/assets/4ddcc318-7b0f-481f-9bc4-ccb6699d9968

To fix the problem I used the same approach that has been used in official Android app example, where we apply a double synchronization in `onApplyWindowInsets`. Android always dispatch the events from there, but I decided to use a more sophisticated approach, and dispatch event only when needed (when desynchronization detected). Otherwise it may break our model when `onEnd` can be called two times 🤷‍♂️ 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1006

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- change `isTransitioning` inside `onPrepare`;
- pass optional `insets` to `getCurrentKeyboardHeight` for reading actual keyboard height from `insets` (not root view);
- don't coalesce keyboard events (to match iOS);
- detect desynchronization state and manually adjust it when desynchronization is detected;

## 🤔 How Has This Been Tested?

Tested manually on:
- Pixel 8 (API 36, emulator)
- Pixel 7 Pro (API 36, real device)
- Redmi Note 5 Pro (API 28, real device)

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/02d63c64-1e18-482a-84d0-a041e35d262f">|<video src="https://github.com/user-attachments/assets/264edc2d-40f8-4aa2-8f94-72947ed1c4b4">|

### Modal show causes a keyboard close

|API 28 (with these changes)|API 28 (without PR changes)|
|----------------------------|-----------------------------|
|<img width="915" height="325" alt="image" src="https://github.com/user-attachments/assets/1e5d4793-5e7f-4cf7-9525-48760728fbca" />|<img width="1156" height="314" alt="image" src="https://github.com/user-attachments/assets/87fe1aab-43f6-46a0-b9b6-2a43c70dea21" />|

|API 33 (with these changes)|API 33 (without PR changes)|
|----------------------------|-----------------------------|
|<img width="1161" height="99" alt="image" src="https://github.com/user-attachments/assets/b8c5d4a4-ccf6-4671-a6ac-663ba7a9a767" />|<img width="1162" height="50" alt="image" src="https://github.com/user-attachments/assets/814d7aae-5bbc-4190-9cce-0610d9e2fb31" />|

> This is why `view.post { callback.syncKeyboardPosition(0.0, false) }` is needed on API 33+

## Known issues

- ~~Android, cold start, Modal screen, quickly focus input -> show Modal -> red circle on first screen stays frozen (API 33)~~ <- looks like a RN bug. I dispatch all events correctly in correct chronological order.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
