### PR TITLE
fix: automatically detect top border of `KeyboardAwareScrollView`

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -16,6 +16,7 @@ import Reanimated, {
   useSharedValue,
 } from "react-native-reanimated";
 
+import { KeyboardControllerNative } from "../../bindings";
 import {
   useFocusedInputHandler,
   useReanimatedFocusedInput,
@@ -155,15 +156,20 @@ const KeyboardAwareScrollView = forwardRef<
     const { height } = useWindowDimensions();
 
     const onScrollViewLayout = useCallback(
-      (e: LayoutChangeEvent) => {
-        scrollViewTarget.value = findNodeHandle(scrollViewAnimatedRef.current);
+      async (e: LayoutChangeEvent) => {
+        const handle = findNodeHandle(scrollViewAnimatedRef.current);
 
-        // @ts-expect-error something is wrong with the type of `measureInWindow`
-        scrollViewRef.current?.measureInWindow((_x, y) => {
-          scrollViewPageY.value = y;
-        });
+        scrollViewTarget.value = handle;
 
         onLayout?.(e);
+
+        if (handle !== null) {
+          const { y } = await KeyboardControllerNative.viewPositionInWindow(
+            handle,
+          );
+
+          scrollViewPageY.value = y;
+        }
       },
       [onLayout],
     );


### PR DESCRIPTION
## 📜 Description

Automatically detect top border of `KeyboardAwareScrollView`.

## 💡 Motivation and Context

Continue the epic with better discovery of component location on the screen and logical continuation of https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1346

In this PR I started to detect relative position of `ScrollView`, so that I better understand if caret is not visible because it obscured by other elements (header etc.) It's still not perfectly implemented and there is still a "blind"/"dead" zone where text is already hidden but scroll doesn't happen. I'll fix it in following PRs but for now I just want to bring these changes to upcoming `1.21.0` release 🤞 

We also can't use `measureInWindow` because it produces incorrect measurements, so we need to use our custom implementation that has been added in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1355

Significantly improves UI for behavior described in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1341

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- auto detect position of `KeyboardAwareScrollView` on the screen to better understand top border of the component relative to screen;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 17 Pro (iOS 26.2, simulator).

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/43fe233f-9c83-40c9-9642-a68e2d8e8e7c

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
