### PR TITLE
fix: clear legacy full screen flag

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Handler
 import android.os.Looper
+import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -153,6 +154,8 @@ class EdgeToEdgeReactViewGroup(
           !isEdgeToEdge,
         )
       }
+      // unclear legacy flag if it was set earlier
+      reactContext.currentActivity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
     }
   }
 


### PR DESCRIPTION
## 📜 Description

Clear `FLAG_FULLSCREEN` when edge-to-edge view gets mounted.

## 💡 Motivation and Context

As per documentation:

> A fullscreen window will ignore a value of [SOFT_INPUT_ADJUST_RESIZE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#SOFT_INPUT_ADJUST_RESIZE) for the window's [softInputMode](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#softInputMode) field; the window will stay fullscreen and will not resize. [1](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_FULLSCREEN)

So if users specified somehow `FLAG_FULLSCREEN` it will ignore `SOFT_INPUT_ADJUST_RESIZE` and it will result in double animations.

Edge-to-edge seems to be a new `FLAG_FULLSCREEN` alternative which gives more control over things, because you can be full screen and still show `StatusBar`. So we have a right to clear that flag when we mount `EdgeToEdge` view 😊 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1091

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- clear `FLAG_FULLSCREEN` when edge-to-edge gets mounted/created.

## 🤔 How Has This Been Tested?

Tested manually on Pixel 9 Pro API 31.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/6a7c4b9d-725f-4415-aadd-88e36c293911">|<video src="https://github.com/user-attachments/assets/a782d868-586e-482b-9bf9-36b8cf7ecf87">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
