### PR TITLE
fix: re-setup `WindowDimensionsListener`after JS bundle reload

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/managers/KeyboardControllerViewManagerImpl.kt
@@ -22,6 +22,7 @@ class KeyboardControllerViewManagerImpl {
 
   fun invalidate() {
     listener?.detachListener()
+    listener = null
   }
 
   fun setEnabled(


### PR DESCRIPTION
## 📜 Description

Re-attach dimension listener after JS bundle reload.

## 💡 Motivation and Context

When we reload the JS bundle we call `invalidate` method. In `invalidate` we detach our dimension listener (but we don't deallocate listener itself). When we create new `EdgeToEdge` view we check whether we have a listener - and actually we have it, because we didn't clear it inside `invalidate`, so we don't attach a new listener.

Because of this fact next time when we reload the bundle we will not get any window updates and `useWindowDimension` will report incorrect height (`850` vs expected `770`).

To fix the problem I simply clear the `listener` (`listener = null`) and it works 🎉 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1032

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- cleanup `listener` in `invalidate` method.

## 🤔 How Has This Been Tested?

Tested manually using Samsung A53 (Android 14).

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/aa2e45d7-73c8-466f-a78f-48d022bc1206

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
