### PR TITLE
fix(ios): guard preloadKeyboardIfNeeded with @available(iOS 26.0, *)

### DIFF
--- a/ios/KeyboardControllerModule.mm
+++ b/ios/KeyboardControllerModule.mm
@@ -87,6 +87,9 @@ RCT_EXPORT_METHOD(setInputMode : (nonnull NSNumber *)mode)
 RCT_EXPORT_METHOD(preload)
 #endif
 {
+  if (@available(iOS 26.0, *)) {
+    return;
+  }
   [UIResponder preloadKeyboardIfNeeded];
 }
 


### PR DESCRIPTION
## Problem

  On iOS 26+, calling `[UIResponder preloadKeyboardIfNeeded]` crashes because it is treated as a private API on that OS version.

  ## Fix

  Guard the call with `@available(iOS 26.0, *)` so it is skipped on iOS 26 and later. When running on iOS 26+, the method returns early without calling the private API.

  ```objc
  - (void)preload
  {
    if (@available(iOS 26.0, *)) {
      return;
    }
    [UIResponder preloadKeyboardIfNeeded];
  }
  ```

  ## Context

  This was discovered in a production React Native application that began crashing on iOS 26 beta devices. A local patch has been in use as a workaround while awaiting an upstream fix.

  ## Testing

  - Tested on iOS 26 simulator — no crash on keyboard preload
  - Tested on iOS 17 device — keyboard preload continues to work as expected