### PR TITLE
fix: ignore interactive keyboard values that are bigger than keyboard height

### DIFF
--- a/ios/observers/movement/KeyboardTrackingView.swift
+++ b/ios/observers/movement/KeyboardTrackingView.swift
@@ -113,6 +113,9 @@ final class KeyboardTrackingView: UIView {
 
     // for `keyboardLayoutGuide` case we can just read keyboard position directly - no interpolation needed
     if #available(iOS 26.0, *) {
+      if keyboardPosition > keyboardHeight {
+        return Self.invalidPosition
+      }
       // when we are the top position KVO takes `inputAccessoryView` into consideration,
       // so we handle it here
       if keyboardPosition == keyboardHeight {


### PR DESCRIPTION
## 📜 Description

Fixed incorrect `onInteractive` event after keyboard gets shown with `KeyboardGestureArea` and `offset` usage.

## 💡 Motivation and Context

An incorrect event can cause a sudden flash, when content gets shown above the keyboard for a fraction of a second.

In `interactive` method we have a lot of various `if`-statements, so this bug I'm fixing in similar way. It's impossible case when interactive keyboard height can be a bigger than an actual keyboard size. So I added

```swift
      if keyboardPosition > keyboardHeight {
        return Self.invalidPosition
      }
```

> I din't attach a video, because it's very hard to record that blink, even using `QuickTime` recorder.

Fixes one issue described in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1155 (with 453 keyboard height).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- return invalid size if "interactive" keyboard size is bigger than actual one on iOS 26+;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 16 Pro (iOS 26, XCode 26) in `InteractiveKeyboardIOS` example.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="862" height="313" alt="image" src="https://github.com/user-attachments/assets/bf54fbe3-d369-4423-9911-6385de5b7a82" />|<img width="859" height="362" alt="image" src="https://github.com/user-attachments/assets/2e6a5107-b63a-4099-b144-afde5d24eb5d" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
