### PR TITLE
fix: mark `KeyboardExtender` `enabled` props as optional in TS

### DIFF
--- a/src/types/views.ts
+++ b/src/types/views.ts
@@ -47,5 +47,5 @@ export type OverKeyboardViewProps = PropsWithChildren<{
 export type KeyboardBackgroundViewProps = PropsWithChildren<ViewProps>;
 export type KeyboardExtenderProps = PropsWithChildren<{
   /** Controls whether this `KeyboardExtender` instance should take an effect. Default is `true`. */
-  enabled: boolean;
+  enabled?: boolean;
 }>;


### PR DESCRIPTION
## 📜 Description

Mark `KeyboardExtender` `enabled` props as optional in TypeScript.

## 💡 Motivation and Context

We assign default `true` value, so it's not a mandatory step to specify this property.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- mark `KeyboardExtender` `enabled` props as optional in TS

## 🤔 How Has This Been Tested?

Tested in VSCode.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="976" height="355" alt="image" src="https://github.com/user-attachments/assets/fa8df9ec-982c-4eef-a9a1-67721214a3b3" />|<img width="967" height="353" alt="image" src="https://github.com/user-attachments/assets/0f604e47-7c31-4a94-9df3-fda311ded171" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
