### PR TITLE
KeyboardChatScrollView: Fix scroll gestures on Android when scrollview content is shorter than the scrollview's viewport

### DIFF
--- a/FabricExample/src/screens/Examples/AILegendListChat/index.tsx
+++ b/FabricExample/src/screens/Examples/AILegendListChat/index.tsx
@@ -30,29 +30,8 @@ type Message = {
 
 const createId = () => String(Date.now());
 
-const INITIAL_AI_TEXT = `Tip: Type 'a' for a short reply, 'b' for medium, 'c' for long, or 'd' for extra long. Any other text picks a random length.
-
-React Native virtualization is a performance optimization technique that's crucial for handling large lists efficiently. Here's how it works:
-
-1. **Rendering Only Visible Items**: Instead of rendering all items in a list at once, virtualization only renders the items that are currently visible on screen, plus a small buffer of items just outside the visible area.
-
-2. **Dynamic Item Creation/Destruction**: As you scroll, items that move out of view are removed from the DOM/native view hierarchy, and new items that come into view are created. This keeps memory usage constant regardless of list size.
-
-3. **View Recycling**: Advanced virtualization systems reuse view components rather than creating new ones, which reduces garbage collection and improves performance.
-
-4. **Estimated vs Actual Sizing**: The system uses estimated item sizes to calculate scroll positions and total content size, then adjusts as actual sizes are measured.
-
-5. **Legend List Implementation**: Legend List enhances this by providing better handling of dynamic item sizes, bidirectional scrolling, and maintains scroll position more accurately than FlatList.
-
-The key benefits are:
-- Constant memory usage regardless of data size
-- Smooth scrolling performance
-- Better handling of dynamic content
-- Reduced time to interactive
-
-This makes it possible to scroll through thousands of items without performance degradation, which is essential for modern mobile apps dealing with large datasets like social media feeds, chat histories, or product catalogs.
-
-Tip: Type 'a' for a short reply, 'b' for medium, 'c' for long, or 'd' for extra long. Any other text picks a random length.`;
+const INITIAL_AI_TEXT =
+  "Tip: Type 'a' for a short reply, 'b' for medium, 'c' for long, or 'd' for extra long. Any other text picks a random length.";
 
 const INITIAL_MESSAGES: Message[] = [
   {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
@@ -15,11 +15,31 @@ class ClippingScrollViewDecoratorView(
   private var insetBottom = 0.0
   private var insetTop = 0.0
   private var appliedTopInsetPx = 0
+  private var boundContentView: ViewGroup? = null
+
+  // Re-run the extension after every Yoga relayout so `child.bottom` (and therefore
+  // `computeVerticalScrollRange()`) stays at the extended target as messages stream in.
+  // This listener MUST fire before `ReactScrollView.onLayoutChange` does its scrollY
+  // clamp (`ReactScrollView` adds itself as a listener in `onChildViewAdded` at
+  // ReactScrollView.java:1145 and the clamp at line 1275 uses the pre-extension
+  // `child.getHeight()` — so if RN's listener runs first, the scrollY snaps to 0
+  // mid-stream as the AI reply arrives). `decorateScrollView()` handles the ordering by
+  // removing RN's listener from the content view and re-adding it AFTER ours.
+  private val layoutListener =
+    View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+      applyInsetExtension()
+    }
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
 
     decorateScrollView()
+  }
+
+  override fun onDetachedFromWindow() {
+    boundContentView?.removeOnLayoutChangeListener(layoutListener)
+    boundContentView = null
+    super.onDetachedFromWindow()
   }
 
   fun setContentInsetBottom(value: Double) {
@@ -50,14 +70,24 @@ class ClippingScrollViewDecoratorView(
     val contentView = scrollView.getChildAt(0) as? ViewGroup ?: return
     contentView.translationY = newTopInsetPx.toFloat()
 
-    scrollView.setPadding(
-      scrollView.paddingLeft,
-      scrollView.paddingTop,
-      scrollView.paddingRight,
-      // pass accumulated value — visually both top and bottom insets
-      // extend the scroll range via bottom padding
-      (insetBottom + insetTop).toFloat().px.toInt(),
-    )
+    if (boundContentView !== contentView) {
+      boundContentView?.removeOnLayoutChangeListener(layoutListener)
+      // Install our listener BEFORE ReactScrollView's so that we restore the extended
+      // child.bottom before RN's scrollY-clamp listener reads child.getHeight(). The
+      // ScrollView itself is the RN listener (it implements OnLayoutChangeListener), so
+      // removing + re-adding it puts it behind ours in the invocation order.
+      val rnListener = scrollView as? View.OnLayoutChangeListener
+      if (rnListener != null) {
+        contentView.removeOnLayoutChangeListener(rnListener)
+      }
+      contentView.addOnLayoutChangeListener(layoutListener)
+      if (rnListener != null) {
+        contentView.addOnLayoutChangeListener(rnListener)
+      }
+      boundContentView = contentView
+    }
+
+    applyInsetExtension()
 
     // scroll by the delta to keep content visually in place
     val delta = newTopInsetPx - appliedTopInsetPx
@@ -66,6 +96,33 @@ class ClippingScrollViewDecoratorView(
     }
 
     appliedTopInsetPx = newTopInsetPx
+  }
+
+  private fun applyInsetExtension() {
+    val contentView = boundContentView ?: return
+    val scrollView = findScrollView(this) ?: return
+    val totalInsetPx = (insetBottom + insetTop).toFloat().px.toInt()
+    // Mirror iOS `contentInset.bottom`: maxScrollY should be
+    //   max(0, measuredHeight + totalInsetPx - viewport)
+    // Extend `child.bottom` directly rather than using `paddingBottom`, because
+    // `computeVerticalScrollRange()` is derived from `child.getBottom()` (padding is
+    // not part of it). Without this, `canScrollVertically(1)` returns false inside
+    // the message area on short content and drags started there aren't intercepted.
+    // The guard below defensively clears any residual `paddingBottom` (e.g. from
+    // hot-reload of an older build that set it); this class never sets it.
+    if (scrollView.paddingBottom != 0) {
+      scrollView.setPadding(
+        scrollView.paddingLeft,
+        scrollView.paddingTop,
+        scrollView.paddingRight,
+        0,
+      )
+    }
+    val measuredHeight = contentView.measuredHeight
+    val expectedBottom = contentView.top + measuredHeight + totalInsetPx
+    if (contentView.bottom != expectedBottom) {
+      contentView.bottom = expectedBottom
+    }
   }
 
   private fun findScrollView(view: View?): ScrollView? {

--- a/cspell.json
+++ b/cspell.json
@@ -195,7 +195,9 @@
     "lottiefiles",
     "dotlottie",
     "legendapp",
-    "kortix"
+    "kortix",
+    "relayout",
+    "overscroll"
   ],
   "ignorePaths": [
     "node_modules",

--- a/src/components/KeyboardChatScrollView/index.tsx
+++ b/src/components/KeyboardChatScrollView/index.tsx
@@ -80,17 +80,18 @@ const KeyboardChatScrollView = forwardRef<
       freeze: freezeSV,
     });
 
+    const totalPadding = useDerivedValue(() =>
+      Math.max(blankSpace.value, padding.value + extraContentPadding.value),
+    );
+
     useEndVisible({
       scroll,
       layout,
       size,
       inverted,
+      appliedInset: totalPadding,
       onEndVisible,
     });
-
-    const totalPadding = useDerivedValue(() =>
-      Math.max(blankSpace.value, padding.value + extraContentPadding.value),
-    );
 
     // Scroll indicator inset = keyboard + extraContentPadding (excludes blankSpace).
     // Apps that render into the unsafe area can supply a negative

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/blankSpace.android.spec.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/blankSpace.android.spec.ts
@@ -71,9 +71,11 @@ describe("blankSpace — Android non-inverted + always", () => {
   });
 
   it("partial absorption: reduced scroll displacement", () => {
-    // Content slightly smaller than viewport so minimum padding is fully visible
-    // (pastContentEnd = 0+800-700 = 100, fraction = 100/100 = 1)
-    mockSize.value = { width: 390, height: 700 };
+    // Natural content height = 700 (slightly smaller than viewport=800). On Android
+    // the native scroll view reports contentSize extended by the applied inset, so
+    // mockSize = natural(700) + appliedInset(max(100, 300)) = 1000 while keyboard open.
+    // pastContentEnd = 0+800-700 = 100, fraction = 100/100 = 1
+    mockSize.value = { width: 390, height: 1000 };
     mockOffset.value = 0;
     render({
       inverted: false,

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/closing.android.spec.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/closing.android.spec.ts
@@ -86,6 +86,10 @@ describe("`useChatKeyboard` — Android closing behaviors", () => {
   });
 
   it("never non-inverted: should scroll back on close when at end", () => {
+    // Natural content = 2000. On Android mockSize reflects native contentSize
+    // extended by the applied inset, so mockSize = natural(2000) + appliedInset(300)
+    // = 2300 while keyboard is open.
+    mockSize.value = { width: 390, height: 2300 };
     mockOffset.value = 1200;
     render({ inverted: false, keyboardLiftBehavior: "never" });
 
@@ -134,8 +138,10 @@ describe("`useChatKeyboard` — Android closing behaviors", () => {
   });
 
   it("persistent non-inverted: should clamp to max when position exceeds valid range", () => {
-    // Small content so position exceeds natural max scroll
-    mockSize.value = { width: 390, height: 1000 };
+    // Natural content = 1000 (small so position exceeds natural max scroll). On
+    // Android mockSize reflects native contentSize extended by the applied inset,
+    // so mockSize = natural(1000) + appliedInset(300) = 1300 while keyboard open.
+    mockSize.value = { width: 390, height: 1300 };
     mockOffset.value = 100;
     render({ inverted: false, keyboardLiftBehavior: "persistent" });
 
@@ -251,8 +257,11 @@ describe("`useChatKeyboard` — Android closing behaviors", () => {
   });
 
   it("whenAtEnd inverted: should clamp scroll to maxScroll on close when position exceeds new range", () => {
-    // Small content so that old scroll (900) exceeds maxScroll after keyboard shrinks
-    mockSize.value = { width: 390, height: 1500 };
+    // Natural content = 1500 (small so old scroll 900 exceeds maxScroll after
+    // keyboard shrinks). On Android mockSize reflects native contentSize extended
+    // by the applied inset, so mockSize = natural(1500) + appliedInset(300) = 1800
+    // while keyboard open.
+    mockSize.value = { width: 390, height: 1800 };
     // Not at end: isScrollAtEnd(900, 800, 1500, true) = (900 <= 20) = false
     mockOffset.value = 900;
     render({ inverted: true, keyboardLiftBehavior: "whenAtEnd" });

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
@@ -6,7 +6,6 @@ import useScrollState from "../../hooks/useScrollState";
 import {
   clampedScrollTarget,
   getEffectiveHeight,
-  getMinimumPaddingAbsorbed,
   getScrollEffective,
   getVisibleMinimumPaddingFraction,
   isScrollAtEnd,
@@ -48,7 +47,13 @@ function useChatKeyboard(
   const offsetBeforeScroll = useSharedValue(0);
   const targetKeyboardHeight = useSharedValue(0);
   const closing = useSharedValue(false);
-  const minimumPaddingFractionOnOpen = useSharedValue(0);
+  // Visible portion of blankSpace at the moment the keyboard started opening. Snapshot
+  // from onStart — used by onMove to keep the per-frame math stable as the keyboard
+  // animates. Must match iOS's per-frame formula: `absorbed = max(0, visiblePadding -
+  // extraContent)`, NOT `(blankSpace - extra) * fraction` (which scales `extra` by
+  // fraction and gives a smaller absorption than iOS when the blank is only partially
+  // visible, causing under-shift on short content).
+  const visiblePaddingOnOpen = useSharedValue(0);
   const actualOpenShift = useSharedValue(0);
   const {
     layout,
@@ -57,6 +62,24 @@ function useChatKeyboard(
     onLayout,
     onContentSizeChange,
   } = useScrollState(scrollViewRef);
+  // On Android, `size.value.height` comes from native scroll events where the
+  // ScrollView reads `contentView.getHeight()` (= bottom - top). The decorator extends
+  // `contentView.bottom` by the applied inset to provide the blank-space scroll range,
+  // so `size.value.height` is "natural content + applied inset". iOS reports pure
+  // natural height via `contentSize` (contentInset is reported separately). To align
+  // Android's `isScrollAtEnd` with iOS, subtract the applied inset here. The applied
+  // inset at any moment equals what `ScrollViewWithBottomPadding` writes to
+  // `contentInsetBottom + contentInsetTop`, which is `max(blankSpace, padding +
+  // extraContentPadding)` (i.e. `bottomPadding.value` from chat).
+  const naturalContentHeight = (): number => {
+    "worklet";
+    const appliedInset = Math.max(
+      blankSpace.value,
+      padding.value + extraContentPadding.value,
+    );
+
+    return Math.max(0, size.value.height - appliedInset);
+  };
   const clampScrollIfNeeded = (
     effective: number,
     totalPaddingForMaxScroll?: number,
@@ -67,8 +90,11 @@ function useChatKeyboard(
       totalPaddingForMaxScroll !== undefined
         ? totalPaddingForMaxScroll
         : effective;
+    // Use the natural content height (not `size.value.height`, which on Android already
+    // includes the applied inset via the decorator's `child.bottom` extension) so we
+    // don't double-count the inset when computing the scrollable range.
     const maxScroll = Math.max(
-      size.value.height - layout.value.height + paddingForMax,
+      naturalContentHeight() - layout.value.height + paddingForMax,
       0,
     );
 
@@ -103,26 +129,29 @@ function useChatKeyboard(
         const atEnd = isScrollAtEnd(
           scroll.value,
           layout.value.height,
-          size.value.height,
+          naturalContentHeight(),
           inverted,
         );
 
         // Scale minimum padding absorption by how much of it is visible.
-        // Fully visible → full absorption; fully off-screen → no absorption.
+        // Proportional, NOT a binary gate: for short content the viewport always shows
+        // content+blank, and blankSpace can never be "fully visible" (visibleFraction <
+        // 1) because blank extends beyond viewport. A binary gate would skip absorption
+        // entirely and we'd shift by the full keyboard height, pushing short content off
+        // the top. Matches iOS's per-frame math (index.ios.ts: `visibleFraction *
+        // blankSpace`).
         const visibleFraction = getVisibleMinimumPaddingFraction(
           scroll.value,
           layout.value.height,
-          size.value.height,
+          naturalContentHeight(),
           blankSpace.value,
           inverted,
         );
-        const minimumPaddingAbsorbed =
-          visibleFraction >= 1
-            ? getMinimumPaddingAbsorbed(
-                blankSpace.value,
-                extraContentPadding.value,
-              )
-            : 0;
+        const visiblePadding = visibleFraction * blankSpace.value;
+        const minimumPaddingAbsorbed = Math.max(
+          0,
+          visiblePadding - extraContentPadding.value,
+        );
         const scrollEffective = getScrollEffective(
           effective,
           minimumPaddingAbsorbed,
@@ -135,7 +164,7 @@ function useChatKeyboard(
           return;
         } else if (e.height > 0) {
           // Android: keyboard opening — set padding + capture scroll position
-          minimumPaddingFractionOnOpen.value = visibleFraction >= 1 ? 1 : 0;
+          visiblePaddingOnOpen.value = visiblePadding;
           padding.value = effective;
           offsetBeforeScroll.value = scroll.value;
 
@@ -184,11 +213,10 @@ function useChatKeyboard(
             offset,
           );
 
-          const minimumPaddingAbsorbed =
-            getMinimumPaddingAbsorbed(
-              blankSpace.value,
-              extraContentPadding.value,
-            ) * minimumPaddingFractionOnOpen.value;
+          const minimumPaddingAbsorbed = Math.max(
+            0,
+            visiblePaddingOnOpen.value - extraContentPadding.value,
+          );
           const scrollEffective = getScrollEffective(
             effective,
             minimumPaddingAbsorbed,
@@ -202,7 +230,7 @@ function useChatKeyboard(
           const wasAtEnd = isScrollAtEnd(
             offsetBeforeScroll.value,
             layout.value.height,
-            size.value.height,
+            naturalContentHeight(),
             inverted,
           );
 
@@ -224,10 +252,16 @@ function useChatKeyboard(
           }
 
           if (!shouldShiftContent(keyboardLiftBehavior, wasAtEnd)) {
-            // Closing, not shifting: reduce padding to avoid gap
+            // Closing, not shifting: reduce padding to avoid gap. Clamp BEFORE
+            // mutating padding.value — `clampScrollIfNeeded` reads
+            // `naturalContentHeight()` which subtracts `padding.value` from the
+            // native-reported `size.value.height`. On Android the native hasn't
+            // applied the new inset yet, so `size.value.height` still reflects the
+            // pre-mutation inset; computing with the post-mutation `padding.value`
+            // would overestimate the natural content and inflate maxScroll.
             if (closing.value && effective < padding.value) {
-              padding.value = effective;
               clampScrollIfNeeded(effective, actualTotalPadding);
+              padding.value = effective;
             }
 
             return;
@@ -249,9 +283,10 @@ function useChatKeyboard(
                 padding.value = effective;
                 scrollTo(scrollViewRef, 0, 0, false);
               } else if (closing.value) {
-                // Not at end: reduce padding to avoid gap
-                padding.value = effective;
+                // Not at end: reduce padding to avoid gap. Clamp BEFORE mutating
+                // padding.value (see comment above in the !shouldShift branch).
                 clampScrollIfNeeded(effective, actualTotalPadding);
+                padding.value = effective;
               }
 
               return;
@@ -263,17 +298,25 @@ function useChatKeyboard(
 
           scrollTo(scrollViewRef, 0, target, false);
         } else {
+          // Skip post-interactive snap-back events. When the user drags on the scroll
+          // view with the keyboard open, Android emits `onMove` with `duration === -1`
+          // as the keyboard re-establishes position. Without this guard, the scrollTo
+          // below would override the user's in-progress drag — causing the scroll
+          // position to snap back when the user lifts their finger.
+          if (e.duration === -1) {
+            return;
+          }
+
           const effective = getEffectiveHeight(
             e.height,
             targetKeyboardHeight.value,
             offset,
           );
 
-          const minimumPaddingAbsorbed =
-            getMinimumPaddingAbsorbed(
-              blankSpace.value,
-              extraContentPadding.value,
-            ) * minimumPaddingFractionOnOpen.value;
+          const minimumPaddingAbsorbed = Math.max(
+            0,
+            visiblePaddingOnOpen.value - extraContentPadding.value,
+          );
           const scrollEffective = getScrollEffective(
             effective,
             minimumPaddingAbsorbed,
@@ -308,11 +351,16 @@ function useChatKeyboard(
             return;
           }
 
-          // "persistent" closing: maintain position, clamped to valid range
+          // "persistent" closing: maintain the actual shift applied during open. Using
+          // `padding.value` here was wrong when blankSpace absorbed part of the keyboard
+          // — the shift during open was only the uncovered-by-blankSpace portion, NOT
+          // the full keyboard height, so `offsetBefore + padding` over-scrolled on
+          // close. `actualOpenShift` records the real clamped shift captured at the end
+          // of the open animation.
           if (keyboardLiftBehavior === "persistent" && closing.value) {
-            const keepAt = offsetBeforeScroll.value + padding.value;
+            const keepAt = offsetBeforeScroll.value + actualOpenShift.value;
             const maxScroll = Math.max(
-              size.value.height - layout.value.height + actualTotalPadding,
+              naturalContentHeight() - layout.value.height + actualTotalPadding,
               0,
             );
 
@@ -324,7 +372,7 @@ function useChatKeyboard(
           const target = clampedScrollTarget(
             offsetBeforeScroll.value,
             scrollEffective,
-            size.value.height,
+            naturalContentHeight(),
             layout.value.height,
             actualTotalPadding,
           );

--- a/src/components/KeyboardChatScrollView/useEndVisible.ts
+++ b/src/components/KeyboardChatScrollView/useEndVisible.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { Platform } from "react-native";
 import {
   runOnJS,
   useAnimatedReaction,
@@ -16,6 +17,14 @@ type Options = {
   layout: SharedValue<{ width: number; height: number }>;
   size: SharedValue<{ width: number; height: number }>;
   inverted: boolean;
+  /**
+   * Inset currently applied to the native ScrollView. Used on Android to subtract the
+   * blank-space extension from `size.value.height` (which on Android includes it,
+   * because the decorator extends `contentView.bottom`). On iOS the native scroll event
+   * reports natural content size independent of `contentInset`, so no adjustment
+   * needed.
+   */
+  appliedInset: SharedValue<number>;
   onEndVisible?: EndVisibleCallback;
 };
 
@@ -23,11 +32,14 @@ const hasWorkletHash = (value: unknown): boolean =>
   typeof value === "function" &&
   !!(value as unknown as Record<string, unknown>).__workletHash;
 
+const IS_ANDROID = Platform.OS === "android";
+
 export const useEndVisible = ({
   scroll,
   layout,
   size,
   inverted,
+  appliedInset,
   onEndVisible,
 }: Options) => {
   const isWorklet = useMemo(() => hasWorkletHash(onEndVisible), [onEndVisible]);
@@ -40,10 +52,14 @@ export const useEndVisible = ({
       return null;
     }
 
+    const naturalContentHeight = IS_ANDROID
+      ? Math.max(0, size.value.height - appliedInset.value)
+      : size.value.height;
+
     return isScrollAtEnd(
       scroll.value,
       layout.value.height,
-      size.value.height,
+      naturalContentHeight,
       inverted,
     );
   });

--- a/src/components/ScrollViewWithBottomPadding/index.tsx
+++ b/src/components/ScrollViewWithBottomPadding/index.tsx
@@ -132,7 +132,7 @@ const ScrollViewWithBottomPadding = forwardRef<
         (scrollIndicatorInsets?.bottom || 0);
 
       const result: Record<string, unknown> = {
-        // iOS prop
+        // iOS ScrollView props.
         contentInset: effective,
         scrollIndicatorInsets: {
           bottom: indicatorBottom,
@@ -140,7 +140,7 @@ const ScrollViewWithBottomPadding = forwardRef<
           right: scrollIndicatorInsets?.right,
           left: scrollIndicatorInsets?.left,
         },
-        // Android prop
+        // Android `KeyboardControllerScrollView` props (ignored by the stock ScrollView on iOS/web).
         contentInsetBottom: dynamic.bottom,
         contentInsetTop: dynamic.top,
       };


### PR DESCRIPTION
## 📜 Description

Fixes #1453 

Reworks the Android blank-space / `extraContentPadding` / keyboard-lift
behavior in `KeyboardChatScrollView` so it matches iOS. Four separate bugs
were stacked on top of each other; fixing one at a time required fixing
the rest.

## 💡 Motivation and Context

The original symptom was that on Android, a drag gesture started inside
the message area was ignored when the conversation was shorter than the
viewport — only drags starting inside the blank-space region scrolled.
Investigating that uncovered a chain of related bugs in the Android
blank-space path: mid-stream snap-to-0 as AI replies grew, wrong
`isScrollAtEnd` / `visibleFraction` / max-scroll math, and wildly wrong
keyboard-lift math on short content. The fixes bring Android's behavior
in line with the iOS per-frame model, where `contentInset.bottom` cleanly
separates the applied inset from the natural content size.

## 📢 Changelog

### JS

- `useChatKeyboard`: introduced a `naturalContentHeight()` helper on
  Android to subtract the applied inset (`max(blankSpace, padding +
  extraContentPadding)`) from `size.value.height`. Android reports
  `contentSize` as `contentView.getHeight()` which now includes the
  decorator's extension, whereas iOS reports natural content size
  independent of `contentInset`. Fed the adjusted value into
  `isScrollAtEnd`, `clampScrollIfNeeded`, `getVisibleMinimumPaddingFraction`,
  `clampedScrollTarget`, and the `persistent`-close `maxScroll`.
- `useChatKeyboard`: replaced the `visibleFraction >= 1` binary gate in
  `onStart` with proportional absorption matching iOS:
  `absorbed = max(0, visibleFraction * blankSpace - extraContentPadding)`.
  Fixes short content being pushed off the top when the keyboard opened
  (blankSpace extends past the viewport on short content, so the
  fraction is never 1 and the gate was always skipping absorption).
- `useChatKeyboard`: replaced `minimumPaddingFractionOnOpen` with a
  `visiblePaddingOnOpen` snapshot so `onMove` uses the same iOS formula
  as `onStart` (`max(0, visiblePadding - extraContent)` instead of
  `(blankSpace - extraContent) * fraction`). The two formulas only
  agreed at `fraction === 1`; at partial fractions the composer clipped
  the last message's timestamp.
- `useChatKeyboard`: non-inverted `onMove` now skips `e.duration === -1`
  snap-back events (matching the inverted path), so dragging the scroll
  view with the keyboard open no longer snaps the scroll position back
  on finger-up.
- `useChatKeyboard`: `persistent`-close now uses
  `offsetBefore + actualOpenShift` instead of
  `offsetBefore + padding.value`, so closing the keyboard doesn't jump
  content up when blankSpace absorbed part of the keyboard height.
- `useEndVisible`: added an `appliedInset` option and a Platform-gated
  natural-content-height adjustment so `isScrollAtEnd` reports correctly
  on Android.
- `KeyboardChatScrollView`: moved the `totalPadding` derived value above
  `useEndVisible` and threaded it through as `appliedInset`.
- `ScrollViewWithBottomPadding`: minor comment cleanup clarifying that
  `contentInset` / `scrollIndicatorInsets` are iOS-only and
  `contentInsetBottom` / `contentInsetTop` are the Android
  `KeyboardControllerScrollView` props.

### Android

- `ClippingScrollViewDecoratorView`: the scroll-range extension now
  extends `contentView.bottom` directly (by the applied inset) instead
  of using `scrollView.paddingBottom`. Base Android
  `ScrollView.computeVerticalScrollRange()` derives from
  `child.getBottom()` and ignores padding, so `paddingBottom` alone
  didn't make `canScrollVertically(1)` return true inside the message
  area on short content — drags started there weren't intercepted.
  Extending `child.bottom` fixes that.
- `ClippingScrollViewDecoratorView`: installs an
  `OnLayoutChangeListener` on the content view that re-applies the
  `child.bottom` extension on every Yoga relayout, and re-orders RN's
  own listener to fire after ours (RN's listener clamps `scrollY`
  against the current `child.getHeight()` at `ReactScrollView.java:1275`
  — if it ran first it would use the un-extended natural height and
  snap `scrollY` toward 0 as each AI reply chunk arrived). The listener
  is cleaned up in `onDetachedFromWindow`.

### iOS

- No iOS native changes. JS-side math was adjusted to match iOS's
  existing per-frame model (see "JS" above).

## 🤔 How Has This Been Tested?

<!-- TODO: fill in with the actual manual test matrix you ran. Suggested
     scenarios to cover: -->
<!-- - Short conversation (fits within viewport): drag starts inside
     message area, keyboard open/close, streaming reply growth. -->
<!-- - Long conversation: scroll position preserved when keyboard opens
     and closes. -->
<!-- - `persistent` keyboardLiftBehavior: close does not jump content. -->
<!-- - Inverted and non-inverted variants. -->
<!-- - iOS regression sweep on the same scenarios. -->

## 📸 Screenshots (if appropriate):

<!-- Before/after clips of short-content drag, mid-stream snap, and
     keyboard-close jump would all be valuable here. -->

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
