### PR TITLE
fix: delay `onStart` event

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -31,6 +31,13 @@ import kotlin.math.abs
 private val TAG = KeyboardAnimationCallback::class.qualifiedName
 private val isResizeHandledInCallbackMethods = Keyboard.IS_ANIMATION_EMULATED
 
+private data class PendingKeyboardStartEvent(
+  val keyboardHeight: Double,
+  val progress: Double,
+  val duration: Int,
+  val target: Int,
+)
+
 data class KeyboardAnimationCallbackConfig(
   val persistentInsetTypes: Int,
   val deferredInsetTypes: Int,
@@ -63,6 +70,7 @@ class KeyboardAnimationCallback(
   private var isTransitioning = false
   private var duration = 0
   private var viewTagFocused = -1
+  private var pendingStartEvent: PendingKeyboardStartEvent? = null
   private var animationsToSkip = hashSetOf<WindowInsetsAnimationCompat>()
   private val isKeyboardInteractive: Boolean
     get() = duration == -1
@@ -177,6 +185,7 @@ class KeyboardAnimationCallback(
     }
 
     isTransitioning = true
+    pendingStartEvent = null
     isKeyboardVisible = isKeyboardVisible()
     duration = animation.durationMillis.toInt()
     val keyboardHeight = getCurrentKeyboardHeight()
@@ -205,18 +214,16 @@ class KeyboardAnimationCallback(
     )
 
     Logger.i(TAG, "HEIGHT:: $keyboardHeight TAG:: $viewTagFocused")
-    context.dispatchEvent(
-      eventPropagationView.id,
-      KeyboardTransitionEvent(
-        surfaceId,
-        eventPropagationView.id,
-        KeyboardTransitionEvent.Start,
+    // AOSP calls app onStart before its internal listener.onReady. Dispatching
+    // a RN event here lets Reanimated synchronously mutate Fabric and can
+    // cancel the pending IME controller before Android starts its animator.
+    pendingStartEvent =
+      PendingKeyboardStartEvent(
         keyboardHeight,
         if (!isKeyboardVisible) 0.0 else 1.0,
         duration,
         viewTagFocused,
-      ),
-    )
+      )
 
     return super.onStart(animation, bounds)
   }
@@ -265,6 +272,11 @@ class KeyboardAnimationCallback(
       "DiffY: $diffY $height $progress ${InteractiveKeyboardProvider.isInteractive} $viewTagFocused",
     )
 
+    flushPendingStartEvent()
+    if (!isTransitioning) {
+      return insets
+    }
+
     val event =
       if (InteractiveKeyboardProvider.isInteractive) {
         KeyboardTransitionEvent.Interactive
@@ -306,9 +318,12 @@ class KeyboardAnimationCallback(
 
         if (animation in animationsToSkip) {
           duration = 0
+          pendingStartEvent = null
           animationsToSkip.remove(animation)
           return@Runnable
         }
+
+        flushPendingStartEvent()
 
         context.emitEvent(
           "KeyboardController::" + if (!isKeyboardVisible) "keyboardDidHide" else "keyboardDidShow",
@@ -352,6 +367,7 @@ class KeyboardAnimationCallback(
     prevKeyboardHeight = keyboardHeight
     isTransitioning = false
     duration = 0
+    pendingStartEvent = null
 
     context.emitEvent(
       "KeyboardController::" + if (!isKeyboardVisible) "keyboardDidHide" else "keyboardDidShow",
@@ -375,6 +391,7 @@ class KeyboardAnimationCallback(
   }
 
   fun destroy() {
+    pendingStartEvent = null
     view.viewTreeObserver.removeOnGlobalFocusChangeListener(focusListener)
     layoutObserver?.destroy()
   }
@@ -428,6 +445,24 @@ class KeyboardAnimationCallback(
 
     // on hide it will be negative value, so we are using max function
     return (keyboardHeight - navigationBar).toFloat().dp.coerceAtLeast(0.0)
+  }
+
+  private fun flushPendingStartEvent() {
+    val event = pendingStartEvent ?: return
+
+    pendingStartEvent = null
+    context.dispatchEvent(
+      eventPropagationView.id,
+      KeyboardTransitionEvent(
+        surfaceId,
+        eventPropagationView.id,
+        KeyboardTransitionEvent.Start,
+        event.keyboardHeight,
+        event.progress,
+        event.duration,
+        event.target,
+      ),
+    )
   }
 
   private fun getEventParams(height: Double): WritableMap {

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -273,28 +273,26 @@ class KeyboardAnimationCallback(
     )
 
     flushPendingStartEvent()
-    if (!isTransitioning) {
-      return insets
-    }
-
-    val event =
-      if (InteractiveKeyboardProvider.isInteractive) {
-        KeyboardTransitionEvent.Interactive
-      } else {
-        KeyboardTransitionEvent.Move
-      }
-    context.dispatchEvent(
-      eventPropagationView.id,
-      KeyboardTransitionEvent(
-        surfaceId,
+    if (isTransitioning) {
+      val event =
+        if (InteractiveKeyboardProvider.isInteractive) {
+          KeyboardTransitionEvent.Interactive
+        } else {
+          KeyboardTransitionEvent.Move
+        }
+      context.dispatchEvent(
         eventPropagationView.id,
-        event,
-        height,
-        progress,
-        duration,
-        viewTagFocused,
-      ),
-    )
+        KeyboardTransitionEvent(
+          surfaceId,
+          eventPropagationView.id,
+          event,
+          height,
+          progress,
+          duration,
+          viewTagFocused,
+        ),
+      )
+    }
 
     return insets
   }


### PR DESCRIPTION
## 📜 Description

Fixed `IllegalStateException` (can't change insets on an animation that is cancelled) crash on Android.

## 💡 Motivation and Context

The crash is caused by the synchronous nature of Fabric. When a continuous Reanimated animation is running, dispatching the keyboard `Start` event from `WindowInsetsAnimation.Callback.onStart` causes Reanimated to process the event immediately on the UI thread and flush pending animated view updates synchronously.

That synchronous flush mutates Fabric/native views while Android is still inside the IME animation start sequence. At this point AOSP has already checked that the `InsetsAnimationControlImpl` runner is not cancelled, then calls app callbacks via `dispatchWindowInsetsAnimationStart(...)`, but it has not yet called `listener.onReady(...)` to start the internal insets animator.

During our `onStart` callback, `context.dispatchEvent(...)` enters RN/Reanimated. Because there is a constantly running animation, Reanimated has pending UI work and `performOperations(true)` pushes it synchronously into Fabric. That can trigger layout/focus/insets side effects. In the focus-switch case, Android receives a competing IME/focus/show-hide operation and cancels the existing insets animation controller.

Then control returns to AOSP. AOSP continues as if the controller is still valid and calls `listener.onReady(...)`. `onReady` starts the internal `ValueAnimator`; on its first update it calls `InsetsAnimationControlImpl.setInsetsAndAlpha(...)`. Since the controller was cancelled reentrantly during our callback, `setInsetsAndAlpha` throws:

```text
IllegalStateException: Can't change insets on an animation that is cancelled.
```

The continuous Reanimated animation is not the logical keyboard bug by itself. It makes the race reproducible because every keyboard event dispatch has unrelated pending animated UI work ready to be flushed synchronously. Without that animation, the same event dispatch often does not mutate Fabric deeply enough to cancel the IME controller inside the fragile AOSP window.

`ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS` does not fully solve it because it changes the update path, not the timing. Reanimated still performs a synchronous UI-thread native mutation during Android’s `onStart` callback, so the same reentrant cancellation window remains.

Useful links:

- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/view/InsetsController.java#2089
- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/view/InsetsController.java#2086
- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/view/InsetsController.java#2109
- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/view/InsetsController.java#394
- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/view/InsetsController.java#430

The solution is to keep all native keyboard bookkeeping in Android `onStart`, but delay dispatching the RN/Reanimated `KeyboardTransitionEvent.Start` until the first safe point: `onProgress`, or `onEnd` if no progress arrives.

We chose this because the crash window is specifically inside AOSP’s `dispatchWindowInsetsAnimationStart(...)`, before `listener.onReady(...)`. Dispatching the RN event there can synchronously enter Reanimated/Fabric and cancel the pending IME controller. Dispatching it from `onProgress` happens after Android has already started the controller path, so Reanimated can no longer invalidate the controller before `onReady`.

This is a minimal keyboard-controller fix:

- It does not swallow or ignore the Android exception.
- It preserves event ordering: `Start` still happens before `Move`, and before `End` for zero-progress transitions.
- It keeps `keyboardWillShow/Hide`, height calculation, focus tag capture, and layout sync in native `onStart`.
- It avoids requiring app-level workarounds like disabling continuous Reanimated animations.
- It does not depend on Reanimated feature flags, which only change the Fabric update path, not the dangerous synchronous timing.

I also tested before/after and it looks like on my Android 16 the difference between events arrival to JS is 1-2ms without a fix, and 1ms with a fix 🤷‍♂️ I don't think 1ms difference can cause any issues because it's significantly lower than 1 frame range (7-8ms).

Code used for repro:

```tsx
import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
import { NavigationContainer } from "@react-navigation/native";
import React from "react";
import { View } from "react-native";
import { GestureHandlerRootView } from "react-native-gesture-handler";
import {
  KeyboardAwareScrollView,
  KeyboardProvider,
} from "react-native-keyboard-controller";
import { SafeAreaProvider } from "react-native-safe-area-context";

import { Loader } from "./Loader";
import { TextInputs } from "./TextInputs";

const App = () => (
  <SafeAreaProvider>
    <KeyboardProvider>
      <NavigationContainer>
        <GestureHandlerRootView style={{ flex: 1 }}>
          <BottomSheetModalProvider>
            <KeyboardAwareScrollView bottomOffset={50}>
              <View style={{ margin: 50 }}>
                <Loader loading={true} />

                <TextInputs />
              </View>
            </KeyboardAwareScrollView>
          </BottomSheetModalProvider>
        </GestureHandlerRootView>
      </NavigationContainer>
    </KeyboardProvider>
  </SafeAreaProvider>
);

export default App;
```

```tsx
import React, { memo, useEffect } from "react";
import { Dimensions, StyleSheet, View } from "react-native";
import Animated, {
  Easing,
  useAnimatedStyle,
  useSharedValue,
  withRepeat,
  withSequence,
  withTiming,
} from "react-native-reanimated";

export const Loader = memo(({ loading }: { loading: boolean }) => {
  const translateX = useSharedValue(0);
  const opacity = useSharedValue(0);
  const DURATION = 1000;

  // Animated style for the loader bar
  const animatedStyle = useAnimatedStyle(() => {
    return {
      transform: [{ translateX: translateX.value }],
      opacity: opacity.value,
      backgroundColor: "#FE5716",
    };
  });

  // Trigger the animation effect when the loader is loading
  useEffect(() => {
    if (loading) {
      opacity.value = 1;
      translateX.value = 0;
      translateX.value = withRepeat(
        withSequence(
          // Go to the right
          withTiming(loaderWidth, {
            duration: DURATION,
            easing: Easing.inOut(Easing.ease),
          }),
          // Go to the left
          withTiming(0, {
            duration: DURATION,
            easing: Easing.inOut(Easing.ease),
          }),
        ),
        -1, // Infinite repetitions
      );
    } else {
      // Fadeout the loader
      opacity.value = withTiming(0, { duration: 50 });
    }
  }, [loading]);

  return (
    <View style={styles.container}>
      <Animated.View style={[styles.loader, animatedStyle]} />
    </View>
  );
});

const loaderWidth = Dimensions.get("window").width + 100;

const styles = StyleSheet.create({
  container: {
    height: 2,
    width: "100%",
    flex: 1,
    overflow: "hidden",
  },
  loader: {
    height: "100%",
    width: 100,
    marginHorizontal: -100, // The loader starts outside the component
  },
});
```

```tsx
import { useRef } from "react";
import { TextInput } from "react-native";

export const TextInputs = () => {
  const input1 = useRef<TextInput>(null);
  const input2 = useRef<TextInput>(null);

  return (
    <>
      <TextInput
        ref={input1}
        keyboardType={"default"}
        placeholder={`TextInput#1`}
        returnKeyType="next"
        style={{paddingVertical: 10, marginVertical: 10, borderColor: "black", borderWidth: 1}}
        onSubmitEditing={() => input2.current?.focus()}
      />
      <TextInput
        ref={input2}
        keyboardType={"default"}
        placeholder={`TextInput#2}`}
        returnKeyType="next"
        style={{
          paddingVertical: 10,
          marginVertical: 10,
          borderColor: "black",
          borderWidth: 1,
        }}
      />
    </>
  );
};
```

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1456 https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1083

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added `PendingKeyboardStartEvent` class;
- clear `pendingStartEvent` in `onStart` and store  new`onStart` event metadata in `pendingStartEvent`;
- dispatch `KeyboardMoveStart` event from `onProgress`;
- cleanup `pendingStartEvent` in corresponding lifecycle methods (cleanup etc.)

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro (API 36, real device).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/950656c8-e767-4831-b746-78b3c822fc6a">|<video src="https://github.com/user-attachments/assets/655cb7db-1eae-448c-8c82-b4e6e9f4e904">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
