### PR TITLE
ci: try to use macos-15 for iOS 26 e2e tests

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -112,13 +112,13 @@ jobs:
       - name: Set matrix for PR or main
         id: set-matrix
         run: |
-          # if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Subset for PRs: Only ios 15, 26, 26e (adjust as needed)
-          #  echo 'matrix={"devices": [{"ios": 15, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "15.5", "iphone": "iPhone 13 Pro", "os": "15.5"}, {"ios": 17, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "17.5", "iphone": "iPhone 15 Pro", "os": "17.5"}, {"ios": "26e", artifact: "26.1", "xcode": "26.1", "macos": 15, "iphone": "iPhone 16e", "os": "26.1"}]}' >> $GITHUB_OUTPUT
-          #else
+            echo 'matrix={"devices": [{"ios": 15, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "15.5", "iphone": "iPhone 13 Pro", "os": "15.5"}, {"ios": 17, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "17.5", "iphone": "iPhone 15 Pro", "os": "17.5"}, {"ios": "26e", artifact: "26.1", "xcode": "26.1", "macos": 15, "iphone": "iPhone 16e", "os": "26.1"}]}' >> $GITHUB_OUTPUT
+          else
             # Full set for main
             echo 'matrix={"devices": [{"ios": 15, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "15.5", "iphone": "iPhone 13 Pro", "os": "15.5"}, {"ios": 16, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "16.4", "iphone": "iPhone 14 Pro", "os": "16.4"}, {"ios": 17, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "17.5", "iphone": "iPhone 15 Pro", "os": "17.5"}, {"ios": 18, artifact: "16.4", "xcode": "16.4", "macos": 15, "iphone": "iPhone 16 Pro", "os": "18.5"}, {"ios": 26, artifact: "16.4", "xcode": "26.0", "macos": 15, "iphone": "iPhone 17 Pro", "os": "26.2"}, {"ios": "26e", artifact: "26.1", "xcode": "26.1", "macos": 15, "iphone": "iPhone 16e", "os": "26.1"}]}' >> $GITHUB_OUTPUT
-          #fi
+          fi
   e2e-test:
     name: ⚙️ Automated test cases (iOS-${{ matrix.devices.ios }}, XCode-${{ matrix.devices.artifact }})
     runs-on: macos-${{ matrix.devices.macos }}


### PR DESCRIPTION
## 📜 Description

Use `macos-15` instead of `macos-26`.

## 💡 Motivation and Context

Looks like `macos-26` + iOS 26 are not stable yet at the moment: https://github.com/actions/runner-images/issues/13830

So in this PR I'm switching to `macos-15` instead. Also reverting https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1382 as it looks like it doesn't improve situation at all.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- removed changes introduced in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1382
- switch to `macos-15` instead of `macos-26`;

## 🤔 How Has This Been Tested?

Tested via this PR (2x run).

## 📸 Screenshots (if appropriate):

<img width="664" height="176" alt="image" src="https://github.com/user-attachments/assets/9d49733a-320e-41d4-8e21-105b58623c5b" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
