### PR TITLE
fix: add `target_compile_reactnative_options`

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -68,15 +68,19 @@ else()
   )
 endif()
 
-target_compile_options(
-  ${LIB_TARGET_NAME}
-  PRIVATE
-  -DLOG_TAG=\"ReactNative\"
-  -fexceptions
-  -frtti
-  -std=c++20
-  -Wall
-)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)
+else()
+  target_compile_options(
+    ${LIB_TARGET_NAME}
+    PRIVATE
+    -DLOG_TAG=\"ReactNative\"
+    -fexceptions
+    -frtti
+    -std=c++20
+    -Wall
+  )
+endif()
 
 target_include_directories(
  ${CMAKE_PROJECT_NAME}


### PR DESCRIPTION
## 📜 Description

Added `target_compile_reactnative_options` for Android in `CMakeList.txt`.

## 💡 Motivation and Context

As per [blogpost](https://reactnative.dev/blog/2025/08/12/react-native-0.81#rn_serializable_state-and-c-flags) we should add `target_compile_reactnative_options` to the lib in order to support RN 0.81.

We use custom C++ code (custom shadow nodes) and we don't rely on codegen, so we need to do it.

> We use custom shadow nodes since `1.17.0` to properly stretch `OverKeyboardView`.

The same fix was added to `react-native-safe-area-context` and `react-native-screens`.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added `target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)` for RN 0.80+

## 🤔 How Has This Been Tested?

Tested via this PR - it doesn't break old builds 🙂 Didn't test on RN 0.81 project yet because upgrade is blocked by Detox.

## 📸 Screenshots (if appropriate):

<img width="691" height="257" alt="image" src="https://github.com/user-attachments/assets/e16587fc-30e9-4d90-80f5-7ce466042382" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
