### PR TITLE
docs: add Juno to Trusted by

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -168,6 +168,12 @@ const trustedBy = [
     name: "PocketPal AI",
   },
   {
+    img: "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/2a/e4/a9/2ae4a9e5-40b0-1ee3-1382-c7f66361d38e/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg",
+    alt: "Juno text chat app",
+    link: "https://apps.apple.com/us/app/juno-chronic-illness-support/id6749455368?uo=4",
+    name: "Juno",
+  },
+  {
     img: "https://play-lh.googleusercontent.com/KsXljWMtBXw131OcLT44ByxwznfdgM1a-2gZVYNBzPBKz9gqOCxEIhC83IpS35OIZQc=w200-h480-rw",
     alt: "Drakula: Watch Videos App",
     link: "https://play.google.com/store/apps/details?id=app.drakula",


### PR DESCRIPTION
## Summary

- Add Juno to the homepage Trusted by list.
- Use the public App Store icon and listing URL.
- Scope the alt text to the Juno text chat app use case.

## Validation

- `git diff --check`
- `npx --yes prettier@2.8.8 --check docs/src/pages/index.tsx`
