### PR TITLE
fix: `KeyboardChatScrollView` + `RefreshControl` conflict

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
@@ -1,6 +1,7 @@
 package com.reactnativekeyboardcontroller.views
 
 import android.annotation.SuppressLint
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
 import com.facebook.react.uimanager.ThemedReactContext
@@ -37,7 +38,7 @@ class ClippingScrollViewDecoratorView(
   }
 
   private fun decorateScrollView() {
-    val scrollView = getChildAt(0) as? ScrollView ?: return
+    val scrollView = findScrollView(this) ?: return
 
     scrollView.clipToPadding = false
 
@@ -65,5 +66,21 @@ class ClippingScrollViewDecoratorView(
     }
 
     appliedTopInsetPx = newTopInsetPx
+  }
+
+  private fun findScrollView(view: View?): ScrollView? {
+    var result: ScrollView? = null
+
+    if (view is ScrollView) {
+      result = view
+    } else if (view is ViewGroup) {
+      var i = 0
+      while (i < view.childCount && result == null) {
+        result = findScrollView(view.getChildAt(i))
+        i++
+      }
+    }
+
+    return result
   }
 }


### PR DESCRIPTION
## 📜 Description

Resolveda non-working `KeyboardChatScrollView` if it's used together with `RefreshControl`.

## 💡 Motivation and Context

If we use `RefreshControl` on Android it wraps whole `ScrollView`:

<img width="490" height="218" alt="image" src="https://github.com/user-attachments/assets/469c257e-ba83-4ff3-9be3-13fc019c1646" />

As a result `getChildAt(0)` will return `RefreshControl` view (not `ScrollView`) and whole decoration approach will fail.

To overcome this problem I added a small helper that traverse all children to find a necessary view to apply proper decoration. It fully fixes the problem.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1396

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added `findScrollView` helper;
- use `findScrollView` instead of `this.getChildAt(0)` for more reliable `ScrollView` detection;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 9 Pro API 35.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="239" height="496" alt="image" src="https://github.com/user-attachments/assets/7c938b6b-95d3-48fe-b5d0-3a634c37cc94" />|<img width="236" height="495" alt="image" src="https://github.com/user-attachments/assets/8285a0e0-51b1-4f3d-8f47-30a0de8a4f78" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
