### PR TITLE
fix: resolve view crash

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
@@ -10,11 +10,11 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.uimanager.IllegalViewOperationException
 import com.reactnativekeyboardcontroller.extensions.dp
-import com.reactnativekeyboardcontroller.log.Logger
 import com.reactnativekeyboardcontroller.extensions.screenLocation
 import com.reactnativekeyboardcontroller.extensions.uiManager
 import com.reactnativekeyboardcontroller.extensions.windowSoftInputMode
 import com.reactnativekeyboardcontroller.interactive.KeyboardAnimationController
+import com.reactnativekeyboardcontroller.log.Logger
 import com.reactnativekeyboardcontroller.traversal.FocusedInputHolder
 import com.reactnativekeyboardcontroller.traversal.ViewHierarchyNavigator
 

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
@@ -10,12 +10,15 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.uimanager.IllegalViewOperationException
 import com.reactnativekeyboardcontroller.extensions.dp
+import com.reactnativekeyboardcontroller.log.Logger
 import com.reactnativekeyboardcontroller.extensions.screenLocation
 import com.reactnativekeyboardcontroller.extensions.uiManager
 import com.reactnativekeyboardcontroller.extensions.windowSoftInputMode
 import com.reactnativekeyboardcontroller.interactive.KeyboardAnimationController
 import com.reactnativekeyboardcontroller.traversal.FocusedInputHolder
 import com.reactnativekeyboardcontroller.traversal.ViewHierarchyNavigator
+
+private val TAG = KeyboardControllerModuleImpl::class.qualifiedName
 
 class KeyboardControllerModuleImpl(
   private val mReactContext: ReactApplicationContext,
@@ -94,6 +97,7 @@ class KeyboardControllerModuleImpl(
         try {
           uiManager?.resolveView(viewTag.toInt())
         } catch (e: IllegalViewOperationException) {
+          Logger.w(TAG, "Could not resolve view for tag ${viewTag.toInt()}", e)
           null
         }
       if (view == null) {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/KeyboardControllerModuleImpl.kt
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.uimanager.IllegalViewOperationException
 import com.reactnativekeyboardcontroller.extensions.dp
 import com.reactnativekeyboardcontroller.extensions.screenLocation
 import com.reactnativekeyboardcontroller.extensions.uiManager
@@ -89,7 +90,12 @@ class KeyboardControllerModuleImpl(
     promise: Promise,
   ) {
     UiThreadUtil.runOnUiThread {
-      val view = uiManager?.resolveView(viewTag.toInt())
+      val view =
+        try {
+          uiManager?.resolveView(viewTag.toInt())
+        } catch (e: IllegalViewOperationException) {
+          null
+        }
       if (view == null) {
         promise.reject("E_VIEW_NOT_FOUND", "Could not find view for tag")
         return@runOnUiThread


### PR DESCRIPTION
## 📜 Description

Fixed `IllegalViewOperationException` crash on Android.

## 💡 Motivation and Context

Original code has been introduced in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1355 and further started to be used in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1352

Now if view is not found it throws an unhandled exception and crashes the app. In reality we already handle "view not found" exception, so we should just add a proper try/catch block to handle this error correctly in Kotlin code 🤞 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1443

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- wrap `resolveView` with `catch (e: IllegalViewOperationException)`;

## 🤔 How Has This Been Tested?

Tested via e2e pipeline.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
