### PR TITLE
fix: typo in arch definition

### DIFF
--- a/ios/views/ClippingScrollViewDecoratorViewManager.mm
+++ b/ios/views/ClippingScrollViewDecoratorViewManager.mm
@@ -221,7 +221,7 @@ RCT_EXPORT_VIEW_PROPERTY(applyWorkaroundForContentInsetHitTestBug, BOOL)
   }
 }
 
-#ifdef RCT_NEW_ARCH_ENABLE
+#ifdef RCT_NEW_ARCH_ENABLED
 Class<RCTComponentViewProtocol> ClippingScrollViewDecoratorViewCls(void)
 {
   return ClippingScrollViewDecoratorView.class;


### PR DESCRIPTION
## 📜 Description

Changed `RCT_NEW_ARCH_ENABLE` to `RCT_NEW_ARCH_ENABLED`.

## 💡 Motivation and Context

In general I'm not sure how this code could be properly compiled. But anyway it's unintended typo and I'm fixing it here.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1366

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- Changed `RCT_NEW_ARCH_ENABLE` to `RCT_NEW_ARCH_ENABLED`.

## 🤔 How Has This Been Tested?

Verified by CI.

## 📸 Screenshots (if appropriate):

<img width="591" height="103" alt="image" src="https://github.com/user-attachments/assets/f489162b-8811-4298-bae7-ecc8a771edbe" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
