### PR TITLE
ci: update shared cache

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -137,6 +137,8 @@ jobs:
           retry_interval: 60
       - name: List all available simulators
         run: xcrun simctl list
+      - name: Update shared cache
+        run: xcrun simctl runtime dyld_shared_cache update --all
       - name: Install AppleSimulatorUtils
         run: brew tap wix/brew && brew install applesimutils
       - name: Save yarn cache directory path


### PR DESCRIPTION
## 📜 Description

Update shared simulator cache.

## 💡 Motivation and Context

We install additional runtimes. As per Apple in this case it's better to update shared cache.

My understanding is that this step may help us to avoid the issue when simulator over-consumes CPU resources on its start up.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- updated shared simulator cache on app startup;

## 🤔 How Has This Been Tested?

Tested manually on CI.

## 📸 Screenshots (if appropriate):

<img width="852" height="395" alt="image" src="https://github.com/user-attachments/assets/895aa770-e9ce-481e-8ff9-5becce1930af" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
