### PR TITLE
fix: iOS 26 interactive dismissal

### DIFF
--- a/ios/observers/KeyboardMovementObserver.swift
+++ b/ios/observers/KeyboardMovementObserver.swift
@@ -117,12 +117,11 @@ public class KeyboardMovementObserver: NSObject {
       return
     }
 
-    let interactive = keyboardTrackingView.interactive(point: changeValue)
+    let position = keyboardTrackingView.interactive(point: changeValue)
 
-    if interactive == KeyboardTrackingView.invalidPosition {
+    if position == KeyboardTrackingView.invalidPosition {
       return
     }
-    let position = interactive - KeyboardAreaExtender.shared.offset
 
     if position == 0 {
       // it will be triggered before `keyboardWillDisappear` and

--- a/ios/observers/KeyboardTrackingView.swift
+++ b/ios/observers/KeyboardTrackingView.swift
@@ -113,7 +113,7 @@ final class KeyboardTrackingView: UIView {
     if #available(iOS 26.0, *) {
       // when we are the top position KVO takes `inputAccessoryView` into consideration,
       // so we handle it here
-      if (keyboardPosition == keyboardHeight) {
+      if keyboardPosition == keyboardHeight {
         return keyboardPosition - KeyboardAreaExtender.shared.offset
       }
       return keyboardPosition

--- a/ios/observers/KeyboardTrackingView.swift
+++ b/ios/observers/KeyboardTrackingView.swift
@@ -111,6 +111,11 @@ final class KeyboardTrackingView: UIView {
 
     // for `keyboardLayoutGuide` case we can just read keyboard position directly - no interpolation needed
     if #available(iOS 26.0, *) {
+      // when we are the top position KVO takes `inputAccessoryView` into consideration,
+      // so we handle it here
+      if (keyboardPosition == keyboardHeight) {
+        return keyboardPosition - KeyboardAreaExtender.shared.offset
+      }
       return keyboardPosition
     }
 
@@ -127,6 +132,6 @@ final class KeyboardTrackingView: UIView {
       currentValue: keyboardPosition
     )
 
-    return position
+    return position - KeyboardAreaExtender.shared.offset
   }
 }


### PR DESCRIPTION
## 📜 Description

Fixed interactive dismissal on iOS 26.

## 💡 Motivation and Context

Fixed the issue with interactive keyboard dismissal on iOS 26. The problem is that we always subtracted `.offset` value, but it looks like KVO doesn't take into consideration `.inputAccessoryView` during interactive dismissal, so we don't need to subtract the value.

However if we simply move `- offset` to iOS < 18, then we'll get a bug, that if keyboard is fully open then it'll use `inputAccessoryView` height. So to fix that I added a condition, that if keyboard is fully open the we subtract, otherwise pass as is.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/973

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- move `- KeyboardAreaExtender.shared.offset` to iOS 18 specific code.
- use `keyboardPosition - KeyboardAreaExtender.shared.offset` only if keyboard is fully open.

## 🤔 How Has This Been Tested?

Tested manually on iPhone 16 Pro (iOS 26).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/d95424e5-e573-4d84-8eb4-b9caecfb1e7a">|<video src="https://github.com/user-attachments/assets/4a4e0843-7402-4b07-977b-b321aeefb781">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
