### PR TITLE
fix: missing scroll animation when switching between inputs in `KeyboardAwareScrollView`

### DIFF
--- a/src/components/KeyboardAwareScrollView/__tests__/toolbar.spec.tsx
+++ b/src/components/KeyboardAwareScrollView/__tests__/toolbar.spec.tsx
@@ -11,8 +11,11 @@ import {
   lastScrollToY,
   mockInput,
   mockKeyboardHandlers,
+  mockLayout,
+  mockOffset,
   mockScrollTo,
   mockSelectionHandler,
+  mockSize,
   renderKeyboardAwareScrollView,
   reset,
   selectionEvent,
@@ -59,5 +62,40 @@ describe("KeyboardAwareScrollView — toolbar focus switch", () => {
     // point = 695.67 + 47 = 742.67
     // relativeScrollTo = 312 - (928 - 742.67) + 62 = 188.67
     expect(lastScrollToY()).toBeCloseTo(188.67, 0);
+  });
+
+  it("should not cancel an animated same-height focus scroll when ghost padding is positive", async () => {
+    await renderKeyboardAwareScrollView();
+    mockInput.value = inputEvent(INPUT_TARGET_A, INPUT_LAYOUT_A);
+
+    // Focus input A so the keyboard is already visible and the next focus
+    // change is a same-height keyboard event.
+    mockSelectionHandler.current(selectionEvent(INPUT_TARGET_A));
+    mockKeyboardHandlers.current.onStart(
+      kbEvent(KEYBOARD_HEIGHT, INPUT_TARGET_A),
+    );
+    mockKeyboardHandlers.current.onEnd(
+      kbEvent(KEYBOARD_HEIGHT, INPUT_TARGET_A),
+    );
+
+    mockLayout.value = { width: 402, height: 636.67 };
+    mockSize.value = { width: 370, height: 1050 };
+    mockOffset.value = 638.33;
+    mockInput.value = inputEvent(INPUT_TARGET_B, INPUT_LAYOUT_B);
+    mockScrollTo.mockClear();
+
+    // iOS can deliver the fresh selection before the same-height onStart.
+    // onStart then issues the animated scroll and computes positive ghost space.
+    mockSelectionHandler.current(selectionEvent(INPUT_TARGET_B, 47, 0));
+    mockKeyboardHandlers.current.onStart(
+      kbEvent(KEYBOARD_HEIGHT, INPUT_TARGET_B),
+    );
+    mockKeyboardHandlers.current.onEnd(
+      kbEvent(KEYBOARD_HEIGHT, INPUT_TARGET_B),
+    );
+
+    expect(mockScrollTo).toHaveBeenCalledTimes(1);
+    expect(mockScrollTo.mock.calls[0][2]).toBeCloseTo(827, 0);
+    expect(mockScrollTo.mock.calls[0][3]).toBe(true);
   });
 });

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -526,11 +526,13 @@ const KeyboardAwareScrollView = forwardRef<
     const synchronize = useCallback(async () => {
       await update();
 
-      runOnUI(() => {
-        "worklet";
+      setTimeout(() => {
+        runOnUI(() => {
+          "worklet";
 
-        scrollFromCurrentPosition();
-      })();
+          scrollFromCurrentPosition();
+        })();
+      }, 1000);
     }, [update, scrollFromCurrentPosition]);
 
     useImperativeHandle(

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -493,7 +493,9 @@ const KeyboardAwareScrollView = forwardRef<
         onEnd: (e) => {
           "worklet";
 
-          removeGhostPadding(e.height);
+          if (e.height === 0) {
+            removeGhostPadding(e.height);
+          }
 
           keyboardHeight.value = e.height;
           scrollPosition.value = position.value;

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -526,13 +526,13 @@ const KeyboardAwareScrollView = forwardRef<
     const synchronize = useCallback(async () => {
       await update();
 
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         runOnUI(() => {
           "worklet";
 
           scrollFromCurrentPosition();
         })();
-      }, 1000);
+      });
     }, [update, scrollFromCurrentPosition]);
 
     useImperativeHandle(


### PR DESCRIPTION
## 📜 Description

Fixed a problem with missing animation in `KeyboardAwareScrollView` when switching between fields.

## 💡 Motivation and Context

The problem was because `removeGhostPadding` performed a synchronous `scrollTo` (which overrides the effect of prior `scrollTo` call with animation).

The fix is to skip the call when it's not necessary.

Additionally I tried to fix flakiness of `KeyboardAwareScrollViewStickyView` tests by increasing an interval between shared value update and call a function on a UI thread.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1483

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- wrap `runOnUI` in `requestAnimationFrame`;
- call `removeGhostPadding` only when keyboard is hidden (`e.height === 0`)
- cover the regression with unit tests;

## 🤔 How Has This Been Tested?

Tested on iPhone 17 Pro (iOS 26.2) + e2e tests.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/8016df4e-ae1d-4c86-8d6a-35dfbec5c7d0">|<video src="https://github.com/user-attachments/assets/8ab020d4-2d87-4ada-bd66-387de7aef30f">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
