### PR TITLE
docs: update compatibility table with react-native 0.81

### DIFF
--- a/docs/docs/guides/compatibility.md
+++ b/docs/docs/guides/compatibility.md
@@ -25,6 +25,7 @@ Below you can find a table with supported versions:
 
 | library version | react-native version |
 | --------------- | -------------------- |
+| 1.18.0+         | 0.81.0+              |
 | 1.16.0+         | 0.77.0+              |
 | 1.13.0+         | 0.75.0+              |
 | 1.12.0+         | 0.74.0+              |

--- a/docs/versioned_docs/version-1.18.0/guides/compatibility.md
+++ b/docs/versioned_docs/version-1.18.0/guides/compatibility.md
@@ -25,6 +25,7 @@ Below you can find a table with supported versions:
 
 | library version | react-native version |
 | --------------- | -------------------- |
+| 1.18.0+         | 0.81.0+              |
 | 1.16.0+         | 0.77.0+              |
 | 1.13.0+         | 0.75.0+              |
 | 1.12.0+         | 0.74.0+              |


### PR DESCRIPTION
## 📜 Description

Mention that RN 0.81 is compatible only with `1.18+` lib.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- add RN 0.81 to fabric compatibility;

## 🤔 How Has This Been Tested?

Tested via preview.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
