### PR TITLE
fix: wrong `onEnd` event on Samsung devices when keyboard gets shown after interactive dismissal

### DIFF
--- a/FabricExample/src/screens/Examples/InteractiveKeyboard/index.tsx
+++ b/FabricExample/src/screens/Examples/InteractiveKeyboard/index.tsx
@@ -23,21 +23,30 @@ const useKeyboardAnimation = () => {
   const progress = useSharedValue(0);
   const height = useSharedValue(0);
 
-  useKeyboardHandler({
-    onMove: (e) => {
-      "worklet";
+  useKeyboardHandler(
+    {
+      onMove: (e) => {
+        "worklet";
 
-      // eslint-disable-next-line react-compiler/react-compiler
-      progress.value = e.progress;
-      height.value = e.height;
-    },
-    onInteractive: (e) => {
-      "worklet";
+        // eslint-disable-next-line react-compiler/react-compiler
+        progress.value = e.progress;
+        height.value = e.height;
+      },
+      onInteractive: (e) => {
+        "worklet";
 
-      progress.value = e.progress;
-      height.value = e.height;
+        progress.value = e.progress;
+        height.value = e.height;
+      },
+      onEnd: (e) => {
+        "worklet";
+
+        progress.value = e.progress;
+        height.value = e.height;
+      },
     },
-  });
+    [],
+  );
 
   return { height, progress };
 };

--- a/android/src/main/java/com/reactnativekeyboardcontroller/constants/UIThread.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/constants/UIThread.kt
@@ -1,0 +1,9 @@
+package com.reactnativekeyboardcontroller.constants
+
+import kotlin.math.floor
+
+object UIThread {
+  const val MILLISECONDS_IN_SECOND = 1000.0
+  const val FPS = 60
+  val NEXT_FRAME = floor(MILLISECONDS_IN_SECOND / FPS).toLong()
+}

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -14,6 +14,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.constants.Keyboard
+import com.reactnativekeyboardcontroller.constants.UIThread
 import com.reactnativekeyboardcontroller.events.KeyboardTransitionEvent
 import com.reactnativekeyboardcontroller.extensions.appearance
 import com.reactnativekeyboardcontroller.extensions.dispatchEvent
@@ -334,8 +335,8 @@ class KeyboardAnimationCallback(
 
     if (isKeyboardInteractive) {
       // in case of interactive keyboard we can not read keyboard frame straight away
-      // (because we'll always read `0`), so we are posting runnable to the main thread
-      view.post(runnable)
+      // (because we'll always read `0`), so we are posting runnable to the next frame on the main thread
+      view.postDelayed(runnable, UIThread.NEXT_FRAME)
     } else {
       runnable.run()
     }

--- a/example/src/screens/Examples/InteractiveKeyboard/index.tsx
+++ b/example/src/screens/Examples/InteractiveKeyboard/index.tsx
@@ -23,21 +23,30 @@ const useKeyboardAnimation = () => {
   const progress = useSharedValue(0);
   const height = useSharedValue(0);
 
-  useKeyboardHandler({
-    onMove: (e) => {
-      "worklet";
+  useKeyboardHandler(
+    {
+      onMove: (e) => {
+        "worklet";
 
-      // eslint-disable-next-line react-compiler/react-compiler
-      progress.value = e.progress;
-      height.value = e.height;
-    },
-    onInteractive: (e) => {
-      "worklet";
+        // eslint-disable-next-line react-compiler/react-compiler
+        progress.value = e.progress;
+        height.value = e.height;
+      },
+      onInteractive: (e) => {
+        "worklet";
 
-      progress.value = e.progress;
-      height.value = e.height;
+        progress.value = e.progress;
+        height.value = e.height;
+      },
+      onEnd: (e) => {
+        "worklet";
+
+        progress.value = e.progress;
+        height.value = e.height;
+      },
     },
-  });
+    [],
+  );
 
   return { height, progress };
 };


### PR DESCRIPTION
## 📜 Description

Fixed wrong event for "end" keyboard movement after interactive dismissal (when keyboard gets shown after interaction).

## 💡 Motivation and Context

Originally reported by @pioner92 months ago and later raised as an issue by @iankberry

It's a known issue that in `onEnd` we may get out-of-dated keyboard frame metrics. The fix that I used earlier was postponing the event a little bit if it was interactive dismissal. It fixed the issue for my pixel device in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/814

However if we test Samsung device we can clearly see that the bug is reproducible again. In this PR I'm continue to use the idea introduced in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/814 and just use larger delay. It fixes the problem, but I'll conduct an exploration for a better/more synchronous code. I started this investigation in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1017 and I plan to return to this PR soon 👀 (but for now we'll merge a workaround)

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1238

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `onEnd` handler in "Interactive Keyboard" example

### Android

- added `UIThread` constants;
- use `.postDelayed()` instead of `.post()` with one frame delay;

## 🤔 How Has This Been Tested?

Tested manually on Samsung S25+, Android 15 (Remote test lab) in example app.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/45e63086-e49f-4b53-b4c1-647045021709">|<video src="https://github.com/user-attachments/assets/bafc21c1-49f3-4ea0-a248-1d587feedfbc">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
