### PR TITLE
fix: call `syncUpLayout` on iOS when keyboard changes its mode (emoji vs text)

### DIFF
--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -112,9 +112,16 @@ public class FocusedInputObserver: NSObject {
     NotificationCenter.default.removeObserver(self)
   }
 
-  @objc func didReceiveFocus(_: Notification) {
+  @objc func didReceiveFocus(_ notification: Notification) {
     if UIResponder.current == currentResponder {
-      // focus was already handled by keyboard event
+      // The same input is still focused — no need to re-run the full onFocus()
+      // setup (observers, delegate substitution, focusDidSet event). However,
+      // keyboardWillShowNotification also fires when the keyboard *resizes*
+      // (e.g. switching between text and emoji keyboards). In that case we must
+      // refresh the layout so consumers receive an up-to-date absoluteY.
+      if notification.name == UIResponder.keyboardWillShowNotification {
+        syncUpLayout()
+      }
       return
     }
 


### PR DESCRIPTION
## 📜 Description

Fixed a problem when switch text -> emoji -> text keeps pushing the content inside `KeyboardAwareScrollView` further and further.

## 💡 Motivation and Context

The issue has been introduced in this PR: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/760

The problem with:

```swift
if UIResponder.current == currentResponder {
  return
}
```

Is that when keyboard resizes we never emit `syncUpLayout` event. The fix proposed in this PR is safe, because:
- we don't run full input listeners mount cycle;
- we only emit additional event;
- it's safe to emit this event multiple times (i. e. two times on focus) because we have this guard:

```swift
    if NSDictionary(dictionary: data).isEqual(to: lastEventDispatched) {
      return
    }
```

Another attempt to fix it has been added here https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1407 But in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1407 we are trying to make JS code even more complex and the main problem is that with this fix documentation stays incorrect:

> when keyboard changes its size (appears, disappears, changes size because of different input mode);

So this is a better fix that fixes a native side of the platform.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1318 https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1407

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- dispatch `syncUpLayout` if this event comes from keyboard notification;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 17 Pro (iOS 26.2) paper arch.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/dab83232-e9c8-47f3-a128-5ebac517a9a4">|<video src="https://github.com/user-attachments/assets/50f74da1-a75f-458d-9f6f-e382fd688b0b">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
