### PR TITLE
fix: crash on catalyst

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -195,7 +195,8 @@
     "lottiefiles",
     "dotlottie",
     "legendapp",
-    "kortix"
+    "kortix",
+    "MACCATALYST"
   ],
   "ignorePaths": [
     "node_modules",

--- a/ios/views/ClippingScrollViewDecoratorViewManager.mm
+++ b/ios/views/ClippingScrollViewDecoratorViewManager.mm
@@ -16,6 +16,7 @@
 #import "RCTFabricComponentsPlugins.h"
 #endif
 
+#import <TargetConditionals.h>
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 
@@ -213,11 +214,16 @@ RCT_EXPORT_VIEW_PROPERTY(applyWorkaroundForContentInsetHitTestBug, BOOL)
 {
   [super didMoveToWindow];
   if (self.window) {
+#if TARGET_OS_MACCATALYST
+    // Catalyst UIScrollView is AppKit-backed; avoid runtime subclassing it.
+    return;
+#else
     UIScrollView *scrollView = KCFindFirstScrollView(self);
     KCApplyNoopScrollRectToVisible(scrollView);
     if (self.applyWorkaroundForContentInsetHitTestBug) {
       KCApplyFixedHitTest(scrollView);
     }
+#endif
   }
 }
 


### PR DESCRIPTION
## 📜 Description

Fixed a crash when using `ClippingScrollViewDecorator` (`KeyboardAwareScrollView`/`KeyboardChatScrollView`) in MacCatalyst apps.

## 💡 Motivation and Context

That crash happens because we try to exchange of methods that don't exist in MacCatalyst implementation. When we run this code the UIKit gets backed by AppKit and mobile-specific methods don't exist. The fix is very simple - for mac catalyst we don't need to exchange the implementations of methods that don't exist.

Fix: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1454

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- don't swizzle implementation of non-existing methods on MacCatalyst;

## 🤔 How Has This Been Tested?

Tested in example catalyst app:

<img width="750" height="345" alt="image" src="https://github.com/user-attachments/assets/280faf74-ed59-4da2-99d7-c1e6b12e6ddd" />

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="1506" height="1030" alt="image" src="https://github.com/user-attachments/assets/c727a030-f476-4260-922d-e1371feb5802" />|<img width="1026" height="767" alt="image" src="https://github.com/user-attachments/assets/a6b765a4-1f06-4180-84a7-9bed5c85686c" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
