### PR TITLE
fix: avoid undesired `reloadInputViews` during keyboard dismissal

### DIFF
--- a/FabricExample/src/screens/Examples/KeyboardExtender/index.tsx
+++ b/FabricExample/src/screens/Examples/KeyboardExtender/index.tsx
@@ -48,7 +48,10 @@ export default function KeyboardExtendExample() {
   return (
     <>
       <Image source={require("./background.jpg")} style={styles.background} />
-      <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+      <TouchableWithoutFeedback
+        testID="keyboard_extender.dismiss"
+        onPress={() => Keyboard.dismiss()}
+      >
         <SafeAreaView edges={["top"]} style={styles.container}>
           <TextInput
             keyboardType="numeric"

--- a/example/src/screens/Examples/KeyboardExtender/index.tsx
+++ b/example/src/screens/Examples/KeyboardExtender/index.tsx
@@ -48,7 +48,10 @@ export default function KeyboardExtendExample() {
   return (
     <>
       <Image source={require("./background.jpg")} style={styles.background} />
-      <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+      <TouchableWithoutFeedback
+        testID="keyboard_extender.dismiss"
+        onPress={() => Keyboard.dismiss()}
+      >
         <SafeAreaView edges={["top"]} style={styles.container}>
           <TextInput
             keyboardType="numeric"

--- a/ios/views/KeyboardExtenderContainerView.swift
+++ b/ios/views/KeyboardExtenderContainerView.swift
@@ -41,7 +41,7 @@ private class BaseContainerView: UIInputView {
   }
 
   func setupContainerSpecifics() {
-    // Override in subclasses
+    updateContentFrame(desiredHeight: calculateDesiredHeight())
   }
 
   func calculateDesiredHeight() -> CGFloat {
@@ -85,6 +85,7 @@ private class ModernContainerView: BaseContainerView {
 
   override func setupContainerSpecifics() {
     setupVisualEffect()
+    super.setupContainerSpecifics()
   }
 
   private func setupVisualEffect() {
@@ -104,8 +105,6 @@ private class ModernContainerView: BaseContainerView {
         visualEffectView.contentView.addSubview(contentView)
         addSubview(visualEffectView)
       }
-
-      updateContentFrame(desiredHeight: calculateDesiredHeight())
     #endif
   }
 
@@ -130,6 +129,7 @@ private class ModernContainerView: BaseContainerView {
 private class LegacyContainerView: BaseContainerView {
   override func setupContainerSpecifics() {
     addSubview(contentView)
+    super.setupContainerSpecifics()
   }
 
   override func updateContentFrame(desiredHeight _: CGFloat) {


### PR DESCRIPTION
## 📜 Description

Fixed issue with non-dismissible keyboard on iOS 26.

## 💡 Motivation and Context

The problem stems from the fact that we compare `61.66668701171875` vs `61.666666666666664` in old implementation. As a result we were calling `UIResponder.reloadInputView` too often and during dismissal it caused a keyboard to appear again.

To fix it I added `abs(frame.height - desiredHeight) > 0.001` instead of `frame.height != desiredHeight`. It fixed problem but introduced regression - initial frame had incorrect dimension. It turns out that `layoutSubviews` wasn't called many times and because of that we didn't specify correct layout. So after creation we need to specify frame. Since we need to do it for modern/legacy views I decided to put common code in default implementation of `setupContainerSpecifics` and call `super.setupContainerSpecifics()` from `setupContainerSpecifics` (in child classes).

Also I wanted to cover this component by e2e tests, but I realized that we can not touch invisible `TouchableWithoutFeedback`. Then I decided to add button + use `KeyboardStickyView`, but I discovered too many issues:
- on Android we don't include `KeyboardExtender` in keyboard rectangle (known issue);
- on iOS 26 after re-attaching extender `KeyboardStickyView` doesn't change its position (iOS 26 specific bug?)

So taking all these issues into account I decided not to fix all of these issues inside one PR. I'll address them later.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1207

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- use `abs(frame.height - desiredHeight) > 0.001` instead of `frame.height != desiredHeight`;
- use `updateContentFrame(desiredHeight: calculateDesiredHeight())` in default implementation of `setupContainerSpecifics`;
- call `super.setupContainerSpecifics()` from `setupContainerSpecifics` (in child classes);

## 🤔 How Has This Been Tested?

Tested in example app.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/fa30464d-dab1-4726-b35f-9bb9cc46a4fb">|<video src="https://github.com/user-attachments/assets/ba03d54e-435c-436f-b58b-50e9840f96c2">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
