### PR TITLE
fix: avoid direct `FBReactNativeSpec` usage

### DIFF
--- a/ios/KeyboardControllerModule.mm
+++ b/ios/KeyboardControllerModule.mm
@@ -11,7 +11,6 @@
 
 // Thanks to this guard, we won't import this header when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
-#import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import <reactnativekeyboardcontroller/reactnativekeyboardcontroller.h>
 #endif
 


### PR DESCRIPTION
## 📜 Description

Don't use `<FBReactNativeSpec/FBReactNativeSpec.h>` import anymore.

## 💡 Motivation and Context

This import was added 3 years ago. I think back to times it was needed (I'm assuming that all specs could be generated in one file or that spec contained some declarations that were needed in other custom specs). However it seems like now it's unnecessary. Moreover in react-native 0.81 it will cause a compilation error (not sure why, maybe react-native doesn't expose this spec publicly anymore).

Anyway, this change seems to be compatible with react-native 0.78..0.81, so I think it's safe to merge it as is without additional conditional imports and other stuff.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1081

## 📢 Changelog

### iOS

- removed `<FBReactNativeSpec/FBReactNativeSpec.h>` import;

## 🤔 How Has This Been Tested?

Tested via compiling `FabricExample` project.

## 📸 Screenshots (if appropriate):

<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/71ec7111-43fc-4dc8-9c9a-f74f03f1a7b0" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
