### PR TITLE
chore: update `detox` to `20.44.0`

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -35,7 +35,7 @@
     "@types/pngjs": "^6.0.1",
     "async-retry": "^1.3.3",
     "colors": "^1.4.0",
-    "detox": "20.43.0-alpha.0",
+    "detox": "20.44.0",
     "jest": "^29",
     "patch-package": "^8.0.0",
     "pixelmatch": "^5.3.0",

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -1160,10 +1160,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detox@20.43.0-alpha.0:
-  version "20.43.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-20.43.0-alpha.0.tgz#f1d61a9c5b85c58ed632a42f37235188dad414ac"
-  integrity sha512-z2nQcYnX80a4pNcoqvFSu+ORrEgWZiIwvV2rxryNGT4KOSpPDHD6uWS1A1SythrODWYWzHD6zEYlGf8tMAtRBQ==
+detox@20.44.0:
+  version "20.44.0"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-20.44.0.tgz#6693e8d9ca35f6aea31592c1b26c5b8e28c069cd"
+  integrity sha512-d7WbZUbFqTMjtr8eOF1Vz8zhjIIrD/MAScwB3wNfF/5BAiBEyOXwbtURq5HfJzscbNRQimkPPojGPZu3eY6R8g==
   dependencies:
     "@wix-pilot/core" "^3.4.2"
     "@wix-pilot/detox" "^1.0.13"


### PR DESCRIPTION
## 📜 Description

Update detox to latest stable release.

## 💡 Motivation and Context

The version `20.44.0` supports both RN 0.81 and RN 0.82. It's better to use stable releases that officially declares the support for specific RN versions.

We still have a problem with unstable Android e2e tests (keyboard toolbar test). We just need to re-work it and add more synchronization, I believe 🤞 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- update detox to `20.44.0`;

## 🤔 How Has This Been Tested?

Tested via CI.

## 📸 Screenshots (if appropriate):

<img width="925" height="398" alt="image" src="https://github.com/user-attachments/assets/735476af-ba8f-43b5-a2af-8cb47f0cc218" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
