### PR TITLE
fix: missing `themedContext` getter causes compilation errors

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardHostShadowNode.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardHostShadowNode.kt
@@ -23,7 +23,9 @@ internal class OverKeyboardHostShadowNode : LayoutShadowNode() {
     i: Int,
   ) {
     super.addChildAt(child, i)
-    val displaySize = themedContext.getDisplaySize()
+    // intentionally use the explicit getter because newer RN Kotlin files no longer
+    // generate the property accessor, so Kotlin property access would fail to compile.
+    @Suppress("UsePropertyAccessSyntax") val displaySize = getThemedContext().getDisplaySize()
     child.setStyleWidth(displaySize.x.toFloat())
     child.setStyleHeight(displaySize.y.toFloat())
   }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardHostShadowNode.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/overlay/OverKeyboardHostShadowNode.kt
@@ -25,7 +25,8 @@ internal class OverKeyboardHostShadowNode : LayoutShadowNode() {
     super.addChildAt(child, i)
     // intentionally use the explicit getter because newer RN Kotlin files no longer
     // generate the property accessor, so Kotlin property access would fail to compile.
-    @Suppress("UsePropertyAccessSyntax") val displaySize = getThemedContext().getDisplaySize()
+    @Suppress("UsePropertyAccessSyntax")
+    val displaySize = getThemedContext().getDisplaySize()
     child.setStyleWidth(displaySize.x.toFloat())
     child.setStyleHeight(displaySize.y.toFloat())
   }


### PR DESCRIPTION
## 📜 Description

Use getter for `themedContext` explicitly. Don't rely on auto-getters anymore.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1489

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- explicitly use `getThemedContext` getter;

## 🤔 How Has This Been Tested?

Tested via CI. Old RN versions works as expected.

## 📸 Screenshots (if appropriate):

<img width="810" height="382" alt="image" src="https://github.com/user-attachments/assets/bf2389ec-d216-473c-8989-2abff54d35cd" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
