### PR TITLE
fix: prevent crash when `KeyboardChatScrollView` unmounted

### DIFF
--- a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
+++ b/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
@@ -69,6 +69,11 @@ function useExtraContentPadding(options: UseExtraContentPaddingOptions): void {
         // Defer scrollTo so the animatedProps inset commit lands first;
         // otherwise the native ScrollView clamps to the old range.
         requestAnimationFrame(() => {
+          // check that view is still mounted and ref is actual
+          // otherwise it may lead to a crash
+          if (!scrollViewRef()) {
+            return;
+          }
           scrollTo(scrollViewRef, 0, target, false);
         });
       } else {


### PR DESCRIPTION
## 📜 Description

Fixed a crash on Android when using `KeyboardChatScrollView`.

## 💡 Motivation and Context

We may schedule a call to perform `scrollTo` later. But if the component is unmounted, then we will get a crash.

In this PR I'm adding a check to skip `scrollTo` operation if view was unmounted.

Based on https://github.com/bluesky-social/social-app/pull/10673

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- skip `scrollTo` if ref is null;

## 🤔 How Has This Been Tested?

There is no way to test it at the moment, but CI is green 🟢 

## 📸 Screenshots (if appropriate):

<img width="808" height="298" alt="image" src="https://github.com/user-attachments/assets/380c610f-3dd0-44e0-b9e0-118d44b42ae8" />


## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
