### PR TITLE
ci: show list of simulators to avoid CI errors due to missing simulator

### DIFF
--- a/.github/workflows/build-ios-fabric.yml
+++ b/.github/workflows/build-ios-fabric.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "16.4"
+      - name: List all available simulators
+        run: xcrun simctl list
 
       - name: Get yarn cache directory path
         id: fabric-yarn-cache-dir-path

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "16.4"
+      - name: List all available simulators
+        run: xcrun simctl list
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/verify-ios.yml
+++ b/.github/workflows/verify-ios.yml
@@ -66,6 +66,8 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "16.4"
+      - name: List all available simulators
+        run: xcrun simctl list
 
       - name: Install xcpretty
         run: gem install xcpretty


### PR DESCRIPTION
## 📜 Description

Added a job for requesting available simulators before proceeding to builds.

## 💡 Motivation and Context

As described in https://github.com/actions/runner-images/issues/12948 I added a logger for querying all devices before making any builds commands.

For example sometimes this step may take 1 minute to complete, but will list all available devices and will complete job successfully:

<img width="1290" height="311" alt="image" src="https://github.com/user-attachments/assets/6e3ae7d5-a7d0-4b96-bf5a-08c953ba2d4a" />

If job is not failing this step executed very fast:

<img width="1292" height="256" alt="image" src="https://github.com/user-attachments/assets/62c63979-e979-402b-951b-b1b84501b98b" />

So let's keep this job (it's used not only for debugging step, but also helps to fix random failures).

Workaround for https://github.com/actions/runner-images/issues/12948

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- run `xcrun simctl list` before XCode builds;

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="262" height="96" alt="image" src="https://github.com/user-attachments/assets/0343dd42-71bb-493b-ae3a-2af49e0b4734" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
