### PR TITLE
fix: `KeyboardAwareScrollView` loosing ref identity

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -497,11 +497,18 @@ const KeyboardAwareScrollView = forwardRef<
       () => {
         const scrollView = scrollViewRef.current;
 
-        const existingMethods = scrollView ? { ...scrollView } : {};
+        if (scrollView) {
+          const scrollViewWithMethods =
+            scrollView as KeyboardAwareScrollViewRef;
+
+          scrollViewWithMethods.assureFocusedInputVisible = () => {
+            synchronize();
+          };
+
+          return scrollViewWithMethods;
+        }
 
         return {
-          ...existingMethods,
-
           assureFocusedInputVisible: () => {
             synchronize();
           },


### PR DESCRIPTION
## 📜 Description

Fixing loosing `ref` identity for `KeyboardAwareScrollView` on RN 0.83+

## 💡 Motivation and Context

We were re-creating ref. However starting from RN 0.83 it's not allowed, see: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1317

In this PR we just extend existing ref with new method. This was a suggested fix and according to e2e pipeline it works and works well 🤞 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1317

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- inject new method into ref instead of re-creating it;

## 🤔 How Has This Been Tested?

Tested by e2e test.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
