### PR TITLE
feat: manual `did` events on iOS

### DIFF
--- a/ios/animations/KeyboardAnimation.swift
+++ b/ios/animations/KeyboardAnimation.swift
@@ -23,13 +23,15 @@ public class KeyboardAnimation: KeyboardAnimationProtocol {
   // constructor variables
   let fromValue: Double
   let toValue: Double
+  let duration: Double
   let speed: Double
   let timestamp: CFTimeInterval
 
-  init(fromValue: Double, toValue: Double, animation: CAMediaTiming) {
+  init(fromValue: Double, toValue: Double, animation: CAMediaTiming, duration: Double) {
     self.fromValue = fromValue
     self.toValue = toValue
     self.animation = animation
+    self.duration = duration
     speed = Double(animation.speed)
     timestamp = CACurrentMediaTime()
   }

--- a/ios/animations/SpringAnimation.swift
+++ b/ios/animations/SpringAnimation.swift
@@ -57,7 +57,7 @@ public final class SpringAnimation: KeyboardAnimation {
       bUnder = 0
     }
 
-    super.init(fromValue: fromValue, toValue: toValue, animation: animation)
+    super.init(fromValue: fromValue, toValue: toValue, animation: animation, duration: animation.settlingDuration)
   }
 
   // public functions

--- a/ios/animations/TimingAnimation.swift
+++ b/ios/animations/TimingAnimation.swift
@@ -30,7 +30,7 @@ public final class TimingAnimation: KeyboardAnimation {
     self.p1 = p1
     self.p2 = p2
 
-    super.init(fromValue: fromValue, toValue: toValue, animation: animation)
+    super.init(fromValue: fromValue, toValue: toValue, animation: animation, duration: animation.duration)
   }
 
   // MARK: public functions

--- a/ios/extensions/Notification.swift
+++ b/ios/extensions/Notification.swift
@@ -18,4 +18,5 @@ extension Notification {
 
 extension Notification.Name {
   static let shouldIgnoreKeyboardEvents = Notification.Name("shouldIgnoreKeyboardEvents")
+  static let keyboardDidAppear = Notification.Name("keyboardDidAppear")
 }

--- a/ios/interactive/KeyboardAreaExtender.swift
+++ b/ios/interactive/KeyboardAreaExtender.swift
@@ -15,7 +15,7 @@ class KeyboardAreaExtender: NSObject {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(keyboardDidAppear),
-      name: UIResponder.keyboardDidShowNotification,
+      name: .keyboardDidAppear,
       object: nil
     )
   }

--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -35,7 +35,9 @@ public class KeyboardMovementObserver: NSObject {
     didSet {
       keyboardDidTask?.cancel()
 
-      guard let notification = notification, let height = notification.keyboardMetaData().1?.cgRectValue.size.height else {
+      guard let notification = notification,
+            let height = notification.keyboardMetaData().1?.cgRectValue.size.height, duration == 0
+      else {
         return
       }
 
@@ -243,6 +245,10 @@ public class KeyboardMovementObserver: NSObject {
       removeKeyboardWatcher()
       setupKVObserver()
       animation = nil
+
+      NotificationCenter.default.post(
+        name: .keyboardDidAppear, object: notification, userInfo: nil
+      )
     }
   }
 


### PR DESCRIPTION
## 📜 Description

Dispatch `keyboardDidShow`/`keyboardDidHide` events manually.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1044

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

-
-

### iOS

-
-

### Android

-
-

## 🤔 How Has This Been Tested?

Tested manually on:
- iPhone 16 Pro (iOS 26 beta 4);

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/95ade378-b36d-4ba3-9935-708be78bdbbe">|<video src="https://github.com/user-attachments/assets/736e5430-273f-455b-940b-b767c650e69e">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
