### PR TITLE
ci: track changes in `common` for fabric-related jobs

### DIFF
--- a/.github/workflows/build-android-fabric.yml
+++ b/.github/workflows/build-android-fabric.yml
@@ -12,6 +12,7 @@ on:
       - "FabricExample/yarn.lock"
       - "FabricExample/patches/**"
       - "src/specs/**"
+      - "common/**"
   pull_request:
     paths:
       - ".github/workflows/build-android-fabric.yml"
@@ -21,6 +22,7 @@ on:
       - "FabricExample/yarn.lock"
       - "FabricExample/patches/**"
       - "src/specs/**"
+      - "common/**"
 
 jobs:
   build:

--- a/.github/workflows/build-ios-fabric.yml
+++ b/.github/workflows/build-ios-fabric.yml
@@ -13,6 +13,7 @@ on:
       - "FabricExample/yarn.lock"
       - "FabricExample/patches/**"
       - "src/specs/**"
+      - "common/**"
   pull_request:
     branches:
       - main
@@ -25,6 +26,7 @@ on:
       - "FabricExample/yarn.lock"
       - "FabricExample/patches/**"
       - "src/specs/**"
+      - "common/**"
 
 jobs:
   build:


### PR DESCRIPTION
## 📜 Description

Added `common` directory for fabric jobs (build).

## 💡 Motivation and Context

In `common` we have a shared c++ code that is used for both iOS/Android (on fabric). So in this PR I added missing path to trigger corresponding jobs when code inside directory changes.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- track `common` for iOS/Android builds (fabric only);

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
