### PR TITLE
fix: delay delegate substitution

### DIFF
--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -140,6 +140,11 @@ public class FocusedInputObserver: NSObject {
     currentInput = currentResponder?.superview as UIView?
 
     setupObservers()
+    // dispatch onSelectionChange on focus
+    if let textInput = responder as? UITextInput {
+      updateSelectionPosition(textInput: textInput, sendEvent: onSelectionChange)
+    }
+    
     syncUpLayout()
 
     FocusedInputHolder.shared.set(currentResponder as? TextInput)
@@ -210,8 +215,12 @@ public class FocusedInputObserver: NSObject {
         guard let self = self else { return }
         self.onLayoutChange(view: view, change: change)
       }
-
-      substituteDelegate(currentResponder)
+      
+      // substitute a delegate into the next frame.
+      // so that other libraries can inject their own delegates
+      DispatchQueue.main.async {
+        self.substituteDelegate(self.currentResponder)
+      }
     }
   }
 
@@ -239,10 +248,6 @@ public class FocusedInputObserver: NSObject {
         delegate.setTextViewDelegate(delegate: textView.delegate)
         textView.setForceDelegate(delegate)
       }
-    }
-    // dispatch onSelectionChange on focus
-    if let textInput = input as? UITextInput {
-      updateSelectionPosition(textInput: textInput, sendEvent: onSelectionChange)
     }
   }
 

--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -216,8 +216,12 @@ public class FocusedInputObserver: NSObject {
         self.onLayoutChange(view: view, change: change)
       }
 
-      // substitute a delegate into the next frame.
-      // so that other libraries can inject their own delegates
+      // Substitute a delegate in the next frame.
+      // This is only applicable if the autofocus prop is true.
+      // Other libraries (e.g., decorator views) might mount *after* the 
+      // TextInput and inject their own delegates at that point.
+      // If we substitute our delegate too early (e.g., during autofocus), and later restore it when the keyboard hides,
+      // we may accidentally overwrite a delegate injected by another library — breaking its logic.
       DispatchQueue.main.async {
         self.substituteDelegate(self.currentResponder)
       }

--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -217,10 +217,10 @@ public class FocusedInputObserver: NSObject {
       }
 
       // Substitute a delegate in the next frame.
-      // This is only applicable if the autofocus prop is true.
-      // Other libraries (e.g., decorator views) might mount *after* the 
+      // This is only applicable if the autoFocus prop is true.
+      // Other libraries (e.g., decorator views) might mount *after* the
       // TextInput and inject their own delegates at that point.
-      // If we substitute our delegate too early (e.g., during autofocus), and later restore it when the keyboard hides,
+      // If we substitute our delegate too early (e.g., during autoFocus), and later restore it when the keyboard hides,
       // we may accidentally overwrite a delegate injected by another library — breaking its logic.
       DispatchQueue.main.async {
         self.substituteDelegate(self.currentResponder)

--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -144,7 +144,7 @@ public class FocusedInputObserver: NSObject {
     if let textInput = responder as? UITextInput {
       updateSelectionPosition(textInput: textInput, sendEvent: onSelectionChange)
     }
-    
+
     syncUpLayout()
 
     FocusedInputHolder.shared.set(currentResponder as? TextInput)
@@ -215,7 +215,7 @@ public class FocusedInputObserver: NSObject {
         guard let self = self else { return }
         self.onLayoutChange(view: view, change: change)
       }
-      
+
       // substitute a delegate into the next frame.
       // so that other libraries can inject their own delegates
       DispatchQueue.main.async {


### PR DESCRIPTION
## 📜 Description

Currently in my library, I have a bug that if we have text input with autofocus, your library adds a delegate and it does it before my library, as I do it with decorator view, which is mounted on the screen by the next element. I think it is not so important for your library to put its delegate( in terms of as early as possible). So I added logic that does this on the next frame.


Advanced input mask issue: https://github.com/IvanIhnatsiuk/react-native-advanced-input-mask/issues/128

## 💡 Motivation and Context

Allow other libraries to set their own delegates

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- Wrapped substituteDelegate call with DispatchQueue.main.async


## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested locally on iOS simulator

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

https://github.com/user-attachments/assets/bb9e4725-d7d4-4fcb-9e28-0d94282315c0

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
