### PR TITLE
feat: preload by default

### DIFF
--- a/FabricExample/src/App.tsx
+++ b/FabricExample/src/App.tsx
@@ -4,10 +4,7 @@ import { NavigationContainer } from "@react-navigation/native";
 import * as React from "react";
 import { ActivityIndicator, StatusBar, StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import {
-  KeyboardController,
-  KeyboardProvider,
-} from "react-native-keyboard-controller";
+import { KeyboardProvider } from "react-native-keyboard-controller";
 import {
   SafeAreaProvider,
   initialWindowMetrics,
@@ -38,8 +35,6 @@ const linking = {
   },
 };
 const spinner = <ActivityIndicator color="blue" size="large" />;
-
-KeyboardController.preload();
 
 export default function App() {
   return (

--- a/docs/docs/api/keyboard-controller.md
+++ b/docs/docs/api/keyboard-controller.md
@@ -58,7 +58,7 @@ KeyboardController.setDefaultMode();
 static preload(): void;
 ```
 
-This method is used to preload the keyboard, so that users will not see a significant delay when they focus a first input since app has been opened.
+This method preloads the keyboard to prevent noticeable delay when the user focuses the first input after launching the app.
 
 ```ts
 KeyboardController.preload();

--- a/docs/docs/api/keyboard-provider.md
+++ b/docs/docs/api/keyboard-provider.md
@@ -29,6 +29,18 @@ A boolean property indicating whether to keep [edge-to-edge](https://developer.a
 If you use [react-native-edge-to-edge](https://github.com/zoontek/react-native-edge-to-edge), then `statusBarTranslucent`, `navigationBarTranslucent` and `preserveEdgeToEdge` are automatically set to `true`, so you don't need to worry about them.
 :::
 
+### `preload` <div className="label ios"></div>
+
+A boolean prop that determines whether to preload the keyboard to eliminate the initial focus lag (improve TTI). Defaults to `true`.
+
+Internally it calls imperative [`KeyboardController.preload()`](./keyboard-controller.md#preload-) API.
+
+:::info Opting out of preloading
+Set this to `false` if your app's initial screen doesn't include any inputs or if you prefer to control keyboard preloading manually.
+
+In general, this method is lightweight and safe to call on app start without any noticeable performance cost.
+:::
+
 ### `enabled`
 
 A boolean prop indicating whether the module is enabled. It indicate only initial state, i. e. if you try to change this prop after component mount it will not have any effect. To change the property in runtime use [useKeyboardController](./hooks/module/use-keyboard-controller.md) hook and `setEnabled` method. Defaults to `true`.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,10 +4,7 @@ import { NavigationContainer } from "@react-navigation/native";
 import * as React from "react";
 import { ActivityIndicator, StatusBar, StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import {
-  KeyboardController,
-  KeyboardProvider,
-} from "react-native-keyboard-controller";
+import { KeyboardProvider } from "react-native-keyboard-controller";
 import {
   SafeAreaProvider,
   initialWindowMetrics,
@@ -38,8 +35,6 @@ const linking = {
   },
 };
 const spinner = <ActivityIndicator color="blue" size="large" />;
-
-KeyboardController.preload();
 
 export default function App() {
   return (

--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -1,5 +1,5 @@
 /* eslint react/jsx-sort-props: off */
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Animated, Platform, StyleSheet } from "react-native";
 import {
   controlEdgeToEdgeValues,
@@ -11,6 +11,7 @@ import { KeyboardControllerView } from "./bindings";
 import { KeyboardContext } from "./context";
 import { focusedInputEventsMap, keyboardEventsMap } from "./event-mappings";
 import { useAnimatedValue, useEventHandlerRegistration } from "./internal";
+import { KeyboardController } from "./module";
 import {
   useAnimatedKeyboardHandler,
   useFocusedInputLayoutHandler,
@@ -82,6 +83,13 @@ type KeyboardProviderProps = {
    * Defaults to `true`.
    */
   enabled?: boolean;
+  /**
+   * A boolean prop indicating whether to preload the keyboard to reduce time-to-interaction (TTI) on first input focus.
+   * Defaults to `true`.
+   *
+   * @platform ios
+   */
+  preload?: boolean;
 };
 
 // capture `Platform.OS` in separate variable to avoid deep workletization of entire RN package
@@ -109,6 +117,7 @@ export const KeyboardProvider = (props: KeyboardProviderProps) => {
     navigationBarTranslucent,
     preserveEdgeToEdge,
     enabled: initiallyEnabled = true,
+    preload = true,
   } = props;
   // ref
   const viewTagRef = useRef<React.Component<KeyboardControllerProps>>(null);
@@ -214,6 +223,12 @@ export const KeyboardProvider = (props: KeyboardProviderProps) => {
     },
     [],
   );
+
+  useEffect(() => {
+    if (preload) {
+      KeyboardController.preload();
+    }
+  }, [preload]);
 
   if (__DEV__) {
     controlEdgeToEdgeValues({


### PR DESCRIPTION
## 📜 Description

Call `KeyboardController.preload()` when `KeyboardProvider` gets mounted.

## 💡 Motivation and Context

It seems like additional setup will require hand engineering and some devs may forget to do that. Keeping in mind that preloading is a safe operation I decided to `preload` keyboard by default (with an ability to turn off such behavior).

I did various tests and couldn't spot any issues with different configurations. The performance impact is minimal, because we only perform a single function call and all warmup happens later on UI thread, so it shouldn't affect app performance.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added documentation for new `preload` property;

### JS

- added `preload` property to `KeyboardProvider` (`true` by default);

## 🤔 How Has This Been Tested?

Tested manually on fabric/paper. iOS 18/iOS 26.

Used this code to test edge case:

```tsx
export default function App() {
  return (
    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
      <GestureHandlerRootView style={styles.root}>
        <KeyboardProvider statusBarTranslucent>
          <TextInput autoFocus />
        </KeyboardProvider>
      </GestureHandlerRootView>
    </SafeAreaProvider>
  );
}
```

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/a569a7d9-fe25-4e17-845d-18b03943d1c7

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
