### PR TITLE
feat: expose `isAtEnd` shared value from `KeyboardChatScrollView`

### DIFF
--- a/src/components/KeyboardChatScrollView/index.tsx
+++ b/src/components/KeyboardChatScrollView/index.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useCallback, useMemo } from "react";
 import { StyleSheet } from "react-native";
 import {
   makeMutable,
+  useAnimatedReaction,
   useAnimatedRef,
   useAnimatedStyle,
   useDerivedValue,
@@ -12,6 +13,7 @@ import useCombinedRef from "../hooks/useCombinedRef";
 import ScrollViewWithBottomPadding from "../ScrollViewWithBottomPadding";
 
 import { useChatKeyboard } from "./useChatKeyboard";
+import { isScrollAtEnd } from "./useChatKeyboard/helpers";
 import { useExtraContentPadding } from "./useExtraContentPadding";
 
 import type { KeyboardChatScrollViewProps } from "./types";
@@ -35,6 +37,7 @@ const KeyboardChatScrollView = forwardRef<
       extraContentPadding = ZERO_CONTENT_PADDING,
       blankSpace = ZERO_BLANK_SPACE,
       applyWorkaroundForContentInsetHitTestBug = false,
+      isAtEnd: isAtEndSV,
       onLayout: onLayoutProp,
       onContentSizeChange: onContentSizeChangeProp,
       ...rest
@@ -60,6 +63,27 @@ const KeyboardChatScrollView = forwardRef<
       blankSpace,
       extraContentPadding,
     });
+
+    useAnimatedReaction(
+      () => {
+        if (!isAtEndSV || layout.value.height <= 0 || size.value.height <= 0) {
+          return true;
+        }
+
+        return isScrollAtEnd(
+          scroll.value,
+          layout.value.height,
+          size.value.height,
+          inverted,
+        );
+      },
+      (atEnd, previous) => {
+        if (isAtEndSV && atEnd !== previous) {
+          // eslint-disable-next-line react-compiler/react-compiler
+          isAtEndSV.value = atEnd;
+        }
+      },
+    );
 
     useExtraContentPadding({
       scrollViewRef,

--- a/src/components/KeyboardChatScrollView/types.ts
+++ b/src/components/KeyboardChatScrollView/types.ts
@@ -87,4 +87,11 @@ export type KeyboardChatScrollViewProps = {
    * Default is `undefined` (equivalent to `0` — no minimum floor).
    */
   blankSpace?: SharedValue<number>;
+  /**
+   * Optional shared value that tracks whether the scroll view is currently at the end.
+   *
+   * When provided, `KeyboardChatScrollView` updates it on the UI thread using the same
+   * scroll metrics that drive `keyboardLiftBehavior="whenAtEnd"`.
+   */
+  isAtEnd?: SharedValue<boolean>;
 } & ScrollViewProps;


### PR DESCRIPTION
## 📜 Description

This PR adds an optional `isAtEnd?: SharedValue<boolean>` prop to `KeyboardChatScrollView`.

When provided, the component updates that shared value on the UI thread using the same internal scroll metrics and `isScrollAtEnd(...)` logic already used by `keyboardLiftBehavior="whenAtEnd"`.

The goal is to let chat-style apps build jump-to-latest / scroll-to-bottom affordances without reimplementing the component's internal "at end" logic in app code.

## 💡 Motivation and Context

This change is intended to solve a common gap in chat UIs:

- the component already knows whether the user is effectively at the end
- apps often need that same signal for follow-mode and jump-to-latest UI
- today, consumers must guess based on external scroll heuristics

That duplication is brittle because app-side heuristics can diverge from the component's own keyboard-aware behavior.

This PR keeps the API small by exposing the semantic state (`isAtEnd`) instead of lower-level raw scroll metrics.

Related issue: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1430

## 📢 Changelog

### JS

- add optional `isAtEnd?: SharedValue<boolean>` prop to `KeyboardChatScrollView`
- update `isAtEnd` on the UI thread using existing `isScrollAtEnd(...)` logic
- add TypeScript declarations for the new prop

### iOS

- no native changes

### Android

- no native changes

## 🤔 How Has This Been Tested?

Validated in the fork clone with:

- `yarn typescript`
- `yarn lint src/components/KeyboardChatScrollView/index.tsx src/components/KeyboardChatScrollView/types.ts`

Not yet completed before opening this draft PR:

- `yarn test`
- manual verification in the example app on iOS
- manual verification in the example app on Android

## 📸 Screenshots (if appropriate):

No screenshots yet. This draft PR is mainly to support API discussion from #1430.

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
