### PR TITLE
fix: `KeyboardExtender` initial mount on Fabric

### DIFF
--- a/ios/views/KeyboardExtenderManager.mm
+++ b/ios/views/KeyboardExtenderManager.mm
@@ -222,10 +222,9 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 #ifdef RCT_NEW_ARCH_ENABLED
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &oldViewProps = *std::static_pointer_cast<const KeyboardExtenderProps>(_props);
   const auto &newViewProps = *std::static_pointer_cast<const KeyboardExtenderProps>(props);
 
-  if (newViewProps.enabled != oldViewProps.enabled) {
+  if (newViewProps.enabled != self.enabled) {
     [self updateEnabledState:newViewProps.enabled];
   }
 


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

-
-

### iOS

-
-

### Android

-
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
||<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/fa290038-7d5e-45f4-8c95-81ac6d75d313" />|

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
