### PR TITLE
refactor: add `useCombinedRef` to separate the code logically

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -23,6 +23,7 @@ import {
   useWindowDimensions,
 } from "../../hooks";
 import { findNodeHandle } from "../../utils/findNodeHandle";
+import useCombinedRef from "../hooks/useCombinedRef";
 
 import { useSmoothKeyboardHandler } from "./useSmoothKeyboardHandler";
 import { debounce, scrollDistanceWithRespectToSnapPoints } from "./utils";
@@ -127,6 +128,7 @@ const KeyboardAwareScrollView = forwardRef<
   ) => {
     const scrollViewAnimatedRef = useAnimatedRef<Reanimated.ScrollView>();
     const scrollViewRef = React.useRef<ScrollView>(null);
+    const onRef = useCombinedRef(scrollViewAnimatedRef, scrollViewRef);
     const scrollViewTarget = useSharedValue<number | null>(null);
     const scrollPosition = useSharedValue(0);
     const position = useScrollViewOffset(scrollViewAnimatedRef);
@@ -143,11 +145,6 @@ const KeyboardAwareScrollView = forwardRef<
 
     const { height } = useWindowDimensions();
 
-    const onRef = useCallback((assignedRef: Reanimated.ScrollView) => {
-      scrollViewRef.current = assignedRef;
-
-      scrollViewAnimatedRef(assignedRef);
-    }, []);
     const onScrollViewLayout = useCallback(
       (e: LayoutChangeEvent) => {
         scrollViewTarget.value = findNodeHandle(scrollViewAnimatedRef.current);

--- a/src/components/hooks/useCombinedRef.ts
+++ b/src/components/hooks/useCombinedRef.ts
@@ -1,0 +1,22 @@
+import { useCallback } from "react";
+
+import type { Ref, RefCallback } from "react";
+
+const useCombinedRef = <T>(...refs: Ref<T>[]): RefCallback<T> => {
+  return useCallback((value: T | null) => {
+    for (const ref of refs) {
+      if (!ref) {
+        continue;
+      }
+
+      if (typeof ref === "function") {
+        ref(value);
+      } else {
+        ref.current = value;
+      }
+    }
+    // eslint-disable-next-line react-compiler/react-compiler
+  }, refs);
+};
+
+export default useCombinedRef;


### PR DESCRIPTION
## 📜 Description

Added `useCombinedRef` hook.

## 💡 Motivation and Context

At the moment this hook extract reusable logic from `KeyboardAwareScrollView` into reusable hook.

In future we'll have more components that share this re-usable logic (i. e. we need internal ref + expose ref to public), so in this small PR I introduce a new hook that helps to avoid duplicated code (and additionally it makes `KeyboardAwareScrollView` codebase slightly smaller).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `useCombinedRef`;
- use `useCombinedRef` in `KeyboardAwareScrollView`;

## 🤔 How Has This Been Tested?

Tested manually via this PR.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
