### PR TITLE
Add DefaultKeyboardToolbarTheme to Jest mock exports

### DIFF
--- a/jest/index.js
+++ b/jest/index.js
@@ -42,6 +42,21 @@ const state = {
   isVisible: false,
 };
 
+const DefaultKeyboardToolbarTheme = {
+  light: {
+    primary: "#2c2c2c",
+    disabled: "#B0BEC5",
+    background: "#f3f3f4",
+    ripple: "#bcbcbcbc",
+  },
+  dark: {
+    primary: "#fafafa",
+    disabled: "#707070",
+    background: "#2C2C2E",
+    ripple: "#F8F8F888",
+  },
+};
+
 const mock = {
   // hooks
   /// keyboard
@@ -105,6 +120,8 @@ const mock = {
   KeyboardAvoidingView: View,
   KeyboardAwareScrollView: ScrollView,
   KeyboardToolbar: View,
+  // themes
+  DefaultKeyboardToolbarTheme,
 };
 
 module.exports = mock;


### PR DESCRIPTION
# Fix Jest Mock Export for DefaultKeyboardToolbarTheme

## 📜 Description

This PR adds the missing `DefaultKeyboardToolbarTheme` export to the Jest mock file, which resolves test failures when components try to access theme properties during testing. The fix includes both light and dark theme configurations with proper color values for primary, disabled, background, and ripple properties.

## 💡 Motivation and Context

Currently, when using this brilliant package in my work repo I used `react-native-keyboard-controller` in my tests, but encountered errors when trying to access `DefaultKeyboardToolbarTheme.dark` or `DefaultKeyboardToolbarTheme.light` properties. This happens because the Jest mock is missing the theme export, causing:

```
TypeError: Cannot read properties of undefined (reading 'dark')
```

This fix ensures that components can properly spread and customize the theme in their test environments without encountering undefined property errors.

## 📢 Changelog

### JS

- Added `DefaultKeyboardToolbarTheme` export to Jest mock (`jest/index.js`)
- Included complete light and dark theme configurations with color values
- Fixed Jest test failures related to missing theme exports

### iOS

- No changes

### Android

- No changes

## 🤔 How Has This Been Tested?

The fix has been tested by:

**Manual verification** (I am using a local version of this in my app but ideally would import it from react-native-keyboard-controller)
**Validation** that the export follows the same pattern as other Jest mock exports

**Testing Environment:**
- React Native project using Jest for testing
- Components that import and use `DefaultKeyboardToolbarTheme` from the Jest mock

**Test Scenarios:**
- ✅ Theme export is properly defined
- ✅ Light theme properties are accessible
- ✅ Dark theme properties are accessible  
- ✅ Theme spreading works without errors
- ✅ No "Cannot read properties of undefined" errors

## 📸 Screenshots (if appropriate):

N/A - This is a Jest mock fix that resolves test failures, no visual changes.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
  - Note: This fix adds the missing export to existing Jest mock, no new API changes
