### PR TITLE
fix: `keyboardAppearanceValue` extension iOS < 12 compatibility

### DIFF
--- a/ios/protocols/TextInput.swift
+++ b/ios/protocols/TextInput.swift
@@ -39,13 +39,17 @@ extension TextInput {
     case .light:
       return "light"
     case .default:
-      switch traitCollection.userInterfaceStyle {
-      case .dark:
-        return "dark"
-      case .light, .unspecified:
-        return "light"
-      @unknown default:
-        return "light"
+      if #available(iOS 12.0, *) {
+        switch traitCollection.userInterfaceStyle {
+        case .dark:
+          return "dark"
+        case .light, .unspecified:
+          return "light"
+        @unknown default:
+          return "light"
+        }
+      } else {
+        return "light" // Default fallback for iOS < 12
       }
     @unknown default:
       return "light"


### PR DESCRIPTION
## 📜 Description

Fix compilation error if minimal supported iOS < 12.

## 💡 Motivation and Context

The `userInterfaceStyle` property was added in iOS 12. Before iOS 12 all user interfaces were only in light mode.

Since I started to use this property I need to wrap it in `#available` - otherwise projects targeting lower iOS versions will throw compilation errors.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1042

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added `#available` before accessing `userInterfaceStyle` property;

## 🤔 How Has This Been Tested?

Tested via patch in test project.

## 📸 Screenshots (if appropriate):

<img width="198" height="48" alt="image" src="https://github.com/user-attachments/assets/6098fa8f-f492-4e5e-814e-6ca68aac9bc3" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
