### PR TITLE
fix: navigation in iOS hybrid app

### DIFF
--- a/ios/observers/movement/KeyboardTrackingView.swift
+++ b/ios/observers/movement/KeyboardTrackingView.swift
@@ -68,9 +68,9 @@ public final class KeyboardTrackingView: UIView {
   @objc public func attachToTopmostView(toWindow window: UIWindow? = nil) {
     var topViewController = window?.rootViewController
     if let rootVC = topViewController, let topView = rootVC.view, topView.window != nil {
-        // ok, attach
+      // ok, attach
     } else {
-        topViewController = UIApplication.topViewController()
+      topViewController = UIApplication.topViewController()
     }
 
     guard let topView = topViewController?.view else { return }


### PR DESCRIPTION
## 📜 Description

Fixed a problem of non-working `onMove` handler on iOS if package is used in hybrid app on iOS 26.

## 💡 Motivation and Context

The problem is that we pick up a wrong controller. In case when you navigate from hybrid app to RN app `rootViewController` may point to old view controller that belongs to native app (which will be dismissed). If we attach a view to the controller that has been detached - we will not attach it to active window, because `willMove(to window` will never be called (because old controller will not be attached to the window again).

To fix this error I added a check to attach tracking view to `rootViewController` only if its window is active (i. e. `!= nil`). Otherwise we need to attach it `topViewController`.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- use `topViewController` if `rootViewController.view.window == nil`

## 🤔 How Has This Been Tested?

Tested in Expensify app.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/8debcf3d-a105-4080-94b8-bf421fb2300a">|<video src="https://github.com/user-attachments/assets/4fa88ea8-a996-4392-985a-694d5f390d19">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
