### PR TITLE
chore: update `@gorhom/bottom-sheet` to v5

### DIFF
--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -10,7 +10,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@gorhom/bottom-sheet": "4.6.4",
+    "@gorhom/bottom-sheet": "5.2.6",
     "@react-native-community/blur": "^4.4.1",
     "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-navigation/bottom-tabs": "^6.6.1",

--- a/FabricExample/src/screens/Examples/AwareScrollView/index.tsx
+++ b/FabricExample/src/screens/Examples/AwareScrollView/index.tsx
@@ -1,4 +1,4 @@
-import BottomSheet from "@gorhom/bottom-sheet";
+import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Button, Platform, Switch, Text, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
@@ -106,42 +106,44 @@ export default function AwareScrollView({ navigation }: Props) {
         />
       </KeyboardAwareScrollView>
       <BottomSheet ref={bottomSheetModalRef} index={-1} snapPoints={["40%"]}>
-        <Button
-          testID="bottom_sheet_close_modal"
-          title="Close modal"
-          onPress={() => bottomSheetModalRef.current?.close()}
-        />
-        <View style={styles.switchContainer}>
-          <Text>Toggle back scroll</Text>
-          <Switch
-            testID="bottom_sheet_toggle_back_scroll"
-            value={disableScrollOnKeyboardHide}
-            onChange={() => {
-              setDisableScrollOnKeyboardHide(!disableScrollOnKeyboardHide);
-            }}
+        <BottomSheetView style={styles.bottomSheetContent}>
+          <Button
+            testID="bottom_sheet_close_modal"
+            title="Close modal"
+            onPress={() => bottomSheetModalRef.current?.close()}
           />
-        </View>
-        <View style={styles.switchContainer}>
-          <Text>Toggle enabled</Text>
-          <Switch
-            testID="bottom_sheet_toggle_enabled_state"
-            value={enabled}
-            onChange={() => {
-              setEnabled(!enabled);
-            }}
-          />
-        </View>
+          <View style={styles.switchContainer}>
+            <Text>Toggle back scroll</Text>
+            <Switch
+              testID="bottom_sheet_toggle_back_scroll"
+              value={disableScrollOnKeyboardHide}
+              onChange={() => {
+                setDisableScrollOnKeyboardHide(!disableScrollOnKeyboardHide);
+              }}
+            />
+          </View>
+          <View style={styles.switchContainer}>
+            <Text>Toggle enabled</Text>
+            <Switch
+              testID="bottom_sheet_toggle_enabled_state"
+              value={enabled}
+              onChange={() => {
+                setEnabled(!enabled);
+              }}
+            />
+          </View>
 
-        <View style={styles.switchContainer}>
-          <Text>Toggle snapToOffsets</Text>
-          <Switch
-            testID="bottom_sheet_toggle_snap_to_offsets"
-            value={snapToOffsetsEnabled}
-            onChange={() => {
-              setSnapToOffsetsEnabled(!snapToOffsetsEnabled);
-            }}
-          />
-        </View>
+          <View style={styles.switchContainer}>
+            <Text>Toggle snapToOffsets</Text>
+            <Switch
+              testID="bottom_sheet_toggle_snap_to_offsets"
+              value={snapToOffsetsEnabled}
+              onChange={() => {
+                setSnapToOffsetsEnabled(!snapToOffsetsEnabled);
+              }}
+            />
+          </View>
+        </BottomSheetView>
       </BottomSheet>
     </>
   );

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -1042,10 +1042,10 @@
   dependencies:
     "@types/hammerjs" "^2.0.36"
 
-"@gorhom/bottom-sheet@4.6.4":
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.6.4.tgz#387d0f0f21e3470eb8575498cb81ce96f5108e79"
-  integrity sha512-0itLMblLBvepE065w3a60S030c2rNUsGshPC7wbWDm31VyqoaU2xjzh/ojH62YIJOcobBr5QoC30IxBBKDGovQ==
+"@gorhom/bottom-sheet@5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.2.6.tgz#5f2045f6ca965383afe39f7dfa3afad1502b7467"
+  integrity sha512-vmruJxdiUGDg+ZYcDmS30XDhq/h/+QkINOI5LY/uGjx8cPGwgJW0H6AB902gNTKtccbiKe/rr94EwdmIEz+LAQ==
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"


### PR DESCRIPTION
## 📜 Description

Fixed a crash in `KeyboardAwareScrollView` example app after https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1120

## 💡 Motivation and Context

`@gorhom/bottom-sheet@4` is not compatible with reanimated v4. So in this PR I updated lib to v5 to fix an instant crash after opening a screen that uses `@gorhom/bottom-sheet` library.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- update `@gorhom/portal` lib to v5;

## 🤔 How Has This Been Tested?

Tested manually in FabricExample in `KeyboardAwareScrollView` example screen (both iOS/Android).

## 📸 Screenshots (if appropriate):

<img width="251" height="519" alt="image" src="https://github.com/user-attachments/assets/1639b865-a7cc-44cf-b845-d05558469ac5" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
