### PR TITLE
ci: remove redundant `Pack` step

### DIFF
--- a/.github/workflows/size-diff-collect.yml
+++ b/.github/workflows/size-diff-collect.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Pack
-        run: npm pack --json
-
       - name: Calculate size of package (current)
         id: new-size
         run: echo "NEW_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 📜 Description

Remove redundant `Pack` step.

## 💡 Motivation and Context

It looks like I added this step for debugging purposes and forgot to remove it.

There is no sense to keep it, because `scripts/size.js` already uses `npm pack --json` command so there is no reason to run the command twice.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- remove `Pack` command from CI size-diff job.

## 🤔 How Has This Been Tested?

Tested manually via this PR.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
