### PR TITLE
docs: add workaround for non-working `scrollToEnd`

### DIFF
--- a/FabricExample/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
+++ b/FabricExample/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
@@ -15,10 +15,12 @@ import {
   invertedContentContainerStyle,
 } from "./styles";
 
+import type { RefCallback } from "react";
 import type { SharedValue } from "react-native-reanimated";
 
 type VirtualizedListScrollViewProps = ScrollViewProps & {
   extraContentPadding?: SharedValue<number>;
+  chatScrollViewRef?: { current: VirtualizedListScrollViewRef | null };
 };
 
 export type VirtualizedListScrollViewRef = React.ElementRef<
@@ -28,50 +30,83 @@ export type VirtualizedListScrollViewRef = React.ElementRef<
 const VirtualizedListScrollView = forwardRef<
   VirtualizedListScrollViewRef,
   VirtualizedListScrollViewProps
->(({ onLayout: onLayoutProp, extraContentPadding, ...props }, ref) => {
-  const [layoutPass, setLayoutPass] = useState(0);
-  const { bottom } = useSafeAreaInsets();
-  const chatKitOffset = bottom - MARGIN;
-
-  const { inverted, freeze, mode, keyboardLiftBehavior } = useChatConfigStore();
-
-  // on new arch only FlatList supports `inverted` prop
-  const isInvertedSupported = inverted && mode === "flat" ? inverted : false;
-  const onLayout = useCallback(
-    (e: LayoutChangeEvent) => {
-      setLayoutPass((l) => l + 1);
-      onLayoutProp?.(e);
+>(
+  (
+    {
+      onLayout: onLayoutProp,
+      extraContentPadding,
+      chatScrollViewRef,
+      ...props
     },
-    [onLayoutProp],
-  );
-
-  return (
-    <>
-      <KeyboardChatScrollView
-        ref={ref}
-        automaticallyAdjustContentInsets={false}
-        contentContainerStyle={
-          isInvertedSupported
-            ? invertedContentContainerStyle
-            : contentContainerStyle
+    ref,
+  ) => {
+    const setScrollViewRef = useCallback(
+      (instance: VirtualizedListScrollViewRef | null) => {
+        if (chatScrollViewRef) {
+          // eslint-disable-next-line react-compiler/react-compiler
+          chatScrollViewRef.current =
+            instance as VirtualizedListScrollViewRef | null;
         }
-        contentInsetAdjustmentBehavior="never"
-        extraContentPadding={extraContentPadding}
-        freeze={freeze}
-        inverted={isInvertedSupported}
-        keyboardDismissMode="interactive"
-        keyboardLiftBehavior={keyboardLiftBehavior}
-        offset={chatKitOffset}
-        testID="chat.scroll"
-        onLayout={onLayout}
-        {...props}
-      />
-      <Text style={styles.counter} testID="layout_passes">
-        Layout pass: {layoutPass}
-      </Text>
-    </>
-  );
-});
+      },
+      [chatScrollViewRef],
+    );
+    const combinedRef: RefCallback<VirtualizedListScrollViewRef> = useCallback(
+      (instance) => {
+        if (typeof ref === "function") {
+          ref(instance);
+        } else if (ref) {
+          ref.current = instance;
+        }
+
+        setScrollViewRef(instance);
+      },
+      [ref, setScrollViewRef],
+    );
+    const [layoutPass, setLayoutPass] = useState(0);
+    const { bottom } = useSafeAreaInsets();
+    const chatKitOffset = bottom - MARGIN;
+
+    const { inverted, freeze, mode, keyboardLiftBehavior } =
+      useChatConfigStore();
+
+    // on new arch only FlatList supports `inverted` prop
+    const isInvertedSupported = inverted && mode === "flat" ? inverted : false;
+    const onLayout = useCallback(
+      (e: LayoutChangeEvent) => {
+        setLayoutPass((l) => l + 1);
+        onLayoutProp?.(e);
+      },
+      [onLayoutProp],
+    );
+
+    return (
+      <>
+        <KeyboardChatScrollView
+          ref={combinedRef}
+          automaticallyAdjustContentInsets={false}
+          contentContainerStyle={
+            isInvertedSupported
+              ? invertedContentContainerStyle
+              : contentContainerStyle
+          }
+          contentInsetAdjustmentBehavior="never"
+          extraContentPadding={extraContentPadding}
+          freeze={freeze}
+          inverted={isInvertedSupported}
+          keyboardDismissMode="interactive"
+          keyboardLiftBehavior={keyboardLiftBehavior}
+          offset={chatKitOffset}
+          testID="chat.scroll"
+          onLayout={onLayout}
+          {...props}
+        />
+        <Text style={styles.counter} testID="layout_passes">
+          Layout pass: {layoutPass}
+        </Text>
+      </>
+    );
+  },
+);
 
 const styles = StyleSheet.create({
   counter: {

--- a/FabricExample/src/screens/Examples/KeyboardChatScrollView/index.tsx
+++ b/FabricExample/src/screens/Examples/KeyboardChatScrollView/index.tsx
@@ -1,5 +1,5 @@
-import { LegendList, type LegendListRef } from "@legendapp/list";
-import { FlashList, type FlashListRef } from "@shopify/flash-list";
+import { LegendList } from "@legendapp/list";
+import { FlashList } from "@shopify/flash-list";
 import React, {
   useCallback,
   useEffect,
@@ -39,13 +39,10 @@ import VirtualizedListScrollView, {
   type VirtualizedListScrollViewRef,
 } from "./VirtualizedListScrollView";
 
-import type { MessageProps } from "../../../components/Message/types";
 import type { LayoutChangeEvent, ScrollViewProps } from "react-native";
 
 function KeyboardChatScrollViewPlayground() {
-  const legendRef = useRef<LegendListRef>(null);
-  const flashRef = useRef<FlashListRef<MessageProps>>(null);
-  const flatRef = useRef<FlatList<MessageProps>>(null);
+  const chatScrollViewRef = useRef<VirtualizedListScrollViewRef | null>(null);
   const scrollRef = useRef<VirtualizedListScrollViewRef>(null);
   const [text, setText] = useState("");
   const [inputHeight, setInputHeight] = useState(TEXT_INPUT_HEIGHT);
@@ -84,15 +81,7 @@ function KeyboardChatScrollViewPlayground() {
   }, [addMessage, text]);
 
   useEffect(() => {
-    legendRef.current?.scrollToOffset({
-      animated: true,
-      offset: Number.MAX_SAFE_INTEGER,
-    });
-    flashRef.current?.scrollToEnd({ animated: true });
-    flatRef.current?.scrollToOffset({
-      animated: true,
-      offset: Number.MAX_SAFE_INTEGER,
-    });
+    chatScrollViewRef.current?.scrollToEnd({ animated: true });
     scrollRef.current?.scrollToEnd({ animated: true });
   }, [messages]);
 
@@ -100,6 +89,7 @@ function KeyboardChatScrollViewPlayground() {
     (props: ScrollViewProps) => (
       <VirtualizedListScrollView
         {...props}
+        chatScrollViewRef={chatScrollViewRef}
         extraContentPadding={extraContentPadding}
       />
     ),
@@ -116,7 +106,6 @@ function KeyboardChatScrollViewPlayground() {
       >
         {mode === "legend" && (
           <LegendList
-            ref={legendRef}
             alignItemsAtEnd={inverted}
             contentContainerStyle={contentContainerStyle}
             data={messages}
@@ -128,7 +117,6 @@ function KeyboardChatScrollViewPlayground() {
         )}
         {mode === "flash" && (
           <FlashList
-            ref={flashRef}
             contentContainerStyle={contentContainerStyle}
             data={messages}
             keyExtractor={(item) => item.text}
@@ -141,7 +129,6 @@ function KeyboardChatScrollViewPlayground() {
         )}
         {mode === "flat" && (
           <FlatList
-            ref={flatRef}
             data={inverted ? reversedMessages : messages}
             inverted={inverted}
             keyExtractor={(item) => item.text}

--- a/docs/docs/api/components/keyboard-chat-scroll-view.mdx
+++ b/docs/docs/api/components/keyboard-chat-scroll-view.mdx
@@ -311,14 +311,52 @@ This issue can occur even if the state update comes from a different screen (e.g
 
 React Native's `FlatList.scrollToEnd()` calculates the scroll offset using `visibleLength` without accounting for the keyboard-adjusted layout. This means calling `listRef.current?.scrollToEnd()` may stop short of the actual end when the keyboard is visible.
 
-**Workaround:** call `scrollToEnd` on the underlying `KeyboardChatScrollView` instead of the `FlatList`. To do that, pass a separate `scrollViewRef` through your `renderScrollComponent` wrapper and use it for scrolling:
+**Workaround:** call `scrollToEnd` on the underlying `KeyboardChatScrollView` instead of the `FlatList`. Since `FlatList` internally assigns its own ref to the scroll component, you need a separate ref to reach it. Create a wrapper component that accepts a custom ref prop and forwards it alongside `FlatList`'s internal ref:
+
+```tsx ChatScrollView.tsx
+import { forwardRef, useCallback } from "react";
+import { KeyboardChatScrollView } from "react-native-keyboard-controller";
+
+import type { RefCallback } from "react";
+import type { ScrollViewProps } from "react-native";
+
+type ChatScrollViewRef = React.ElementRef<typeof KeyboardChatScrollView>;
+type ChatScrollViewProps = ScrollViewProps & {
+  chatScrollViewRef?: { current: ChatScrollViewRef | null };
+};
+
+const ChatScrollView = forwardRef<ChatScrollViewRef, ChatScrollViewProps>(
+  ({ chatScrollViewRef, ...props }, ref) => {
+    const combinedRef: RefCallback<ChatScrollViewRef> = useCallback(
+      (instance) => {
+        // forward to FlatList's internal ref
+        if (typeof ref === "function") {
+          ref(instance);
+        } else if (ref) {
+          ref.current = instance;
+        }
+
+        // forward to the user-provided ref
+        if (chatScrollViewRef) {
+          chatScrollViewRef.current = instance as ChatScrollViewRef | null;
+        }
+      },
+      [ref, chatScrollViewRef],
+    );
+
+    return <KeyboardChatScrollView ref={combinedRef} {...props} />;
+  },
+);
+```
+
+Then use it with `FlatList` via `renderScrollComponent`:
 
 ```tsx
-const scrollViewRef = useRef(null);
+const chatScrollViewRef = useRef<ChatScrollViewRef>(null);
 
 const renderScrollComponent = useCallback(
-  (props) => (
-    <KeyboardChatScrollView {...props} scrollViewRef={scrollViewRef} />
+  (props: ScrollViewProps) => (
+    <ChatScrollView {...props} chatScrollViewRef={chatScrollViewRef} />
   ),
   [],
 );
@@ -330,9 +368,5 @@ const renderScrollComponent = useCallback(
 />;
 
 // Instead of listRef.current?.scrollToEnd()
-scrollViewRef.current?.scrollToEnd();
+chatScrollViewRef.current?.scrollToEnd();
 ```
-
-:::note
-`FlatList` internally assigns its own ref to the component returned by `renderScrollComponent`. The `scrollViewRef` prop gives you a **second** ref to the same `KeyboardChatScrollView` instance so you can call `scrollToEnd` without interfering with `FlatList`'s internals.
-:::

--- a/docs/versioned_docs/version-1.21.0/api/components/keyboard-chat-scroll-view.mdx
+++ b/docs/versioned_docs/version-1.21.0/api/components/keyboard-chat-scroll-view.mdx
@@ -306,3 +306,67 @@ To fix this, enable the [DISABLE_COMMIT_PAUSING_MECHANISM](https://docs.swmansio
 :::info Do I need to enable this flag?
 This issue can occur even if the state update comes from a different screen (e.g. a parent navigator). To check, open the React Profiler and look for any React commits that happen just before the keyboard event — if you see one, you likely need this flag.
 :::
+
+### `scrollToEnd` doesn't scroll to the correct position when keyboard is open
+
+React Native's `FlatList.scrollToEnd()` calculates the scroll offset using `visibleLength` without accounting for the keyboard-adjusted layout. This means calling `listRef.current?.scrollToEnd()` may stop short of the actual end when the keyboard is visible.
+
+**Workaround:** call `scrollToEnd` on the underlying `KeyboardChatScrollView` instead of the `FlatList`. Since `FlatList` internally assigns its own ref to the scroll component, you need a separate ref to reach it. Create a wrapper component that accepts a custom ref prop and forwards it alongside `FlatList`'s internal ref:
+
+```tsx ChatScrollView.tsx
+import { forwardRef, useCallback } from "react";
+import { KeyboardChatScrollView } from "react-native-keyboard-controller";
+
+import type { RefCallback } from "react";
+import type { ScrollViewProps } from "react-native";
+
+type ChatScrollViewRef = React.ElementRef<typeof KeyboardChatScrollView>;
+type ChatScrollViewProps = ScrollViewProps & {
+  chatScrollViewRef?: { current: ChatScrollViewRef | null };
+};
+
+const ChatScrollView = forwardRef<ChatScrollViewRef, ChatScrollViewProps>(
+  ({ chatScrollViewRef, ...props }, ref) => {
+    const combinedRef: RefCallback<ChatScrollViewRef> = useCallback(
+      (instance) => {
+        // forward to FlatList's internal ref
+        if (typeof ref === "function") {
+          ref(instance);
+        } else if (ref) {
+          ref.current = instance;
+        }
+
+        // forward to the user-provided ref
+        if (chatScrollViewRef) {
+          chatScrollViewRef.current = instance as ChatScrollViewRef | null;
+        }
+      },
+      [ref, chatScrollViewRef],
+    );
+
+    return <KeyboardChatScrollView ref={combinedRef} {...props} />;
+  },
+);
+```
+
+Then use it with `FlatList` via `renderScrollComponent`:
+
+```tsx
+const chatScrollViewRef = useRef<ChatScrollViewRef>(null);
+
+const renderScrollComponent = useCallback(
+  (props: ScrollViewProps) => (
+    <ChatScrollView {...props} chatScrollViewRef={chatScrollViewRef} />
+  ),
+  [],
+);
+
+<FlatList
+  data={messages}
+  renderItem={renderItem}
+  renderScrollComponent={renderScrollComponent}
+/>;
+
+// Instead of listRef.current?.scrollToEnd()
+chatScrollViewRef.current?.scrollToEnd();
+```

--- a/example/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
+++ b/example/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useRef, useState } from "react";
+import React, { forwardRef, useCallback, useState } from "react";
 import {
   type LayoutChangeEvent,
   type ScrollViewProps,
@@ -15,12 +15,12 @@ import {
   invertedContentContainerStyle,
 } from "./styles";
 
-import type { Ref } from "react";
+import type { RefCallback } from "react";
 import type { SharedValue } from "react-native-reanimated";
 
 type VirtualizedListScrollViewProps = ScrollViewProps & {
   extraContentPadding?: SharedValue<number>;
-  scrollViewRef?: Ref<VirtualizedListScrollViewRef>;
+  chatScrollViewRef?: { current: VirtualizedListScrollViewRef | null };
 };
 
 export type VirtualizedListScrollViewRef = React.ElementRef<
@@ -32,30 +32,35 @@ const VirtualizedListScrollView = forwardRef<
   VirtualizedListScrollViewProps
 >(
   (
-    { onLayout: onLayoutProp, extraContentPadding, scrollViewRef, ...props },
+    {
+      onLayout: onLayoutProp,
+      extraContentPadding,
+      chatScrollViewRef,
+      ...props
+    },
     ref,
   ) => {
-    // combine FlatList's internal ref with the user-provided scrollViewRef
-    const scrollViewRefStable = useRef<Ref<VirtualizedListScrollViewRef>>(null);
-
-    scrollViewRefStable.current = scrollViewRef ?? null;
-    const combinedRef = useCallback(
+    const setScrollViewRef = useCallback(
       (instance: VirtualizedListScrollViewRef | null) => {
+        if (chatScrollViewRef) {
+          // eslint-disable-next-line react-compiler/react-compiler
+          chatScrollViewRef.current =
+            instance as VirtualizedListScrollViewRef | null;
+        }
+      },
+      [chatScrollViewRef],
+    );
+    const combinedRef: RefCallback<VirtualizedListScrollViewRef> = useCallback(
+      (instance) => {
         if (typeof ref === "function") {
           ref(instance);
         } else if (ref) {
           ref.current = instance;
         }
 
-        const svRef = scrollViewRefStable.current;
-
-        if (typeof svRef === "function") {
-          svRef(instance);
-        } else if (svRef) {
-          svRef.current = instance;
-        }
+        setScrollViewRef(instance);
       },
-      [ref, scrollViewRefStable],
+      [ref, setScrollViewRef],
     );
     const [layoutPass, setLayoutPass] = useState(0);
     const { bottom } = useSafeAreaInsets();

--- a/example/src/screens/Examples/KeyboardChatScrollView/index.tsx
+++ b/example/src/screens/Examples/KeyboardChatScrollView/index.tsx
@@ -1,4 +1,4 @@
-import { LegendList, type LegendListRef } from "@legendapp/list";
+import { LegendList } from "@legendapp/list";
 import { FlashList } from "@shopify/flash-list";
 import React, {
   useCallback,
@@ -40,13 +40,10 @@ import VirtualizedListScrollView, {
   type VirtualizedListScrollViewRef,
 } from "./VirtualizedListScrollView";
 
-import type { MessageProps } from "../../../components/Message/types";
 import type { LayoutChangeEvent, ScrollViewProps } from "react-native";
 
 function KeyboardChatScrollViewPlayground() {
-  const legendRef = useRef<LegendListRef>(null);
-  const flashRef = useRef<FlashList<MessageProps>>(null);
-  const flatRef = useRef<FlatList<MessageProps>>(null);
+  const chatScrollViewRef = useRef<VirtualizedListScrollViewRef | null>(null);
   const scrollRef = useRef<VirtualizedListScrollViewRef>(null);
   const textInputRef = useRef<TextInput>(null);
   const textRef = useRef("");
@@ -90,15 +87,7 @@ function KeyboardChatScrollViewPlayground() {
   }, [addMessage]);
 
   useEffect(() => {
-    legendRef.current?.scrollToOffset({
-      animated: true,
-      offset: Number.MAX_SAFE_INTEGER,
-    });
-    flashRef.current?.scrollToEnd({ animated: true });
-    flatRef.current?.scrollToOffset({
-      animated: true,
-      offset: Number.MAX_SAFE_INTEGER,
-    });
+    chatScrollViewRef.current?.scrollToEnd({ animated: true });
     scrollRef.current?.scrollToEnd({ animated: true });
   }, [messages]);
 
@@ -106,6 +95,7 @@ function KeyboardChatScrollViewPlayground() {
     (props: ScrollViewProps) => (
       <VirtualizedListScrollView
         {...props}
+        chatScrollViewRef={chatScrollViewRef}
         extraContentPadding={extraContentPadding}
       />
     ),
@@ -122,7 +112,6 @@ function KeyboardChatScrollViewPlayground() {
       >
         {mode === "legend" && (
           <LegendList
-            ref={legendRef}
             alignItemsAtEnd={inverted}
             contentContainerStyle={contentContainerStyle}
             data={messages}
@@ -134,7 +123,6 @@ function KeyboardChatScrollViewPlayground() {
         )}
         {mode === "flash" && (
           <FlashList
-            ref={flashRef}
             contentContainerStyle={
               inverted ? invertedContentContainerStyle : contentContainerStyle
             }
@@ -147,7 +135,6 @@ function KeyboardChatScrollViewPlayground() {
         )}
         {mode === "flat" && (
           <FlatList
-            ref={flatRef}
             data={inverted ? reversedMessages : messages}
             inverted={inverted}
             keyExtractor={(item) => item.text}


### PR DESCRIPTION
## 📜 Description

Added workaround for non-working `scrollToEnd` method for virtualized lists.

## 💡 Motivation and Context

This code in `FlatList` causes a problem:

```tsx
  // scrollToEnd may be janky without getItemLayout prop
  scrollToEnd(params?: ?{animated?: ?boolean, ...}) {
    const animated = params ? params.animated : true;
    const veryLast = this.props.getItemCount(this.props.data) - 1;
    if (veryLast < 0) {
      return;
    }
    const frame = this._listMetrics.getCellMetricsApprox(veryLast, this.props);
    const offset = Math.max(
      0,
      frame.offset +
        frame.length +
        this._footerLength -
        this._scrollMetrics.visibleLength,
    );

    // TODO: consider using `ref.scrollToEnd` directly
    this.scrollToOffset({animated, offset});
  }
```

So this function doesn't consider keyboard offset and because of that scrolls to wrong offset when keyboard is shown.

In this PR I explained how to pass a ref directly to underlying `ScrollView` and use `scrollToEnd` of `ScrollView` level. Additionally in example project I started to use it as well.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1357

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- pass `scrollRef` to `VirtualizedList` in example appl
- use `scrollTo` from `ScrollView` ref;

### Docs

- added a new item to troubleshooting guide;

## 🤔 How Has This Been Tested?

Tested manually in exampel app (paper/fabric).

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
