### PR TITLE
fix: pass through touches in `KeyboardToolbar`

### DIFF
--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -99,6 +99,8 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> & {
   );
   const containerStyle = useMemo(
     () => [
+      // CRUCIAL: gives the native view real bounds
+      styles.toolbar,
       KEYBOARD_HAS_ROUNDED_CORNERS
         ? {
             marginLeft: (insets?.left ?? 0) + 16,

--- a/src/components/KeyboardToolbar/index.tsx
+++ b/src/components/KeyboardToolbar/index.tsx
@@ -100,12 +100,12 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> & {
   const containerStyle = useMemo(
     () => [
       // CRUCIAL: gives the native view real bounds
-      styles.toolbar,
+      styles.sticky,
       KEYBOARD_HAS_ROUNDED_CORNERS
-        ? {
-            marginLeft: (insets?.left ?? 0) + 16,
-            marginRight: (insets?.right ?? 0) + 16,
-          }
+        ? ({
+            left: (insets?.left ?? 0) + 16,
+            right: (insets?.right ?? 0) + 16,
+          } as const)
         : null,
     ],
     [insets],
@@ -209,6 +209,13 @@ const KeyboardToolbar: React.FC<KeyboardToolbarProps> & {
 };
 
 const styles = StyleSheet.create({
+  sticky: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: KEYBOARD_TOOLBAR_HEIGHT,
+  },
   toolbar: {
     position: "absolute",
     bottom: 0,


### PR DESCRIPTION
## 📜 Description

Fixed an issue when touches pas through `KeyboardToolbar`.

## 💡 Motivation and Context

The issue was because `KeyboardStickyView` had `0x0` dimensions. As a result that `View` wasn't visible for touch system in `react-native` and focus was forwarded further (to input or other elements that can handle a touch).

The fix is quite trivial - we simply adding missing `style` (fixed `height`, `100%` width).

I also hope it can fix the issue on Android 31 e2e tests and make `KeyboardToolbar` tests stable again 🤞 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1021

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `styles.toolbar` to `KeyboardStickyView` style;

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro (API 36).

## 📸 Screenshots (if appropriate):

### Android

|Paper|Fabric|
|------|------|
|<video src="https://github.com/user-attachments/assets/336fc478-21aa-4773-87a5-a8f14ba5bae5">|<video src="https://github.com/user-attachments/assets/4a1cf1f8-69bc-4501-8746-8d13f157094c">|

### iOS (verical)

|iOS 18.5|iOS 26.2|
|--------|---------|
|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/7f5bf948-3736-45ba-ab3e-6321b2734af0" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/974fa969-a8b0-425f-b879-56257b49cecc" />|

### iOS (horizontal)

|iOS 18.5|iOS 26.2|
|--------|---------|
|<img width="2622" height="1206" alt="image" src="https://github.com/user-attachments/assets/3de76a35-89f9-47c5-a56e-eb3d70e399d8" />|<img width="2622" height="1206" alt="image" src="https://github.com/user-attachments/assets/812b7cf8-5bac-4fe6-8663-48025a9a5154" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
