### PR TITLE
fix: could not fing view for tag warning

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -164,11 +164,15 @@ const KeyboardAwareScrollView = forwardRef<
         onLayout?.(e);
 
         if (handle !== null) {
-          const { y } = await KeyboardControllerNative.viewPositionInWindow(
-            handle,
-          );
+          try {
+            const { y } = await KeyboardControllerNative.viewPositionInWindow(
+              handle,
+            );
 
-          scrollViewPageY.value = y;
+            scrollViewPageY.value = y;
+          } catch {
+            // ignore
+          }
         }
       },
       [onLayout],


### PR DESCRIPTION
## 📜 Description

Silent `could not fing view for tag` warning for `KeyboardAwareScrollView` (similarly how it works for `KeyboardAvoidingView` now).

## 💡 Motivation and Context

This issue got introduced after https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1352 (which was based on https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1346)

In certain cases `onLayout` may be triggered but view may be not laid out yet (if you use it with `react-native-pager` lazy). Since changes in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1352 were purely additional (we try to understand the position of element on the screen, but before these changes we always assumed we were in the top of the screen) I decided to wrap it for now in `try/catch` block.

Silenting error is not a correct fix, but this is the best what we can do now - we will not spam logs when devs update the package (in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1346 we also used `catch` block), but yes, in certain cases detection of top border will not work (and it didn't work before, so it's fair enough to silent the error).

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1375

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- handle rejected promises within `try/catch` block;

## 🤔 How Has This Been Tested?

Tested via e2e tests, I didn't test changes manually because I don't have a repro.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
