### PR TITLE
fix(ios): guard delayed manual keyboard did events by current keyboard state

### DIFF
--- a/ios/observers/movement/observer/KeyboardMovementObserver+Lifecycle.swift
+++ b/ios/observers/movement/observer/KeyboardMovementObserver+Lifecycle.swift
@@ -29,6 +29,11 @@ public extension KeyboardMovementObserver {
 
   @objc func unmount() {
     isMounted = false
+    keyboardDidTask?.cancel()
+    keyboardDidTask = nil
+    notification = nil
+    removeKeyboardWatcher()
+    removeKVObserver()
     // swiftlint:disable:next notification_center_detachment
     NotificationCenter.default.removeObserver(self)
   }

--- a/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
+++ b/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
@@ -6,6 +6,32 @@
 //
 
 extension KeyboardMovementObserver {
+  private func emitKeyboardDidAppear(height: CGFloat, duration: Int) {
+    let progress = 1.0
+
+    onCancelAnimation()
+    onEvent("onKeyboardMoveEnd", height as NSNumber, progress as NSNumber, duration as NSNumber, tag)
+    onNotify("KeyboardController::keyboardDidShow", buildEventParams(height, duration, tag))
+
+    removeKeyboardWatcher()
+    setupKVObserver()
+    animation = nil
+  }
+
+  private func emitKeyboardDidDisappear(duration: Int) {
+    onCancelAnimation()
+    onEvent("onKeyboardMoveEnd", 0 as NSNumber, 0, duration as NSNumber, tag)
+    onNotify("KeyboardController::keyboardDidHide", buildEventParams(0, duration, tag))
+
+    removeKeyboardWatcher()
+    animation = nil
+  }
+
+  private func currentKeyboardHeight() -> CGFloat {
+    let (visibleKeyboardHeight, _) = keyboardTrackingView.view.frameTransitionInWindow
+    return max(CGFloat(visibleKeyboardHeight) - KeyboardAreaExtender.shared.offset, 0)
+  }
+
   @objc func keyboardWillAppear(_ notification: Notification) {
     guard !UIResponder.isKeyboardPreloading else { return }
 
@@ -63,17 +89,7 @@ extension KeyboardMovementObserver {
       tag = UIResponder.current.reactViewTag
       self.keyboardHeight = keyboardHeight
 
-      let height = self.keyboardHeight
-      // always limit progress to the maximum possible value
-      let progress = min(height / self.keyboardHeight, 1.0)
-
-      onCancelAnimation()
-      onEvent("onKeyboardMoveEnd", height as NSNumber, progress as NSNumber, duration as NSNumber, tag)
-      onNotify("KeyboardController::keyboardDidShow", buildEventParams(height, duration, tag))
-
-      removeKeyboardWatcher()
-      setupKVObserver()
-      animation = nil
+      emitKeyboardDidAppear(height: self.keyboardHeight, duration: duration)
 
       NotificationCenter.default.post(
         name: .keyboardDidAppear, object: notification, userInfo: nil
@@ -86,16 +102,14 @@ extension KeyboardMovementObserver {
     let (duration, _) = notification.keyboardMetaData()
     tag = UIResponder.current.reactViewTag
 
-    onCancelAnimation()
-    onEvent("onKeyboardMoveEnd", 0 as NSNumber, 0, duration as NSNumber, tag)
-    onNotify("KeyboardController::keyboardDidHide", buildEventParams(0, duration, tag))
-
-    removeKeyboardWatcher()
-    animation = nil
+    emitKeyboardDidDisappear(duration: duration)
   }
 
-  @objc func scheduleDidEvent(height: CGFloat, duration: CGFloat) {
+  @objc func scheduleDidEvent(height targetHeight: CGFloat, duration: CGFloat) {
     keyboardDidTask?.cancel()
+    keyboardDidEventID += 1
+    let eventID = keyboardDidEventID
+    _ = targetHeight
 
     guard let notification = notification else {
       return
@@ -103,10 +117,21 @@ extension KeyboardMovementObserver {
 
     let task = DispatchWorkItem { [weak self] in
       guard let self = self else { return }
-      if height > 0 {
-        self.keyboardDidAppear(notification)
+      guard self.isMounted, eventID == self.keyboardDidEventID else { return }
+
+      let duration = self.duration
+      let currentHeight = self.currentKeyboardHeight()
+      self.tag = UIResponder.current.reactViewTag
+
+      if currentHeight > 0 {
+        self.keyboardHeight = currentHeight
+        self.emitKeyboardDidAppear(height: currentHeight, duration: duration)
+
+        NotificationCenter.default.post(
+          name: .keyboardDidAppear, object: notification, userInfo: nil
+        )
       } else {
-        self.keyboardDidDisappear(notification)
+        self.emitKeyboardDidDisappear(duration: duration)
       }
     }
 

--- a/ios/observers/movement/observer/KeyboardMovementObserver.swift
+++ b/ios/observers/movement/observer/KeyboardMovementObserver.swift
@@ -37,6 +37,7 @@ public class KeyboardMovementObserver: NSObject {
   // manual did events
   var notification: Notification?
   var keyboardDidTask: DispatchWorkItem?
+  var keyboardDidEventID: UInt = 0
 
   @objc public init(
     handler: @escaping (NSString, NSNumber, NSNumber, NSNumber, NSNumber) -> Void,


### PR DESCRIPTION
## 📜 Description

Fix race condition in manual iOS `did` keyboard events introduced in #1161.

When navigating between screens, keyboard events may arrive in non-linear order (`willHide` -> `didShow` -> `didHide`). The last delayed `didHide` could incorrectly win and reset keyboard height to `0`, even when keyboard is already visible on the new screen.

This change keeps the manual `did` strategy from #1161, but validates actual keyboard state at delayed execution time.

## 💡 Motivation and Context

After upgrading to `1.20.6`, some navigation flows started producing incorrect keyboard offset on the next screen:

- keyboard is visible
- but computed offset is `0`
- content goes under keyboard

Root cause: delayed `DispatchWorkItem` tasks may execute out of logical order during responder/navigation transitions.

This PR prevents stale delayed events from overriding current keyboard state.

### Problem Statement (clear event order issue)

When navigating between screens, keyboard events can arrive in an invalid order:

1. `keyboard hide`
2. `keyboard show end`
3. `keyboard hide end`

As a result, the last processed event is `hide`, keyboard height is set to `0`, and offset is recalculated to `0`.
On the next screen, keyboard is visible, but bottom inset is not applied, so content goes under the keyboard.

### Reproduction

```ts
Keyboard.dismiss();

await wait(400);

// navigate to screen with auto-focus input
navigation.navigate(...);
```

Expected:
- final keyboard state should match visible keyboard (`height > 0`)
- bottom offset should remain applied on the destination screen

Actual before fix:
- delayed stale `didHide` may run last
- keyboard height/offset becomes `0` while keyboard is still visible

## 📢 Changelog

### iOS

- validate delayed `did` event against current keyboard visibility before emitting `didShow`/`didHide`
- add stale-task guard (`keyboardDidEventID`) so old delayed tasks cannot override newer state
- cancel pending delayed `did` tasks and clean up watchers/KVO on `unmount`
- keep manual `did` dispatch approach from #1161 (no rollback to system `keyboardDid*`)

## 🤔 How Has This Been Tested?

Tested manually on iOS navigation scenario with focused input:

1. Open screen A with focused input (keyboard visible).
2. Navigate quickly to screen B where input becomes focused.
3. Reproduce event interleaving where hide/show callbacks race.
4. Verify final state:
   - keyboard remains visible
   - `keyboardDidHide` does not incorrectly win
   - keyboard height/offset is not reset to `0`
   - content stays above keyboard on the new screen

Also verified `unmount` path does not emit late delayed `did` events from removed screen observer.

## 📸 Screenshots (if appropriate):

Before

https://github.com/user-attachments/assets/a69c43b3-11ce-4e98-a79f-fffe279b3bc3

After

https://github.com/user-attachments/assets/6df95ff8-355f-46c8-abc8-ef428963b6d2


## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
