### PR TITLE
fix: `KeyboardAwareScrollView` regression after optimization

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -416,11 +416,12 @@ const KeyboardAwareScrollView = forwardRef<
             keyboardWillChangeSize ||
             focusWasChanged
           ) {
-            syncKeyboardFrame(e);
             // persist scroll value
             scrollPosition.value = position.value;
             // just persist height - later will be used in interpolation
             keyboardHeight.value = e.height;
+            // and update keyboard spacer size
+            syncKeyboardFrame(e);
           }
 
           // focus was changed


### PR DESCRIPTION
## 📜 Description

Call `syncKeyboardFrame` after `keyboardHeight` has been set.

## 💡 Motivation and Context

If we set call `syncKeyboardFrame` and `keyboardHeight = 0`, then interpolation simply doesn't work we interpolate between `[0, 0]` to `[0, 0]`, so we get `0`. This regression has been introduced after https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1381 changes and in this follow-up PR I'm fixing it 🤞 

The fix is quite straightforward - we just need to call `syncKeyboardFrame` after updating `keyboardHeight` variable.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1385

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- call `syncKeyboardFrame` after `keyboardHeight` has been set.

## 🤔 How Has This Been Tested?

Tested manually on iPhone 17 Pro (iOS 26.2).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/70e2fef8-81b0-455d-b877-98067dfd3965">|<video src="https://github.com/user-attachments/assets/08113d77-89b3-4b42-8d0e-f6334c05c602">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
