### PR TITLE
fix: remove unnecessary code

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -552,14 +552,8 @@ const KeyboardAwareScrollView = forwardRef<
       [],
     );
 
-    // animations become choppy when scrolling to the end of the `ScrollView` (when the last input is focused)
-    // this happens because the layout recalculates on every frame. To avoid this we slightly increase padding
-    // by `+1`. In this way we assure, that `scrollTo` will never scroll to the end, because it uses interpolation
-    // from 0 to `keyboardHeight`, and here our padding is `keyboardHeight + 1`. It allows us not to re-run layout
-    // re-calculation on every animation frame and it helps to achieve smooth animation.
-    // see: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/342
     const padding = useDerivedValue(
-      () => (enabled ? currentKeyboardFrameHeight.value + 1 : 0),
+      () => (enabled ? currentKeyboardFrameHeight.value : 0),
       [enabled],
     );
 


### PR DESCRIPTION
## 📜 Description

Removed a fix with increased padding by `+1`.

## 💡 Motivation and Context

This code has been added in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/342 But these changes became irrelevant after https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1381 Since we started to change frame to full-height frame once per the animation we no longer have a condition described in #342 

Additionally https://github.com/kirillzyusko/react-native-keyboard-controller/pull/332 is no longer reproducible, because in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/797 we already were fighting with "ghost view" issue and fix for this problem also fixes https://github.com/kirillzyusko/react-native-keyboard-controller/pull/332 (just in a different way).

So to sum it up:
- we no longer need to adjust spacer each frame;
- we no longer need a fix with artificial spacer increasing 🤞 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- don't apply `+1` to keyboard spacer size in `KeyboardAwareScrollView`;

## 🤔 How Has This Been Tested?

Tested manually on Redmi Note 5 Pro (Android 9).

## 📸 Screenshots (if appropriate):

|Current code|Latest main (before PR changes)|1.20.7 release|
|-------------|---------------------------------|-------------|
|<video src="https://github.com/user-attachments/assets/7ab3477c-eedd-42da-9af9-5bdb0c842284">|<video src="https://github.com/user-attachments/assets/8697e5e6-84d3-49c5-adb6-2d286cd9ccaa">|<video src="https://github.com/user-attachments/assets/37c9b30c-8aa8-470a-9255-8c4a3d752a95">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
