### PR TITLE
fix: close keyboard even if it's partially visible

### DIFF
--- a/src/hooks/useKeyboardState/index.ts
+++ b/src/hooks/useKeyboardState/index.ts
@@ -5,7 +5,7 @@ import { KeyboardController } from "../../module";
 
 import type { IKeyboardState } from "../../types";
 
-const EVENTS = ["keyboardDidShow", "keyboardDidHide"] as const;
+const EVENTS = ["keyboardWillShow", "keyboardDidHide"] as const;
 
 const getLatestState = () => ({
   ...KeyboardController.state(),
@@ -53,12 +53,6 @@ function useKeyboardState<T = IKeyboardState>(
         setState(selector(getLatestState())),
       ),
     );
-    // update `appearance` prematurely
-    const willShowSubscription = KeyboardEvents.addListener(
-      "keyboardWillShow",
-      (e) =>
-        setState(selector({ ...getLatestState(), appearance: e.appearance })),
-    );
 
     // we might have missed an update between reading a value in render and
     // `addListener` in this handler, so we set it here. If there was
@@ -67,7 +61,6 @@ function useKeyboardState<T = IKeyboardState>(
 
     return () => {
       subscriptions.forEach((subscription) => subscription.remove());
-      willShowSubscription.remove();
     };
   }, []);
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -21,7 +21,7 @@ KeyboardEvents.addListener("keyboardDidHide", (e) => {
   lastState = e;
 });
 
-KeyboardEvents.addListener("keyboardDidShow", (e) => {
+KeyboardEvents.addListener("keyboardWillShow", (e) => {
   isClosed = false;
   lastState = e;
 });


### PR DESCRIPTION
## 📜 Description

Fixed an issue when calling `KeyboardController.dismiss` during the keyboard animation (when it appears) doesn't close a keyboard.

## 💡 Motivation and Context

If we use `keyboardDidShow` as an indication that keyboard is fully shown, then when keyboard is in progress of the animation calling `KeyboardController.dismiss` will not close keyboard, because `isClosed` will be `true`, so we'll go into this code:

```ts
return new Promise((resolve) => {
  if (isClosed) {
    resolve();

    return;
  }
```

The fix is quite trivial - we need to use `keyboardWillShow` instead of `keyboardDIdShow`. In this case as soon as keyboard starts its animation the `isClosed` will be `false`:

```tsx
KeyboardEvents.addListener("keyboardWillShow", (e) => {
  isClosed = false;
  lastState = e;
});
```

The reasonable question is that such small fix produces a different behavior for `KeyboardController.state()` and `KeyboardController.isVisible()`. Before they would update their values only when animation completes. But now they will update values before keyboard appearance.

Technically it still makes sense and the bug above confirms that. We should treat keyboard as shown even if 1% of keyboard is visible on a screen.

I think further we may add additional prop to `state` like `isAnimating`/`isTransitioning` (or maybe even enum to show the difference `OPENING | OPENED | CLOSING | CLOSED`) to indicate that animation is in the process. But this is a future improvement. Hopefully it's not a breaking change 🤞 

Close https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1400

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- change `keyboardDidShow` to `keyboardWillShow` in `module.ts` file;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 17 Pro (iOS 26.2).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/9d43d0d7-696c-488f-9478-6a4b9d6c2f10">|<video src="https://github.com/user-attachments/assets/9ae385e5-f617-4ed0-b59e-041758e84fec">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
