### PR TITLE
refactor: move `KeyboardProvider` props in separate file

### DIFF
--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -30,6 +30,7 @@ import type { KeyboardAnimationContext } from "./context";
 import type {
   FocusedInputLayoutChangedEvent,
   KeyboardControllerProps,
+  KeyboardProviderProps,
   NativeEvent,
 } from "./types";
 import type { ViewStyle } from "react-native";
@@ -54,50 +55,6 @@ const styles = StyleSheet.create<Styles>({
     position: "absolute",
   },
 });
-
-type KeyboardProviderProps = {
-  children: React.ReactNode;
-  /**
-   * Set the value to `true`, if you use translucent status bar on Android.
-   * If you already control status bar translucency via `react-native-screens`
-   * or `StatusBar` component from `react-native`, you can ignore it.
-   * Defaults to `false`.
-   *
-   * @platform android
-   * @see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/14
-   */
-  statusBarTranslucent?: boolean;
-  /**
-   * Set the value to `true`, if you use translucent navigation bar on Android.
-   * Defaults to `false`.
-   *
-   * @platform android
-   * @see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/119
-   */
-  navigationBarTranslucent?: boolean;
-  /**
-   * A boolean property indicating whether to keep edge-to-edge mode always enabled (even when you disable the module).
-   * Defaults to `false`.
-   *
-   * @platform android
-   * @see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/592
-   */
-  preserveEdgeToEdge?: boolean;
-  /**
-   * A boolean prop indicating whether the module is enabled. It indicate only initial state
-   * (if you try to change this prop after component mount it will not have any effect).
-   * To change the property in runtime use `useKeyboardController` hook and `setEnabled` method.
-   * Defaults to `true`.
-   */
-  enabled?: boolean;
-  /**
-   * A boolean prop indicating whether to preload the keyboard to reduce time-to-interaction (TTI) on first input focus.
-   * Defaults to `true`.
-   *
-   * @platform ios
-   */
-  preload?: boolean;
-};
 
 // capture `Platform.OS` in separate variable to avoid deep workletization of entire RN package
 // see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/393 and https://github.com/kirillzyusko/react-native-keyboard-controller/issues/294 for more details

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./hooks";
 export * from "./views";
 export * from "./module";
 export * from "./internal";
+export * from "./provider";

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -1,0 +1,43 @@
+export type KeyboardProviderProps = {
+  children: React.ReactNode;
+  /**
+   * Set the value to `true`, if you use translucent status bar on Android.
+   * If you already control status bar translucency via `react-native-screens`
+   * or `StatusBar` component from `react-native`, you can ignore it.
+   * Defaults to `false`.
+   *
+   * @platform android
+   * @see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/14
+   */
+  statusBarTranslucent?: boolean;
+  /**
+   * Set the value to `true`, if you use translucent navigation bar on Android.
+   * Defaults to `false`.
+   *
+   * @platform android
+   * @see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/119
+   */
+  navigationBarTranslucent?: boolean;
+  /**
+   * A boolean property indicating whether to keep edge-to-edge mode always enabled (even when you disable the module).
+   * Defaults to `false`.
+   *
+   * @platform android
+   * @see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/592
+   */
+  preserveEdgeToEdge?: boolean;
+  /**
+   * A boolean prop indicating whether the module is enabled. It indicate only initial state
+   * (if you try to change this prop after component mount it will not have any effect).
+   * To change the property in runtime use `useKeyboardController` hook and `setEnabled` method.
+   * Defaults to `true`.
+   */
+  enabled?: boolean;
+  /**
+   * A boolean prop indicating whether to preload the keyboard to reduce time-to-interaction (TTI) on first input focus.
+   * Defaults to `true`.
+   *
+   * @platform ios
+   */
+  preload?: boolean;
+};


### PR DESCRIPTION
## 📜 Description

Moved props declaration to a separate file.

## 💡 Motivation and Context

Web implementation for `KeyboardProvider` will have a separate implementation and we need to re-use types, so in this PR I'm moving types into separate file to make it reusable.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- move `KeyboardProviderProps` in `types/provider.ts` file;

## 🤔 How Has This Been Tested?

Tested via CI (this PR);

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
