### PR TITLE
security: avoid compromised release being publish through the poisoned cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,5 +21,6 @@ jobs:
           # It increases the chance of a compromised release being publish
           # See https://github.com/actions/setup-node/issues/1445#issuecomment-4040130833
           # cache: yarn
+          package-manager-cache: false
       - run: yarn install --frozen-lockfile
       - run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
-          cache: yarn
+          # ⚠️ Do not use any cache on purpose
+          # It increases the chance of a compromised release being publish
+          # See https://github.com/actions/setup-node/issues/1445#issuecomment-4040130833
+          # cache: yarn
       - run: yarn install --frozen-lockfile
       - run: npm publish --provenance


### PR DESCRIPTION
## 📜 Description

Don't use `cache` for publish job.

## 💡 Motivation and Context

Based on https://github.com/actions/setup-node/issues/1445#issuecomment-4040130833

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- do not use cache for publishing (to avoid poisoned cache vector attack);

## 🤔 How Has This Been Tested?

There is no way to test it at the moment 😅 

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
