### PR TITLE
fix: wrong `onInteractive` event when keyboard closed on iOS 26+ with attached `KeyboardGestureArea`

### DIFF
--- a/ios/observers/movement/observer/KeyboardMovementObserver+Interactive.swift
+++ b/ios/observers/movement/observer/KeyboardMovementObserver+Interactive.swift
@@ -30,6 +30,10 @@ extension KeyboardMovementObserver {
       return
     }
 
+    if KeyboardEventsIgnorer.shared.shouldIgnore {
+      return
+    }
+
     let position = keyboardTrackingView.interactive(point: changeValue)
 
     if position == KeyboardTrackingView.invalidPosition {


### PR DESCRIPTION
## 📜 Description

Fixed undesired `onInteractive` event during keyboard dismissal (non interactive).

## 💡 Motivation and Context

It looks like on iOS 26 timings are different than on previous iOS versions and now when we detach `InvisibleAccessoryView` we may get a KVO event listener (that will report invalid keyboard frame).

To avoid that I added a condition that will ignore this interactive event if you dismiss keyboard with attached `InvisibleAccessoryView`.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1298

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- use `KeyboardEventsIgnored` in KVO;

## 🤔 How Has This Been Tested?

Tested manually in example project.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="857" height="72" alt="image" src="https://github.com/user-attachments/assets/dccaed3b-33e6-4b72-86a5-e44766808362" />|<img width="667" height="48" alt="image" src="https://github.com/user-attachments/assets/4a7a21a9-5acb-45e6-a80f-70b855f0d8f3" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
