### PR TITLE
perf: don't change `currentKeyboardFrame` each frame

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -412,6 +412,7 @@ const KeyboardAwareScrollView = forwardRef<
             keyboardWillChangeSize ||
             focusWasChanged
           ) {
+            syncKeyboardFrame(e);
             // persist scroll value
             scrollPosition.value = position.value;
             // just persist height - later will be used in interpolation
@@ -459,8 +460,6 @@ const KeyboardAwareScrollView = forwardRef<
         },
         onMove: (e) => {
           "worklet";
-
-          syncKeyboardFrame(e);
 
           if (removeGhostPadding(e.height)) {
             return;


### PR DESCRIPTION
## 📜 Description

Don't change keyboard padding in `KeyboardAwareScrollView` each frame as keyboard moves and do it only in the beginning of the animation (when keyboard appears) or in the end of the animation (when keyboard closed).

## 💡 Motivation and Context

After https://github.com/kirillzyusko/react-native-keyboard-controller/pull/797 introduced removal of `ghost padding` we don't need to change `inset` every frame. Instead we can use an optimized approach and:
- add full keyboard frame padding only in the beginning of the animation (when keyboard appears)
- remove  full keyboard frame padding when keyboard fully closed.

Roughly it gives us `2x` less load on UI thread because now we only need to adjust scroll position inside `onMove` handler. A similar approach is already used in `KeyboardChatScrollView` (we also change padding only one time there). So these changes just makes components consistent.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- don't change `currentKeyboardFrame` each frame;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 17 Pro (iOS 26.2, simulator), Pixel 7 Pro (API 36, real device).

## 📸 Screenshots (if appropriate):

|iOS|Android|
|---|--------|
|<video src="https://github.com/user-attachments/assets/9e5f72cc-b6c7-4ea5-999f-d5c56c046809">|<video src="https://github.com/user-attachments/assets/31f5a675-2de8-4136-91fe-7390364bbb97">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
