### PR TITLE
docs: add "accessory" algolia keyword

### DIFF
--- a/docs/docs/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/docs/api/components/keyboard-sticky-view/index.mdx
@@ -16,11 +16,7 @@ keywords:
 
 # KeyboardStickyView
 
-{/* Hidden keywords for Algolia */}
-
-<div style={{ display: "none" }}>keyboard accessory KeyboardAccessoryView</div>
-
-A `KeyboardStickyView` component seamlessly ensures that a designated view sticks to the keyboard's movements, maintaining visibility and interaction. Use it when you want to enhance the user experience by preventing important UI elements from being obscured by the keyboard, creating a smooth and user-friendly interface in your React Native application.
+A `KeyboardStickyView` component seamlessly ensures that a designated view sticks to the keyboard's movements, maintaining visibility and interaction. Often referred to as a **keyboard accessory** or **keyboard accessory view**, it helps you enhance the user experience by preventing important UI elements from being obscured by the keyboard, creating a smooth and user-friendly interface in your React Native application.
 
 :::info `KeyboardAvoidingView` vs `KeyboardStickyView`
 Unlike [KeyboardAvoidingView](../keyboard-avoiding-view.mdx) the `KeyboardStickyView` just moves the content along with keyboard and not resizing the inner view. Try to compare animations of `KeyboardStickyView` and `KeyboardAvoidingView` to see a difference in details on how it works and which component is suitable for your needs.

--- a/docs/versioned_docs/version-1.19.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.19.0/api/components/keyboard-sticky-view/index.mdx
@@ -16,11 +16,7 @@ keywords:
 
 # KeyboardStickyView
 
-{/* Hidden keywords for Algolia */}
-
-<div style={{ display: "none" }}>keyboard accessory KeyboardAccessoryView</div>
-
-A `KeyboardStickyView` component seamlessly ensures that a designated view sticks to the keyboard's movements, maintaining visibility and interaction. Use it when you want to enhance the user experience by preventing important UI elements from being obscured by the keyboard, creating a smooth and user-friendly interface in your React Native application.
+A `KeyboardStickyView` component seamlessly ensures that a designated view sticks to the keyboard's movements, maintaining visibility and interaction. Often referred to as a **keyboard accessory** or **keyboard accessory view**, it helps you enhance the user experience by preventing important UI elements from being obscured by the keyboard, creating a smooth and user-friendly interface in your React Native application.
 
 :::info `KeyboardAvoidingView` vs `KeyboardStickyView`
 Unlike [KeyboardAvoidingView](../keyboard-avoiding-view.mdx) the `KeyboardStickyView` just moves the content along with keyboard and not resizing the inner view. Try to compare animations of `KeyboardStickyView` and `KeyboardAvoidingView` to see a difference in details on how it works and which component is suitable for your needs.


### PR DESCRIPTION
## 📜 Description

Mention "accessory" explicitly on `KeyboardStickyView` page.

## 💡 Motivation and Context

The `KeyboardStickyView` effectively is an "accessory" view. And some people use "accessory" to find this page:

<img width="599" height="365" alt="image" src="https://github.com/user-attachments/assets/a1894c2d-88c5-4527-860a-79905053d4a0" />

<img width="609" height="507" alt="image" src="https://github.com/user-attachments/assets/ebe4894a-8a42-449c-bfac-e3d3cf1788cd" />

So in this PR I decided to explicitly add "accessory" word on this page, so that it'll be discovered in Algolia searcher.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added "keyboard accessory"/"keyboard accessory view" words on `KeyboardStickyView` API page;

## 🤔 How Has This Been Tested?

Tested via preview.

## 📸 Screenshots (if appropriate):

<img width="995" height="367" alt="image" src="https://github.com/user-attachments/assets/d60965ca-7405-40e3-aa0b-cc91c54c187d" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
