### PR TITLE
ci: use better restore keys for derived data (iOS builds)

### DIFF
--- a/.github/workflows/build-ios-fabric.yml
+++ b/.github/workflows/build-ios-fabric.yml
@@ -98,9 +98,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: FabricExample/ios/build
-          key: ${{ runner.os }}-fabric-derived-data-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock', '**/package.json', '**/yarn.lock') }}-xcode-${{ env.XCODE_VERSION }}
+          key: ${{ runner.os }}-fabric-derived-data-xcode-${{ env.XCODE_VERSION }}-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock', '**/package.json', '**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-fabric-derived-data
+            ${{ runner.os }}-fabric-derived-data-xcode-${{ env.XCODE_VERSION }}-
       - name: Install xcpretty
         run: gem install xcpretty
       - name: Build App

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -96,9 +96,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: example/ios/build
-          key: ${{ runner.os }}-derived-data-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock', '**/package.json', '**/yarn.lock') }}-xcode-${{ env.XCODE_VERSION }}
+          key: ${{ runner.os }}-derived-data-xcode-${{ env.XCODE_VERSION }}-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock', '**/package.json', '**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-derived-data-
+            ${{ runner.os }}-derived-data-xcode-${{ env.XCODE_VERSION }}-
       - name: Build App
         run: "set -o pipefail && xcodebuild \
           CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \


### PR DESCRIPTION
## 📜 Description

Don't restore build cache if xcode version has been changed.

## 💡 Motivation and Context

If we change XCode version then we may consume the derived data from old xcode version. This PR assures that we will not restore derived data if xcode version has been changed 🤞 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- use better restore keys for derived data (iOS builds).

## 🤔 How Has This Been Tested?

Tested manually via this PR.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
