### PR TITLE
fix(android): use composition for JSPointerDispatcherCompat

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/JSPointerDispatcherCompat.kt
@@ -1,17 +1,23 @@
 package com.reactnativekeyboardcontroller.views.overlay
 
 import android.view.MotionEvent
+import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.uimanager.JSPointerDispatcher
 import com.facebook.react.uimanager.events.EventDispatcher
 import java.lang.reflect.Method
 
 /**
- * Compat layer for `JSPointerDispatcher` interface for RN < 0.72
+ * Compat layer for `JSPointerDispatcher` interface for RN < 0.72.
+ *
+ * Uses composition instead of inheritance because `JSPointerDispatcher`
+ * became a final Kotlin class in RN 0.87+.
  */
 class JSPointerDispatcherCompat(
   viewGroup: ViewGroup,
-) : JSPointerDispatcher(viewGroup) {
+) {
+  private val delegate = JSPointerDispatcher(viewGroup)
+
   private val handleMotionEventMethod: Method? by lazy {
     try {
       // Try to get the 3-parameter method (for RN >= 0.72)
@@ -42,11 +48,23 @@ class JSPointerDispatcherCompat(
   ) {
     handleMotionEventMethod?.let { method ->
       if (method.parameterCount == RN_72_PARAMS_COUNT) {
-        method.invoke(this, event, eventDispatcher, isCapture)
+        method.invoke(delegate, event, eventDispatcher, isCapture)
       } else {
-        method.invoke(this, event, eventDispatcher)
+        method.invoke(delegate, event, eventDispatcher)
       }
     }
+  }
+
+  fun onChildStartedNativeGesture(
+    childView: View?,
+    ev: MotionEvent,
+    eventDispatcher: EventDispatcher,
+  ) {
+    delegate.onChildStartedNativeGesture(childView, ev, eventDispatcher)
+  }
+
+  fun onChildEndedNativeGesture() {
+    delegate.onChildEndedNativeGesture()
   }
 
   companion object {


### PR DESCRIPTION
## 📜 Description

JSPointerDispatcher became a final Kotlin class in React Native 0.87+
(after the Java-to-Kotlin migration in https://github.com/facebook/react-native/pull/56910), so
JSPointerDispatcherCompat can no longer extend it.

While I'm restoring it in:
- https://github.com/facebook/react-native/pull/57022

Ideally we would want to reduce the API surface of RN apis. 

So here I'm switching from inheritance to composition by holding an internal
JSPointerDispatcher delegate and forwarding calls to it.

## 🤔 How Has This Been Tested?

Looking for guidance on how to test this.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

N/A

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
