### PR TITLE
ci: run less e2e jobs when when running from PR

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -113,7 +113,7 @@ jobs:
             echo 'matrix={"devices": [{"ios": 15, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "15.5", "iphone": "iPhone 13 Pro", "os": "15.5"}, {"ios": 16, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "16.4", "iphone": "iPhone 14 Pro", "os": "16.4"}, {"ios": 17, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "17.5", "iphone": "iPhone 15 Pro", "os": "17.5"}, {"ios": 18, artifact: "16.4", "xcode": "16.4", "macos": 15, "iphone": "iPhone 16 Pro", "os": "18.5"}, {"ios": 26, artifact: "16.4", "xcode": "26.0", "macos": 26, "iphone": "iPhone 17 Pro", "os": "26.0"}, {"ios": "26e", artifact: "26.1", "xcode": "26.1", "macos": 26, "iphone": "iPhone 16e", "os": "26.1"}]}' >> $GITHUB_OUTPUT
           fi
   e2e-test:
-    name: ⚙️ Automated test cases (iOS-${{ matrix.devices.ios }}, XCode-${{ matrix.devices.xcode }})
+    name: ⚙️ Automated test cases (iOS-${{ matrix.devices.ios }}, XCode-${{ matrix.devices.artifact }})
     runs-on: macos-${{ matrix.devices.macos }}
     timeout-minutes: 90
     env:


### PR DESCRIPTION
## 📜 Description

Reduced amount of iOS e2e tests for PR.

## 💡 Motivation and Context

When we open PR we want to move as quick as possible. Running 2 build jobs + 6 e2e jobs is a very expensive in terms of time (because we have only 5 runners available to use simultaneously). So in this PR I decide to use only 3 jobs for tests:
- iOS 15 (prior to this version only TextKit v1 was used, events were more synchronous and we had less strange bugs and less strange events were emitted);
- iOS 17 - classically broken iOS version. On this version we have TextKit v2, we have early end events etc. +iOS 17 runner is running fast, so it's our gold standard.
- iOS 26 + Xcode 26 - this is a new combination and we need to assure that newest iOS runs without issues/regressions.

When we merge into main we run all 6 jobs (just for double verification).

To achieve this I added a separate step that prepares a matrix for e2e tests. I've tried other options but this was the only one that was working 🤷‍♂️ 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- run only 3 iOS e2e for PRs;

## 🤔 How Has This Been Tested?

Tested manually via this PR.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
