### PR TITLE
fix: add `KeyboardBackgroundView` to turbo package

### DIFF
--- a/android/src/turbo/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
+++ b/android/src/turbo/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
@@ -59,5 +59,6 @@ class KeyboardControllerPackage : TurboReactPackage() {
       KeyboardControllerViewManager(),
       KeyboardGestureAreaViewManager(),
       OverKeyboardViewManager(),
+      KeyboardBackgroundViewManager(),
     )
 }


### PR DESCRIPTION
## 📜 Description

Expose `KeyboardBackgroundView` for react-native < 0.74.

## 💡 Motivation and Context

On react-native < 0.74 we are using `TurboPackage`. It looks like I accidentally forgot to export `KeyboardBackgroundView` for older react-native versions. In this version I'm fixing this and adding `KeyboardBackgroundViewManager` to `TurboPackage` 😎 

## 📢 Changelog

### Android

- export `KeyboardBackgroundView` for RN < 0.74

## 🤔 How Has This Been Tested?

Tested on CI.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
