### PR TITLE
fix: types mismatch for `dismiss` method

### DIFF
--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -85,10 +85,11 @@ export type KeyboardControllerModule = {
   // all platforms
   /**
    * Dismisses the active keyboard. Removes a focus by default, but allows to pass `{keepFocus: true}` to keep focus.
+   * If you want to close keyboard immediately pass `{animated: false}`.
    *
    * @see {@link https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/keyboard-controller#dismiss|docs} page for more details.
    */
-  dismiss: (options?: DismissOptions) => Promise<void>;
+  dismiss: (options?: Partial<DismissOptions>) => Promise<void>;
   /**
    * Moves focus to the specified direction (`next`, `prev` or `current` to restore a focus).
    *


### PR DESCRIPTION
## 📜 Description

Updated jsdoc and type declaration for `dismiss` method.

## 💡 Motivation and Context

The `options` object serves asa configuration object. We may skip some properties and it should use default options then. In fact our implementation already has correct options:

```tsx
const dismiss = async (options?: Partial<DismissOptions>): Promise<void> => {
```

So in this PR I just reflected it in types 🙃 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- changed JSDoc of `dismiss` method;
- marked options as `Partial` in `types` declaration file.

## 🤔 How Has This Been Tested?

Tested in example project.

## 📸 Screenshots (if appropriate):

|Before|After|
|------|------|
|<img width="915" height="174" alt="Screenshot 2025-12-01 at 10 13 27" src="https://github.com/user-attachments/assets/ad515fc9-c79f-4b65-afc6-6bb1608429ad" />|<img width="614" height="102" alt="image" src="https://github.com/user-attachments/assets/05e51607-acb8-443c-bac5-a7d39b6a8537" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
