### PR TITLE
ci: XCode 16 deprecation on macOS 26

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -108,6 +108,7 @@ jobs:
           [
             {
               ios: 15,
+              artifact: "16.4",
               xcode: "16.4",
               macos: 15,
               runtime: "15.5",
@@ -116,6 +117,7 @@ jobs:
             },
             {
               ios: 16,
+              artifact: "16.4",
               xcode: "16.4",
               macos: 15,
               runtime: "16.4",
@@ -124,6 +126,7 @@ jobs:
             },
             {
               ios: 17,
+              artifact: "16.4",
               xcode: "16.4",
               macos: 15,
               runtime: "17.5",
@@ -132,6 +135,7 @@ jobs:
             },
             {
               ios: 18,
+              artifact: "16.4",
               xcode: "16.4",
               macos: 15,
               iphone: "iPhone 16 Pro",
@@ -139,13 +143,15 @@ jobs:
             },
             {
               ios: 26,
-              xcode: "16.4",
+              artifact: "16.4",
+              xcode: "26.1",
               macos: 26,
               iphone: "iPhone 17 Pro",
               os: "26.0",
             },
             {
               ios: "26e",
+              artifact: "26.1",
               xcode: "26.1",
               macos: 26,
               iphone: "iPhone 16e",
@@ -158,7 +164,7 @@ jobs:
       - name: Download a single artifact
         uses: actions/download-artifact@v4
         with:
-          name: ios-e2e-ipa-xcode${{ matrix.devices.xcode }}
+          name: ios-e2e-ipa-xcode${{ matrix.devices.artifact }}
           path: example/ios/build/Build/Products/Release-iphonesimulator/KeyboardControllerExample.app/
       - uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
## 📜 Description

Fixed failing CI.

## 💡 Motivation and Context

XCode 16.4 is removed from macOS 26 runners. We want to test a specific flow, when app is built with XCode 16 but runs on iOS 26. For that we already build app on different XCodes. But in reality we can use ANY xcode for e2e tests.

So in this PR I'm using compatible XCode version, but for each workflow I'm using different artifacts. It fixes the failing CI and e2e iOS tests can pass again.

Preparation for https://github.com/actions/runner-images/issues/13345

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- added `artifact` param
- use xcode 26 on macos 26

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="856" height="397" alt="image" src="https://github.com/user-attachments/assets/6f122a11-2fc6-44ea-b0d3-bd924f9c34ee" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
