### PR TITLE
fix: iOS crash caused by the `KeyboardControllerView` class implementation

### DIFF
--- a/ios/views/KeyboardControllerView.mm
+++ b/ios/views/KeyboardControllerView.mm
@@ -178,16 +178,16 @@ using namespace facebook::react;
                           .duration = [duration intValue],
                           .target = [target intValue]});
             }
-          }
-          if ([event isEqualToString:@"onKeyboardMoveInteractive"]) {
-            std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(
-                self->_eventEmitter)
-                ->onKeyboardMoveInteractive(
-                    facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMoveInteractive{
-                        .height = [height doubleValue],
-                        .progress = [progress doubleValue],
-                        .duration = [duration intValue],
-                        .target = [target intValue]});
+            if ([event isEqualToString:@"onKeyboardMoveInteractive"]) {
+              std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(
+                  self->_eventEmitter)
+                  ->onKeyboardMoveInteractive(
+                      facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMoveInteractive{
+                          .height = [height doubleValue],
+                          .progress = [progress doubleValue],
+                          .duration = [duration intValue],
+                          .target = [target intValue]});
+            }
           }
 
           KeyboardMoveEvent *keyboardMoveEvent =

--- a/ios/views/KeyboardControllerView.mm
+++ b/ios/views/KeyboardControllerView.mm
@@ -182,11 +182,12 @@ using namespace facebook::react;
               std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(
                   self->_eventEmitter)
                   ->onKeyboardMoveInteractive(
-                      facebook::react::KeyboardControllerViewEventEmitter::OnKeyboardMoveInteractive{
-                          .height = [height doubleValue],
-                          .progress = [progress doubleValue],
-                          .duration = [duration intValue],
-                          .target = [target intValue]});
+                      facebook::react::KeyboardControllerViewEventEmitter::
+                          OnKeyboardMoveInteractive{
+                              .height = [height doubleValue],
+                              .progress = [progress doubleValue],
+                              .duration = [duration intValue],
+                              .target = [target intValue]});
             }
           }
 


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

We caught an iOS crash by the Sentry error monitoring, according to the stack trace, finally we found there is a bug in the `KeyboardControllerView` class, the stack trace is like the below screenshot.

![image](https://github.com/user-attachments/assets/c654b3a7-f46e-4a8a-9b0f-cafacc40e3da)


## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR solved this crash with a very simple fix, seems that this bug is caused by a unconscious typo error...

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- Changed the `KeyboardControllerView` class implementation to resolve this crash.

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Actually this crash is occasional and at least I didn't manage to reproduce it locally, the current fix is totally from logic inference, however we have applied the fix in this PR in our prod app more than one month by patching the library file, and we didn't find any new relevant crash occurrences since the fix, so it proves to work on our end.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
