### PR TITLE
fix: non-scrollable `ScrollView` when `blankSpace` is big should make it scrollable

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
@@ -15,6 +15,21 @@ class ClippingScrollViewDecoratorView(
   private var insetBottom = 0.0
   private var insetTop = 0.0
   private var appliedTopInsetPx = 0
+  private var appliedContentInsetPx = 0
+  private var contentViewBaseBottom = 0
+  private var decoratedContentView: ViewGroup? = null
+  private var isApplyingContentInset = false
+  private val contentLayoutListener =
+    View.OnLayoutChangeListener { view, _, _, _, bottom, _, _, _, _ ->
+      if (isApplyingContentInset) {
+        return@OnLayoutChangeListener
+      }
+
+      val contentView = view as? ViewGroup ?: return@OnLayoutChangeListener
+
+      contentViewBaseBottom = bottom
+      applyContentInset(contentView, appliedContentInsetPx)
+    }
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
@@ -49,13 +64,21 @@ class ClippingScrollViewDecoratorView(
     // not translationY).
     val contentView = scrollView.getChildAt(0) as? ViewGroup ?: return
     contentView.translationY = newTopInsetPx.toFloat()
+    trackContentView(contentView)
 
     scrollView.setPadding(
       scrollView.paddingLeft,
       scrollView.paddingTop,
       scrollView.paddingRight,
-      // pass accumulated value — visually both top and bottom insets
-      // extend the scroll range via bottom padding
+      0,
+    )
+
+    // Extend the real child bottom instead of ScrollView padding. Android's
+    // ScrollView.canScrollVertically() ignores padding-created range, which
+    // prevents child-started drags when the content itself is shorter than the
+    // viewport.
+    applyContentInset(
+      contentView,
       (insetBottom + insetTop).toFloat().px.toInt(),
     )
 
@@ -82,5 +105,35 @@ class ClippingScrollViewDecoratorView(
     }
 
     return result
+  }
+
+  private fun trackContentView(contentView: ViewGroup) {
+    if (decoratedContentView === contentView) {
+      return
+    }
+
+    decoratedContentView?.removeOnLayoutChangeListener(contentLayoutListener)
+    decoratedContentView = contentView
+    contentViewBaseBottom = contentView.bottom
+    contentView.addOnLayoutChangeListener(contentLayoutListener)
+  }
+
+  private fun applyContentInset(
+    contentView: ViewGroup,
+    insetPx: Int,
+  ) {
+    appliedContentInsetPx = insetPx
+
+    val targetBottom = contentViewBaseBottom + insetPx
+    if (contentView.bottom == targetBottom) {
+      return
+    }
+
+    isApplyingContentInset = true
+    try {
+      contentView.bottom = targetBottom
+    } finally {
+      isApplyingContentInset = false
+    }
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
@@ -1,12 +1,14 @@
 package com.reactnativekeyboardcontroller.views
 
 import android.annotation.SuppressLint
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.extensions.px
+import kotlin.math.max
 
 @SuppressLint("ViewConstructor")
 class ClippingScrollViewDecoratorView(
@@ -15,26 +17,40 @@ class ClippingScrollViewDecoratorView(
   private var insetBottom = 0.0
   private var insetTop = 0.0
   private var appliedTopInsetPx = 0
-  private var appliedContentInsetPx = 0
-  private var contentViewBaseBottom = 0
-  private var decoratedContentView: ViewGroup? = null
-  private var isApplyingContentInset = false
-  private val contentLayoutListener =
-    View.OnLayoutChangeListener { view, _, _, _, bottom, _, _, _, _ ->
-      if (isApplyingContentInset) {
-        return@OnLayoutChangeListener
-      }
-
-      val contentView = view as? ViewGroup ?: return@OnLayoutChangeListener
-
-      contentViewBaseBottom = bottom
-      applyContentInset(contentView, appliedContentInsetPx)
-    }
+  private var paddingScrollWorkaroundActive = false
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
 
     decorateScrollView()
+  }
+
+  override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+    val scrollView = findScrollView(this)
+
+    if (scrollView == null) {
+      return super.dispatchTouchEvent(event)
+    }
+
+    if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+      paddingScrollWorkaroundActive = shouldUsePaddingScrollWorkaround(scrollView, event)
+    }
+
+    val handled =
+      if (paddingScrollWorkaroundActive) {
+        dispatchWithExpandedContentRange(scrollView, event)
+      } else {
+        super.dispatchTouchEvent(event)
+      }
+
+    if (
+      event.actionMasked == MotionEvent.ACTION_UP ||
+      event.actionMasked == MotionEvent.ACTION_CANCEL
+    ) {
+      paddingScrollWorkaroundActive = false
+    }
+
+    return handled
   }
 
   fun setContentInsetBottom(value: Double) {
@@ -64,21 +80,13 @@ class ClippingScrollViewDecoratorView(
     // not translationY).
     val contentView = scrollView.getChildAt(0) as? ViewGroup ?: return
     contentView.translationY = newTopInsetPx.toFloat()
-    trackContentView(contentView)
 
     scrollView.setPadding(
       scrollView.paddingLeft,
       scrollView.paddingTop,
       scrollView.paddingRight,
-      0,
-    )
-
-    // Extend the real child bottom instead of ScrollView padding. Android's
-    // ScrollView.canScrollVertically() ignores padding-created range, which
-    // prevents child-started drags when the content itself is shorter than the
-    // viewport.
-    applyContentInset(
-      contentView,
+      // pass accumulated value — visually both top and bottom insets
+      // extend the scroll range via bottom padding
       (insetBottom + insetTop).toFloat().px.toInt(),
     )
 
@@ -89,6 +97,65 @@ class ClippingScrollViewDecoratorView(
     }
 
     appliedTopInsetPx = newTopInsetPx
+  }
+
+  private fun shouldUsePaddingScrollWorkaround(
+    scrollView: ScrollView,
+    event: MotionEvent,
+  ): Boolean {
+    val contentView = scrollView.getChildAt(0) ?: return false
+    val viewportHeight =
+      scrollView.height - scrollView.paddingTop - scrollView.paddingBottom
+    val paddingCreatesScrollRange = contentView.height > viewportHeight
+
+    return scrollView.scrollY == 0 &&
+      paddingCreatesScrollRange &&
+      !scrollView.canScrollVertically(1) &&
+      isTouchInScrollContent(scrollView, event)
+  }
+
+  private fun dispatchWithExpandedContentRange(
+    scrollView: ScrollView,
+    event: MotionEvent,
+  ): Boolean {
+    val contentView = scrollView.getChildAt(0) ?: return super.dispatchTouchEvent(event)
+    val originalBottom = contentView.bottom
+    val expandedBottom =
+      max(originalBottom, scrollView.height + scrollView.scrollY + MIN_SCROLL_RANGE_PX)
+
+    if (expandedBottom == originalBottom) {
+      return super.dispatchTouchEvent(event)
+    }
+
+    return try {
+      contentView.bottom = expandedBottom
+      super.dispatchTouchEvent(event)
+    } finally {
+      contentView.bottom = originalBottom
+    }
+  }
+
+  private fun isTouchInScrollContent(
+    scrollView: ScrollView,
+    event: MotionEvent,
+  ): Boolean {
+    val contentView = scrollView.getChildAt(0) ?: return false
+    val thisLocation = IntArray(COORDINATES_SIZE)
+    val scrollViewLocation = IntArray(COORDINATES_SIZE)
+
+    getLocationOnScreen(thisLocation)
+    scrollView.getLocationOnScreen(scrollViewLocation)
+
+    val x = event.x + thisLocation[0] - scrollViewLocation[0]
+    val y = event.y + thisLocation[1] - scrollViewLocation[1]
+    val scrollY = scrollView.scrollY
+
+    return !(
+      y < contentView.top - scrollY ||
+        y >= contentView.bottom - scrollY ||
+        x < contentView.left ||
+        x >= contentView.right
+    )
   }
 
   private fun findScrollView(view: View?): ScrollView? {
@@ -107,33 +174,8 @@ class ClippingScrollViewDecoratorView(
     return result
   }
 
-  private fun trackContentView(contentView: ViewGroup) {
-    if (decoratedContentView === contentView) {
-      return
-    }
-
-    decoratedContentView?.removeOnLayoutChangeListener(contentLayoutListener)
-    decoratedContentView = contentView
-    contentViewBaseBottom = contentView.bottom
-    contentView.addOnLayoutChangeListener(contentLayoutListener)
-  }
-
-  private fun applyContentInset(
-    contentView: ViewGroup,
-    insetPx: Int,
-  ) {
-    appliedContentInsetPx = insetPx
-
-    val targetBottom = contentViewBaseBottom + insetPx
-    if (contentView.bottom == targetBottom) {
-      return
-    }
-
-    isApplyingContentInset = true
-    try {
-      contentView.bottom = targetBottom
-    } finally {
-      isApplyingContentInset = false
-    }
+  companion object {
+    private const val COORDINATES_SIZE = 2
+    private const val MIN_SCROLL_RANGE_PX = 2
   }
 }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
@@ -118,12 +118,12 @@ class ClippingScrollViewDecoratorView(
     scrollView: ScrollView,
     event: MotionEvent,
   ): Boolean {
-    val contentView = scrollView.getChildAt(0) ?: return super.dispatchTouchEvent(event)
-    val originalBottom = contentView.bottom
+    val contentView = scrollView.getChildAt(0)
+    val originalBottom = contentView?.bottom ?: 0
     val expandedBottom =
       max(originalBottom, scrollView.height + scrollView.scrollY + MIN_SCROLL_RANGE_PX)
 
-    if (expandedBottom == originalBottom) {
+    if (contentView == null || expandedBottom == originalBottom) {
       return super.dispatchTouchEvent(event)
     }
 

--- a/src/components/KeyboardChatScrollView/index.tsx
+++ b/src/components/KeyboardChatScrollView/index.tsx
@@ -88,8 +88,18 @@ const KeyboardChatScrollView = forwardRef<
       onEndVisible,
     });
 
+    // intentionally clamp `blankSpace` at one ScrollView viewport. The Android
+    // `ClippingScrollView` workaround temporarily substitutes padding/range
+    // during touch handling, and oversized blank ranges can de-sync during fast
+    // momentum gestures. One viewport is enough for the short-content case;
+    // larger values only allow scrolling to a fully blank screen which is not
+    // the use case for this library. If you found this comment and it causes
+    // a bug for you, please open an issue.
     const totalPadding = useDerivedValue(() =>
-      Math.max(blankSpace.value, padding.value + extraContentPadding.value),
+      Math.min(
+        layout.value.height,
+        Math.max(blankSpace.value, padding.value + extraContentPadding.value),
+      ),
     );
 
     // Scroll indicator inset = keyboard + extraContentPadding (excludes blankSpace).


### PR DESCRIPTION
## 📜 Description

This fixes an Android-only `KeyboardChatScrollView` edge case where short content can become scrollable only because of `blankSpace`, but a scroll gesture that starts on the content is not intercepted by the `ScrollView`.

## 💡 Motivation and Context

The root cause is not Fabric and not React Native “overriding touch events” in the usual sense. The issue comes from Android `ScrollView` having two different scrollability calculations when padding is used as synthetic scrollable space.

[AOSP ScrollView.java](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/widget/ScrollView.java#581) `ScrollView.onInterceptTouchEvent` exits early when it thinks the view cannot scroll down:

```java
if (getScrollY() == 0 && !canScrollVertically(1)) {
  return false;
}
```

`canScrollVertically()` is implemented on [View](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/view/View.java#22167) and uses:

```java
computeVerticalScrollRange() - computeVerticalScrollExtent()
```

For [ScrollView](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/widget/ScrollView.java#1338), `computeVerticalScrollRange()` is based on the content child bounds:

```java
int scrollRange = getChildAt(0).getBottom();
```

That does not include `paddingBottom`.

But the actual scroll/drag range uses [`getScrollRange()`](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/widget/ScrollView.java#1036):

```java
child.getHeight() - (getHeight() - mPaddingBottom - mPaddingTop)
```

That does include padding, because padding reduces the viewport height.

So with short content plus padding-backed `blankSpace`, Android can get into this contradictory state:

```text
canScrollVertically(1) -> false
actual getScrollRange() -> positive
```

React Native is not the primary source of the bug. `ReactScrollView` adds RN event/state handling, but still delegates interception and touch handling to AOSP `ScrollView`. The package triggers the Android edge case because `KeyboardChatScrollView` uses native padding to model an iOS-like `contentInset`/`blankSpace`.

There are a few possible ways to fix this:

1. Patch Android or React Native `ScrollView` so `canScrollVertically()` and the actual scroll range agree when padding is used as scrollable inset. This would be the most fundamental fix, but it is outside this package.

2. Own a custom Android `ReactScrollView` subclass and override the relevant scrollability/range methods. This is more correct in isolation, but it is a large maintenance burden because we would need to preserve React Native ScrollView props, events, commands, refs, Paper/Fabric behavior, and Reanimated compatibility.

3. Represent `blankSpace` as real content layout, for example with a spacer/footer or `contentContainerStyle.paddingBottom`. This makes Android’s range calculations agree naturally, but it changes content layout semantics and can interfere with virtualized lists (it changes layout, JS update may overwrite it etc., not really "safe" way of doing this)

4. Keep the current `ClippingScrollView` approach and avoid pathological blank ranges.

This PR chooses option 4. The native workaround fixes the short-content gesture issue without forking React Native’s ScrollView or changing user content layout. On top of that, we clamp `blankSpace` in JS so it cannot exceed one ScrollView viewport. Otherwise we have this bug:

https://github.com/user-attachments/assets/5311381b-76ad-4f0e-95b5-f235741ab754

The JS clamp is needed because values larger than the viewport create a scroll range made mostly or entirely of empty space. That oversized empty range is not useful for the chat use case and can expose Android momentum/range desynchronization during fast gestures. One viewport of `blankSpace` is enough to make short content scrollable and position it correctly; larger values only allow scrolling to a fully blank screen: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1497 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1497 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1453 https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1455

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

## 📢 Changelog

### JS

- clamp `KeyboardChatScrollView` `blankSpace` to the ScrollView viewport height;
- prevent oversized blank scroll ranges that can cause Android momentum flicker;

### Android

- adjust `ClippingScrollViewDecoratorView` touch handling to allow short content with padding-backed `blankSpace` to start scrolling from the content area;
- keep the temporary content range expansion scoped to the touch dispatch path and restore it immediately after dispatch;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro (API 36).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/2c9aabdd-7252-4d23-95a2-9de944ecdafa">|<video src="https://github.com/user-attachments/assets/8e64eefd-55a8-49ce-8f53-ac32d6b36598">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
