### PR TITLE
fix: publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ name: 🌐 Publish Package to npmjs
 on:
   release:
     types: [created]
-  pull_request:
-    paths:
-      - ".github/workflows/publish.yml"
   workflow_dispatch:
 jobs:
   publish:


### PR DESCRIPTION
## 📜 Description

Fixed publishing workflow.

## 💡 Motivation and Context

Recently npmjs restricted usage of classic tokens. As a result all workflows that were dependent on it are failing now.

In this PR I'm migrating to the official way of publishing packages from GH actions.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- don't use access tokens;
- use Node 24.x

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="860" height="334" alt="image" src="https://github.com/user-attachments/assets/7108ce6f-9f6f-47e4-8bed-dd70667c1b85" />

<img width="781" height="493" alt="image" src="https://github.com/user-attachments/assets/df58c9ee-4433-4719-a776-008f02ec6169" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
