### PR TITLE
ci: do not use shared derived data between different xcodes

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -93,9 +93,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: example/ios/build
-          key: ${{ runner.os }}-e2e-derived-data-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock', '**/package.json', '**/yarn.lock') }}-xcode-${{ matrix.config.xcode }}
+          key: ${{ runner.os }}-e2e-derived-data-xcode-${{ matrix.config.xcode }}-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock', '**/package.json', '**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-e2e-derived-data-
+            ${{ runner.os }}-e2e-derived-data-xcode-${{ matrix.config.xcode }}-
       - name: Build app
         working-directory: e2e
         run: yarn build-example:ios


### PR DESCRIPTION
## 📜 Description

Use separate derived cache for separate xcode versions.

## 💡 Motivation and Context

A fix for https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1274

We speed up a build for XCode 16.4, but fabric build consumed XCode 16.4 Derived Data and it was slowing down it significantly.

In this PR we start to manage separate build caches (as it was originally intended).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- use proper key for restoring derived data to take XCode version into consideration.

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="1521" height="869" alt="image" src="https://github.com/user-attachments/assets/4dcd4f23-e37d-4888-8560-9eafc1535448" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
