### PR TITLE
fix: don't use `@RequiresApi` with old SDK versions

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
@@ -3,7 +3,6 @@ package com.reactnativekeyboardcontroller.extensions
 import android.graphics.Rect
 import android.os.Build
 import android.view.View
-import androidx.annotation.RequiresApi
 import com.reactnativekeyboardcontroller.log.Logger
 
 /**
@@ -38,14 +37,15 @@ private val tmpIntArr = IntArray(2)
 /**
  * Function which updates the given [rect] with this view's position and bounds in its window.
  */
-@RequiresApi(Build.VERSION_CODES.KITKAT)
 fun View.copyBoundsInWindow(rect: Rect) {
-  if (isAttachedToWindow) {
-    rect.set(0, 0, width, height)
-    getLocationInWindow(tmpIntArr)
-    rect.offset(tmpIntArr[0], tmpIntArr[1])
-  } else {
-    Logger.w("View.copyBoundsInWindow", "Can not copy bounds as view is not attached to window")
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    if (isAttachedToWindow) {
+      rect.set(0, 0, width, height)
+      getLocationInWindow(tmpIntArr)
+      rect.offset(tmpIntArr[0], tmpIntArr[1])
+    } else {
+      Logger.w("View.copyBoundsInWindow", "Can not copy bounds as view is not attached to window")
+    }
   }
 }
 

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/View.kt
@@ -1,5 +1,6 @@
 package com.reactnativekeyboardcontroller.extensions
 
+import android.annotation.SuppressLint
 import android.graphics.Rect
 import android.os.Build
 import android.view.View
@@ -10,6 +11,7 @@ import com.reactnativekeyboardcontroller.log.Logger
  * to ensure that insets are always received.
  * @see https://stackoverflow.com/a/61909205/9272042
  */
+@SuppressLint("ObsoleteSdkInt")
 fun View.requestApplyInsetsWhenAttached() {
   // https://chris.banes.dev/2019/04/12/insets-listeners-to-layouts/
   if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT && isAttachedToWindow) {
@@ -37,6 +39,7 @@ private val tmpIntArr = IntArray(2)
 /**
  * Function which updates the given [rect] with this view's position and bounds in its window.
  */
+@SuppressLint("ObsoleteSdkInt")
 fun View.copyBoundsInWindow(rect: Rect) {
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
     if (isAttachedToWindow) {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarManagerCompatModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarManagerCompatModuleImpl.kt
@@ -4,7 +4,6 @@ import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
 import android.app.Activity
 import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.facebook.react.bridge.ReactApplicationContext
@@ -37,37 +36,38 @@ class StatusBarManagerCompatModuleImpl(
     }
   }
 
-  @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
   fun setColor(
     color: Int,
     animated: Boolean,
   ) {
-    if (!isEnabled()) {
-      return original.setColor(color.toDouble(), animated)
-    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      if (!isEnabled()) {
+        return original.setColor(color.toDouble(), animated)
+      }
 
-    val activity = mReactContext.currentActivity
-    if (activity == null) {
-      Logger.w(
-        TAG,
-        "StatusBarManagerCompatModule: Ignored status bar change, current activity is null.",
-      )
-      return
-    }
+      val activity = mReactContext.currentActivity
+      if (activity == null) {
+        Logger.w(
+          TAG,
+          "StatusBarManagerCompatModule: Ignored status bar change, current activity is null.",
+        )
+        return
+      }
 
-    UiThreadUtil.runOnUiThread {
-      val window = activity.window
+      UiThreadUtil.runOnUiThread {
+        val window = activity.window
 
-      if (animated) {
-        val curColor: Int = window.statusBarColor
-        val colorAnimation = ValueAnimator.ofObject(ArgbEvaluator(), curColor, color)
-        colorAnimation.addUpdateListener { animator ->
-          window.statusBarColor = animator.animatedValue as Int
+        if (animated) {
+          val curColor: Int = window.statusBarColor
+          val colorAnimation = ValueAnimator.ofObject(ArgbEvaluator(), curColor, color)
+          colorAnimation.addUpdateListener { animator ->
+            window.statusBarColor = animator.animatedValue as Int
+          }
+          colorAnimation.setDuration(DEFAULT_ANIMATION_TIME).startDelay = 0
+          colorAnimation.start()
+        } else {
+          window.statusBarColor = color
         }
-        colorAnimation.setDuration(DEFAULT_ANIMATION_TIME).startDelay = 0
-        colorAnimation.start()
-      } else {
-        window.statusBarColor = color
       }
     }
   }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarManagerCompatModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarManagerCompatModuleImpl.kt
@@ -2,6 +2,7 @@ package com.reactnativekeyboardcontroller.modules.statusbar
 
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Build
 import androidx.core.view.WindowInsetsCompat
@@ -36,6 +37,7 @@ class StatusBarManagerCompatModuleImpl(
     }
   }
 
+  @SuppressLint("ObsoleteSdkInt")
   fun setColor(
     color: Int,
     animated: Boolean,

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
@@ -86,7 +86,6 @@ class KeyboardGestureAreaReactViewGroup(
   // endregion
 
   // region Handlers
-  @RequiresApi(Build.VERSION_CODES.KITKAT)
   private fun onActionDown(event: MotionEvent) {
     velocityTracker?.addMovement(event)
 

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
@@ -6,7 +6,6 @@ import android.os.Build
 import android.view.MotionEvent
 import android.view.VelocityTracker
 import android.view.ViewConfiguration
-import androidx.annotation.RequiresApi
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.uimanager.ThemedReactContext
@@ -50,7 +49,6 @@ class KeyboardGestureAreaReactViewGroup(
 
   private var velocityTracker: VelocityTracker? = null
 
-  @RequiresApi(Build.VERSION_CODES.R)
   override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
     if (velocityTracker == null) {
       // Obtain a VelocityTracker if we don't have one yet
@@ -96,7 +94,6 @@ class KeyboardGestureAreaReactViewGroup(
     lastWindowY = bounds.top
   }
 
-  @RequiresApi(Build.VERSION_CODES.R)
   private fun onActionMove(event: MotionEvent) {
     // Since the view is likely to be translated/moved as the WindowInsetsAnimation
     // progresses, we need to make sure we account for that change in our touch
@@ -229,11 +226,14 @@ class KeyboardGestureAreaReactViewGroup(
     else -> false
   }
 
-  @RequiresApi(Build.VERSION_CODES.R)
   private fun getWindowHeight(): Int {
-    val metrics = reactContext.currentActivity?.windowManager?.currentWindowMetrics
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      val metrics = reactContext.currentActivity?.windowManager?.currentWindowMetrics
 
-    return metrics?.bounds?.height() ?: 0
+      return metrics?.bounds?.height() ?: 0
+    }
+
+    return 0
   }
 
   companion object {

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt
@@ -1,7 +1,6 @@
 package com.reactnativekeyboardcontroller
 
 import android.os.Build
-import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
@@ -22,7 +21,6 @@ class StatusBarManagerCompatModule(
   }
 
   @ReactMethod
-  @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
   private fun setColor(
     color: Int,
     animated: Boolean,

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/StatusBarManagerCompatModule.kt
@@ -1,6 +1,5 @@
 package com.reactnativekeyboardcontroller
 
-import android.os.Build
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod


### PR DESCRIPTION
## 📜 Description

Removed `@RequiresApi` annotations usage.

## 💡 Motivation and Context

When I was getting compilation issues due to usage of API which is not available in older versions I was constantly using first option provided by Android Studio: to add `@RequiresApi` annotation.

However it has some downsides:
- if you mark one method with this annotation - all other methods must use the same annotation if they call this method;
- this method is kind of semantic, and if you somehow accidentally call this method on older devices it will lead to crash.

So to make code structure a little bit cleaner I decided to remove those annotations and switch to `if`-statements. Initially the idea was to fix https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1104, but turned out that [ObsoleteSdkInt] checks also `if`-statements. So for me as a library author there is only one reliable way to fix the issue is to suppress those warnings (if people set linter to treat warnings as errors it will prevent the lib from being compiled)

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1104

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- rewrite `@RequiresApi` to `if`-statements;
- suppress new `if`-statements lint warnings via `@SuppressLint`;

## 🤔 How Has This Been Tested?

Tested in example app.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
