### PR TITLE
fix: do not use `BackgroundStyleApplicator` directly

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/background/KeyboardBackgroundViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/background/KeyboardBackgroundViewGroup.kt
@@ -3,7 +3,6 @@ package com.reactnativekeyboardcontroller.views.background
 import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.view.WindowInsets
-import com.facebook.react.uimanager.BackgroundStyleApplicator
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 
@@ -14,18 +13,18 @@ class KeyboardBackgroundViewGroup(
   // view mounted
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
-    BackgroundStyleApplicator.setBackgroundColor(this, reactContext.getInputMethodColor())
+    super.setBackgroundColor(reactContext.getInputMethodColor())
   }
 
   // theme changed
   override fun onConfigurationChanged(newConfig: Configuration?) {
     super.onConfigurationChanged(newConfig)
-    BackgroundStyleApplicator.setBackgroundColor(this, reactContext.getInputMethodColor())
+    super.setBackgroundColor(reactContext.getInputMethodColor())
   }
 
   // keyboard changed
   override fun onApplyWindowInsets(insets: WindowInsets?): WindowInsets {
-    BackgroundStyleApplicator.setBackgroundColor(this, reactContext.getInputMethodColor())
+    super.setBackgroundColor(reactContext.getInputMethodColor())
     return super.onApplyWindowInsets(insets)
   }
 


### PR DESCRIPTION
## 📜 Description

Don't use `BackgroundStyleApplicator` directly.

## 💡 Motivation and Context

`BackgroundStyleApplicator` was added ~9 months ago and in older react-native versions this class doesn't exist. Taking this fact into consideration it seems like `BackgroundStyleApplicator` is an internal implementation, which can be removed in future versions and overall I don't think it's reliable to use internal things.

So in this PR I'm switching to `super.setBackgroundColor` - internally it uses `BackgroundStyleApplicator`, but this is a public API and it will work across all react-native versions 😎 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1038

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- use `super.setBackgroundColor` instead of `BackgroundStyleApplicator`;

## 🤔 How Has This Been Tested?

Tested via e2e tests.

## 📸 Screenshots (if appropriate):

<img width="703" height="114" alt="image" src="https://github.com/user-attachments/assets/1169df52-8af7-4529-be73-dd4fd81ec31e" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
