### PR TITLE
fix: call `maybeScroll` in `onEnd` handler in `KeyboardAwareScrollView`

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -462,6 +462,8 @@ const KeyboardAwareScrollView = forwardRef<
         onEnd: (e) => {
           "worklet";
 
+          maybeScroll(e.height);
+
           removeGhostPadding(e.height);
 
           keyboardHeight.value = e.height;

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -462,7 +462,10 @@ const KeyboardAwareScrollView = forwardRef<
         onEnd: (e) => {
           "worklet";
 
-          maybeScroll(e.height);
+          // if the user has set disableScrollOnKeyboardHide, only auto-scroll when the keyboard opens
+          if (!disableScrollOnKeyboardHide || keyboardWillAppear.value) {
+            maybeScroll(e.height);
+          }
 
           removeGhostPadding(e.height);
 


### PR DESCRIPTION
## 📜 Description

Call `maybeScroll` in `onEnd` handler.

## 💡 Motivation and Context

The `onMove` can be missing because of many things:
- resize event;
- enabled a11y with reduced motion on Android;
- iOS 15 may not have enough `onMove` keyboard events on first app start.

So in this PR I added `maybeScroll` call in `onEnd`. Before we were avoiding this, because on iOS we could have a situation when `end` event arrives before `start` but it has been fixed in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1161 so it should be safe to do now 🤞 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- call `maybeScroll(e, false)` in `onEnd` handler'

## 🤔 How Has This Been Tested?

Tested via e2e tests 🤞 

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/25c10f74-7f27-41d8-8f95-ec74565bb6de" />|<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/b92fbf66-1ba8-4452-9e62-b8eb66dfa2e0" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
