### PR TITLE
fix: respect `UIDesignRequiresCompatibility` in `KeyboardExtenderCont…

### DIFF
--- a/ios/views/KeyboardExtenderContainerView.swift
+++ b/ios/views/KeyboardExtenderContainerView.swift
@@ -12,7 +12,10 @@ public class KeyboardExtenderContainerView: NSObject {
   @objc public static func create(frame: CGRect, contentView: UIView) -> UIView {
     #if canImport(UIKit.UIGlassEffect)
       if #available(iOS 26.0, *) {
-        return ModernContainerView(frame: frame, contentView: contentView)
+        let requiresCompat = Bundle.main.object(forInfoDictionaryKey: "UIDesignRequiresCompatibility") as? Bool ?? false
+        if !requiresCompat {
+          return ModernContainerView(frame: frame, contentView: contentView)
+        }
       }
     #endif
 


### PR DESCRIPTION
Closes #1401 

## Summary

- Check `UIDesignRequiresCompatibility` before using `ModernContainerView` on iOS 26+
- Fall back to `LegacyContainerView` when compatibility mode is enabled


## Before
<img width="250"  alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-26 at 13 17 40" src="https://github.com/user-attachments/assets/e3a93db9-15b3-43a3-a24e-cd64ffac8c6e" />

## After

<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-26 at 13 18 54" src="https://github.com/user-attachments/assets/3700fc52-5c7e-4a0d-9168-2c52a02e7626" />

## Test plan

- Set `UIDesignRequiresCompatibility` to `true` in `Info.plist`
- Run on iOS 26.2 simulator
- Verify `KeyboardExtender` renders without rounded corners


