### PR TITLE
fix: ios e2e job title

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -120,7 +120,7 @@ jobs:
             echo 'matrix={"devices": [{"ios": 15, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "15.5", "iphone": "iPhone 13 Pro", "os": "15.5"}, {"ios": 16, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "16.4", "iphone": "iPhone 14 Pro", "os": "16.4"}, {"ios": 17, artifact: "16.4", "xcode": "16.4", "macos": 15, "runtime": "17.5", "iphone": "iPhone 15 Pro", "os": "17.5"}, {"ios": 18, artifact: "16.4", "xcode": "16.4", "macos": 15, "iphone": "iPhone 16 Pro", "os": "18.5"}, {"ios": 26, artifact: "16.4", "xcode": "26.0", "macos": 15, "iphone": "iPhone 17 Pro", "os": "26.2"}, {"ios": "26e", artifact: "26.4", "xcode": "26.1", "macos": 15, "iphone": "iPhone 16e", "os": "26.1"}]}' >> $GITHUB_OUTPUT
           fi
   e2e-test:
-    name: ⚙️ Automated test cases (iOS-${{ matrix.devices.ios }}, XCode-${{ matrix.devices.artifact }})
+    name: ⚙️ Automated test cases (iOS-${{ matrix.devices.ios }}, XCode-${{ matrix.devices.xcode }})
     runs-on: macos-${{ matrix.devices.macos }}
     timeout-minutes: 90
     env:


### PR DESCRIPTION
## 📜 Description

Fixed a problem when e2e job shows incorrect XCode version used in tests.

## 💡 Motivation and Context

Build can be performed on a different XCode version than actual run of the application.

So we should use `xcode` version in job title, not `artifact`.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- use `xcode` instead of `artifact` for xcode runner version;

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="748" height="588" alt="image" src="https://github.com/user-attachments/assets/0ff73c5c-f7f2-4878-bf09-12cbf3d635ac" />|<img width="747" height="440" alt="image" src="https://github.com/user-attachments/assets/80fcfb86-a7b4-429a-8a92-ebc9672a2ffa" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
