### PR TITLE
refactor: isolate keyboard view locator

### DIFF
--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -18,19 +18,7 @@ public class KeyboardMovementObserver: NSObject {
   var onRequestAnimation: () -> Void
   var onCancelAnimation: () -> Void
   // progress tracker
-  private var _keyboardView: UIView?
-  private var keyboardView: UIView? {
-    let windowsCount = UIApplication.shared.windows.count
-
-    if _keyboardView == nil || windowsCount != _windowsCount {
-      _keyboardView = KeyboardView.find()
-      _windowsCount = windowsCount
-    }
-
-    return _keyboardView
-  }
-
-  private var _windowsCount: Int = 0
+  private var keyboardView: UIView? { KeyboardViewLocator.shared.resolve() }
   private var prevKeyboardPosition = 0.0
   private var displayLink: CADisplayLink!
   private var interactiveKeyboardObserver: NSKeyValueObservation?

--- a/ios/observers/KeyboardViewLocator.swift
+++ b/ios/observers/KeyboardViewLocator.swift
@@ -1,0 +1,23 @@
+//
+//  KeyboardViewLocator.swift
+//  Pods
+//
+//  Created by Kiryl Ziusko on 25/07/2025.
+//
+
+final class KeyboardViewLocator {
+  static let shared = KeyboardViewLocator()
+  private var cachedKeyboardView: UIView?
+  private var cachedWindowsCount: Int = 0
+
+  func resolve() -> UIView? {
+    let currentWindowsCount = UIApplication.shared.windows.count
+
+    if cachedKeyboardView == nil || currentWindowsCount != cachedWindowsCount {
+      cachedKeyboardView = KeyboardView.find()
+      cachedWindowsCount = currentWindowsCount
+    }
+
+    return cachedKeyboardView
+  }
+}


### PR DESCRIPTION
## 📜 Description

Isolate keyboard view locating into separate class.

## 💡 Motivation and Context

`KeyboardMovementObserver` almost reaches its cognitive complexity, so I decided to simplify that class a little bit and group a related logic for discovering keyboard into separate class.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- created `KeyboardViewLocator` class;
- use `KeyboardViewLocator` in `KeyboardMovementObserver`

## 🤔 How Has This Been Tested?

Tested via e2e test.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
