### PR TITLE
fix: use weak reference to keyboard view on iOS

### DIFF
--- a/ios/observers/movement/KeyboardViewLocator.swift
+++ b/ios/observers/movement/KeyboardViewLocator.swift
@@ -7,7 +7,7 @@
 
 final class KeyboardViewLocator {
   static let shared = KeyboardViewLocator()
-  private var cachedKeyboardView: UIView?
+  private weak var cachedKeyboardView: UIView?
   private var cachedWindowsCount: Int = 0
 
   func resolve() -> UIView? {


### PR DESCRIPTION
## 📜 Description

Use `weak` reference to `KeyboardView`.

## 💡 Motivation and Context

The keyboard is a system view and we don't manage a lifecycle of this view. So we shouldn't try to keep a reference to it when view has been destroyed. For that we need to use `weak` keyword so that when keyboard instance has been destroyed we'll try to find a new instance of the keyboard.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- use `weak` reference to the keyboard view in `KeyboardViewLocator`;

## 🤔 How Has This Been Tested?

Tested via e2e tests. The issue has been discovered on iOS 26.2 (there after keyboard dismissal the reference is stale and keyboard is getting re-created when it's getting shown again).

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
