### PR TITLE
fix: stable playwright CI job

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -165,7 +165,7 @@ const trustedBy = [
 
 function TrustedBy(): JSX.Element {
   return (
-    <section className={clsx(styles.trustedBySection)}>
+    <section className={clsx("playwright", styles.trustedBySection)}>
       <h2 className={clsx(styles.trustedByTitle)}>Trusted by</h2>
       <div className={clsx(styles.trustedByContainer)}>
         {trustedBy.map((item, index) => (


### PR DESCRIPTION
## 📜 Description

Hide Trusted By section, since images from PlayMarket are loaded asynchonously.

## 💡 Motivation and Context

It's necessary to prevent flakiness of `argos` job. At the moment it's very flacky on CI because images may be loaded asynchonously. This PR aims to fix it bu hiding those pictures in CI/e2e pipeline.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- hide "Trusted by" images in e2e pipeline;

## 🤔 How Has This Been Tested?

Tested manually via this PR.

## 📸 Screenshots (if appropriate):

<img width="1414" height="692" alt="image" src="https://github.com/user-attachments/assets/fbf03630-33ef-4925-89a0-7badf72fa296" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
