### PR TITLE
fix: non-working release version on iOS 26

### DIFF
--- a/ios/observers/movement/KeyboardTrackingView.swift
+++ b/ios/observers/movement/KeyboardTrackingView.swift
@@ -56,7 +56,12 @@ final class KeyboardTrackingView: UIView {
       name: UIResponder.keyboardDidShowNotification,
       object: nil
     )
-    attachToTopmostView()
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(attachToTopmostView),
+      name: UIApplication.didBecomeActiveNotification,
+      object: nil
+    )
   }
 
   override func willMove(toWindow newWindow: UIWindow?) {


### PR DESCRIPTION
## 📜 Description

Fixed an issue when `react-native-keyboard-controller` is not reporting keyboard movements when launching from release app version on iOS 26.

## 💡 Motivation and Context

The problem is that if we attach `keyboardLayoutGuide` to `rootView` straight in mount lifecycle, then `rootView` may be not available yet. To fix this problem we need to subscribe to event which will indicate that `rootView` is available and only then attach a view.
 
Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1182

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- attach `KeyboardTrackingView` only when app became active;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 16 Pro (iOS 26.1, real device).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/ff7c8982-8d19-4e9d-a09f-718f5b67c33b">|<video src="https://github.com/user-attachments/assets/9b2fc7ad-d702-4f6c-ba3d-a8932e7c5fa7">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
