### PR TITLE
refactor: change conditional code in `KeyboardAvoidingView`

### DIFF
--- a/src/components/KeyboardAvoidingView/hooks.ts
+++ b/src/components/KeyboardAvoidingView/hooks.ts
@@ -88,7 +88,7 @@ export const useTranslateAnimation = () => {
       onMove: (e) => {
         "worklet";
 
-        if (OS === "android") {
+        if (OS !== "ios") {
           translate.value = e.progress;
         }
       },
@@ -104,7 +104,7 @@ export const useTranslateAnimation = () => {
 
         padding.value = e.progress;
 
-        if (OS === "android") {
+        if (OS !== "ios") {
           translate.value = e.progress;
         }
       },


### PR DESCRIPTION
## 📜 Description

Compare `OS` only with `ios` string.

## 💡 Motivation and Context

We want `KeyboardAvoidingView` to have `translate` specific behavior only for iOS (because only this platform can smoothly animate instant changes). Before we were comparing `OS` with `android` to make it "android specific" behavior, but in reality it should be "non-iOS behavior", so i'm flipping the condition in this PR.

Since we support only two platforms it shouldn't make any difference, but for web which will work in the same way as android it makes a lot of sense, because otherwise it will not be able to animate it properly.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- flip `OS === "android"` into `OS !== "ios"` condition;

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
