### PR TITLE
fix: iOS e2e tests

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -126,7 +126,7 @@ jobs:
         run: xcodebuild -version
       # needed for additional runtime installation
       - name: Install Xcodes
-        run: brew tap robotsandpencils/made
+        run: brew tap xcodesorg/made
       - name: Install additional iOS runtimes
         if: ${{ matrix.devices.runtime != '' && matrix.devices.runtime != null }}
         uses: ./.github/actions/retry-sudo-with-timeout


### PR DESCRIPTION
## 📜 Description

Fixed constantly failing e2e jobs. 

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixed a problem with red CI (iOS jobs) due to fact that brew dependency can not be installed. It happens because `robotsandpencils/made` has been renamed to `xcodesorg/made` so we need to update naming.

We still have a problem with unstable Android e2e tests (toolbar tests) and iOS 26 (simulator sometimes can not be started).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- replace brew dependency `robotsandpencils/made` -> `xcodesorg/made`

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="619" height="149" alt="image" src="https://github.com/user-attachments/assets/455fe927-a058-423b-95f4-f2d0d24ff7e7" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
