### PR TITLE
ci: fix `swiftformat` failures

### DIFF
--- a/.github/workflows/verify-ios.yml
+++ b/.github/workflows/verify-ios.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install SwiftFormat
-        run: brew install swiftformat
+        run: brew install swiftformat@0.56.4
 
       - name: Format Swift code
         run: swiftformat --verbose .


### PR DESCRIPTION
## 📜 Description

Lock `swiftformat` version.
 
## 💡 Motivation and Context

If we don't lock the version we may end up in a situation, when new version of dependency has been release which has breaking changes and PR that didn't affect the functionality may fail. To prevent this we should always lock the version of other tool/dependencies.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- lock and synchronize `swiftformat` version with a local one;

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
