### PR TITLE
fix(android): make onConfigurationChanged param non-nullable

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/EdgeToEdgeReactViewGroup.kt
@@ -94,7 +94,7 @@ class EdgeToEdgeReactViewGroup(
     this.deactivate()
   }
 
-  override fun onConfigurationChanged(newConfig: Configuration?) {
+  override fun onConfigurationChanged(newConfig: Configuration) {
     this.reApplyWindowInsets()
   }
   // endregion

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/background/KeyboardBackgroundViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/background/KeyboardBackgroundViewGroup.kt
@@ -17,7 +17,7 @@ class KeyboardBackgroundViewGroup(
   }
 
   // theme changed
-  override fun onConfigurationChanged(newConfig: Configuration?) {
+  override fun onConfigurationChanged(newConfig: Configuration) {
     super.onConfigurationChanged(newConfig)
     super.setBackgroundColor(reactContext.getInputMethodColor())
   }


### PR DESCRIPTION
## Description

Android's `View.onConfigurationChanged(@NonNull Configuration newConfig)` is now strictly enforced as non-null by Kotlin under the compileSdk shipped with React Native 0.86. The overrides in `EdgeToEdgeReactViewGroup` and `KeyboardBackgroundViewGroup` declared the parameter as `Configuration?`, which no longer matches the parent signature and breaks the build:

```
e: EdgeToEdgeReactViewGroup.kt:97 'onConfigurationChanged' overrides nothing.
Potential signatures for overriding:
fun onConfigurationChanged(newConfig: Configuration): Unit
e: KeyboardBackgroundViewGroup.kt:20 'onConfigurationChanged' overrides nothing.
e: KeyboardBackgroundViewGroup.kt:21 Argument type mismatch: actual type
is 'Configuration?', but 'Configuration' was expected.
```


Dropping the `?` matches the parent signature. The change is backwards-compatible with older React Native / compileSdk versions because the parent method is exposed there as a Kotlin platform type (`Configuration!`), which accepts a non-nullable override.

## 💡 Motivation and Context

- react-native 0.86 support

## 📢 Changelog

### Android

- Make `onConfigurationChanged` param non-nullable

## 🤔 How Has This Been Tested?

- Android build (`./gradlew :react-native-keyboard-controller:compileReleaseKotlin`) succeeds against React Native 0.86
- Android build still succeeds against the previously supported React Native versions
- Theme change still triggers `setBackgroundColor` / `reApplyWindowInsets` at runtime

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
