### PR TITLE
fix: attaching `KeyboardExtender`

### DIFF
--- a/ios/views/KeyboardExtenderContainerView.swift
+++ b/ios/views/KeyboardExtenderContainerView.swift
@@ -55,7 +55,6 @@ private class BaseContainerView: UIInputView {
     if frame.height != desiredHeight {
       frame.size.height = desiredHeight
 
-      // Update content frame
       updateContentFrame(desiredHeight: desiredHeight)
 
       // Trigger layout updates
@@ -105,8 +104,6 @@ private class ModernContainerView: BaseContainerView {
   }
 
   override func updateContentFrame(desiredHeight: CGFloat) {
-    let totalHeight = desiredHeight + paddingBottom
-
     visualEffectView?.frame = CGRect(
       x: paddingHorizontal,
       y: -paddingBottom,

--- a/ios/views/KeyboardExtenderManager.mm
+++ b/ios/views/KeyboardExtenderManager.mm
@@ -244,15 +244,13 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 {
   _enabled = enabled;
 
-  if (_sharedInputAccessoryView) {
-    if (!enabled) {
-      [self detachInputAccessoryView];
-    } else {
-      // Re-attach if a text input is active
-      UIResponder *firstResponder = [UIResponder current];
-      if ([firstResponder conformsToProtocol:@protocol(UITextInput)]) {
-        [self attachToTextInput:(UIView *)firstResponder];
-      }
+  if (!enabled) {
+    [self detachInputAccessoryView];
+  } else {
+    // Re-attach if a text input is active
+    UIResponder *firstResponder = [UIResponder current];
+    if ([firstResponder conformsToProtocol:@protocol(UITextInput)]) {
+      [self attachToTextInput:(UIView *)firstResponder];
     }
   }
 }


### PR DESCRIPTION
## 📜 Description

Fixed mounting `KeyboardExtender` when switching `enabled` from `false` to `true`.

## 💡 Motivation and Context

When initial `enabled={false}` and then we switch it to `true`, then this code:

```tsx
  if (_sharedInputAccessoryView) {
    if (!enabled) {
      [self detachInputAccessoryView];
    } else {
      // Re-attach if a text input is active
      UIResponder *firstResponder = [UIResponder current];
      if ([firstResponder conformsToProtocol:@protocol(UITextInput)]) {
        [self attachToTextInput:(UIView *)firstResponder];
      }
```

Will never be executed. Because `_sharedInputAccessoryView` is `nil` (it's initialized in `attachInputAccessoryViewTo`).

To fix this bug I simply removed `if (_sharedInputAccessoryView)` condition - it should work without it too 🙂 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1056

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- removed `if (_sharedInputAccessoryView)` condition;
- cleanup `KeyboardExtenderContainerView` file;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 15 Pro (iOS 17.5). 

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/6ffc5462-6425-4d32-bef0-99e1f37c06a8

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
