### PR TITLE
fix: do not use `emitDeviceEvent` directly

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ThemedReactContext.kt
@@ -47,7 +47,7 @@ fun ThemedReactContext?.keepShadowNodesInSync(viewId: Int) {
   val onAnimationEndedData = Arguments.createMap()
   onAnimationEndedData.putArray("tags", tagsArray)
 
-  this?.reactApplicationContext?.emitDeviceEvent("onUserDrivenAnimationEnded", onAnimationEndedData)
+  this.emitEvent("onUserDrivenAnimationEnded", onAnimationEndedData)
 }
 
 val ThemedReactContext?.appearance: String


### PR DESCRIPTION
## 📜 Description

Fixed compilation error on RN 0.70

## 💡 Motivation and Context

`emitDeviceEvent` is available only on RN 0.72+ Similar changes were made here: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/475

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1281

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- use `emitEvent` extension method instead of `emitDeviceEvent`;

## 🤔 How Has This Been Tested?

Tested manually via this PR.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
