### PR TITLE
fix: dependencies array changes size between renders

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -98,7 +98,6 @@ jobs:
     timeout-minutes: 90
     env:
       WORKING_DIRECTORY: example
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     concurrency:
       group: ios-e2e-${{ matrix.devices.ios }}-${{ github.ref }}
       cancel-in-progress: true
@@ -125,9 +124,6 @@ jobs:
           xcode-version: ${{ matrix.devices.xcode }}
       - name: Get Xcode version
         run: xcodebuild -version
-      - name: GitHub auth for Homebrew
-        run: |
-          git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
       # needed for additional runtime installation
       - name: Install Xcodes
         run: brew tap xcodesorg/made


### PR DESCRIPTION
## 📜 Description

Fixed `The final argument passed to %s changed size between renders. The order and size of this array must remain constant.` warning.

## 💡 Motivation and Context

This warning happens inside `useSmoothKeyboardHandler` and started to happen after https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1209 The main difference from these changes is that we started to use `useHandler`/`useEvent` hooks, while in the past we simply used direct worklet registration.

Turns out `useAnimatedReaction` modifies array of dependencies:

```tsx
if (dependencies === undefined) {
    dependencies = [
      ...Object.values(prepare.__closure ?? {}),
      ...Object.values(react.__closure ?? {}),
      prepare.__workletHash,
      react.__workletHash,
    ];
  } else {
    dependencies.push(prepare.__workletHash, react.__workletHash);
  }
```

Then `useHandler` (used in `useKeyboardHandler`) uses `buildDependencies` which also modifies the array of dependencies:

```ts
dependencies.push(buildWorkletsHash(handlersList));
```

So if we use deps like:

```ts
const useMyCustomHook = (deps) => {
  useAnimatedReaction(() => {}, deps);
  
  useKeyboardHandler({}, deps);
}
```

Then we'll get this warning because we mutate deps two times.

To fix this issue I decided to make a shallow copy of `deps` for `useAnimatedReaction` hook. It fixes the problem 🤞 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1228

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- create shallow array copy for `useAnimatedReaction` in `useSmoothKeyboardHandler`;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 16 Pro.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/a82b9e6d-adb9-4530-9f2c-2b50ec954386">|<video src="https://github.com/user-attachments/assets/e8fe2cac-bb8c-47eb-89ac-b8d34d01591f">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
