### PR TITLE
fix: reconcile frozen chat keyboard padding

### DIFF
--- a/src/components/KeyboardChatScrollView/useChatKeyboard/__fixtures__/testUtils.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/__fixtures__/testUtils.ts
@@ -22,6 +22,14 @@ export const mockSize = { value: { width: 390, height: 2000 } };
 export const KEYBOARD = 300;
 export const mockScrollTo = jest.fn();
 
+type Reaction = {
+  producer: () => unknown;
+  effect: (current: unknown, previous: unknown | null) => void;
+  previous: unknown;
+};
+
+const reactions: Reaction[] = [];
+
 /**
  * Linear interpolate mock matching Reanimated's `interpolate` signature.
  *
@@ -61,15 +69,36 @@ export function reset() {
  */
 export function setupBeforeEach() {
   jest.resetModules();
+  reactions.length = 0;
 
   jest.doMock("react-native-reanimated", () => ({
     ...require("react-native-reanimated/mock"),
     scrollTo: mockScrollTo,
     interpolate: mockInterpolate,
+    useAnimatedReaction: (
+      producer: () => unknown,
+      effect: (current: unknown, previous: unknown | null) => void,
+    ) => {
+      reactions.push({
+        producer,
+        effect,
+        previous: producer(),
+      });
+    },
   }));
 
   reset();
   mockScrollTo.mockClear();
+}
+
+/** Run registered Reanimated reactions after mutating mocked shared values. */
+export function flushAnimatedReactions() {
+  for (const reaction of reactions) {
+    const current = reaction.producer();
+
+    reaction.effect(current, reaction.previous);
+    reaction.previous = current;
+  }
 }
 
 type RenderOptions = Omit<

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/freeze.android.spec.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/freeze.android.spec.ts
@@ -1,7 +1,9 @@
+import { sv } from "../../../../__fixtures__/sv";
 import {
   type Handlers,
   KEYBOARD,
   createRender,
+  flushAnimatedReactions,
   mockLayout,
   mockOffset,
   mockScrollTo,
@@ -74,6 +76,31 @@ describe("`useChatKeyboard` — Android freeze", () => {
     });
 
     handlers.onEnd({ height: KEYBOARD });
+
+    expect(result.current.padding.value).toBe(0);
+  });
+
+  it("should apply the latest frozen keyboard padding when unfrozen", () => {
+    const freeze = sv(false);
+    const { result } = render({
+      inverted: false,
+      keyboardLiftBehavior: "always",
+      freeze,
+    });
+
+    handlers.onStart({ height: KEYBOARD });
+    handlers.onEnd({ height: KEYBOARD });
+    expect(result.current.padding.value).toBe(KEYBOARD);
+
+    freeze.value = true;
+    flushAnimatedReactions();
+    handlers.onStart({ height: 0 });
+    handlers.onMove({ height: 120 });
+    handlers.onEnd({ height: 0 });
+    expect(result.current.padding.value).toBe(KEYBOARD);
+
+    freeze.value = false;
+    flushAnimatedReactions();
 
     expect(result.current.padding.value).toBe(0);
   });

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/index.ios.spec.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/index.ios.spec.ts
@@ -1,7 +1,9 @@
+import { sv } from "../../../../__fixtures__/sv";
 import {
   type Handlers,
   KEYBOARD,
   createRender,
+  flushAnimatedReactions,
   mockLayout,
   mockOffset,
   mockScrollTo,
@@ -102,6 +104,29 @@ describe("`useChatKeyboard` — iOS non-inverted + always", () => {
     handlers.onMove({ height: 150 });
 
     expect(mockScrollTo).not.toHaveBeenCalled();
+  });
+
+  it("should apply the latest frozen keyboard padding when unfrozen", () => {
+    const freeze = sv(false);
+    const { result } = render({
+      inverted: false,
+      keyboardLiftBehavior: "always",
+      freeze,
+    });
+
+    handlers.onStart({ height: KEYBOARD });
+    expect(result.current.padding.value).toBe(KEYBOARD);
+
+    freeze.value = true;
+    flushAnimatedReactions();
+    handlers.onStart({ height: 0 });
+    handlers.onEnd({ height: 0 });
+    expect(result.current.padding.value).toBe(KEYBOARD);
+
+    freeze.value = false;
+    flushAnimatedReactions();
+
+    expect(result.current.padding.value).toBe(0);
   });
 });
 

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/index.ios.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/index.ios.ts
@@ -1,4 +1,4 @@
-import { useSharedValue } from "react-native-reanimated";
+import { useAnimatedReaction, useSharedValue } from "react-native-reanimated";
 
 import { useKeyboardHandler } from "../../../hooks";
 import useScrollState from "../../hooks/useScrollState";
@@ -64,14 +64,12 @@ function useChatKeyboard(
       onStart: (e) => {
         "worklet";
 
-        if (freeze.value) {
-          return;
-        }
-
         if (e.height > 0) {
           // eslint-disable-next-line react-compiler/react-compiler
           targetKeyboardHeight.value = e.height;
         }
+
+        currentHeight.value = e.height;
 
         const effective = getEffectiveHeight(
           e.height,
@@ -108,6 +106,10 @@ function useChatKeyboard(
           blankSpace.value,
           effective + extraContentPadding.value,
         );
+
+        if (freeze.value) {
+          return;
+        }
 
         // persistent mode: when keyboard shrinks, clamp to valid range
         if (
@@ -229,9 +231,7 @@ function useChatKeyboard(
       onEnd: (e) => {
         "worklet";
 
-        if (freeze.value) {
-          return;
-        }
+        currentHeight.value = e.height;
 
         const effective = getEffectiveHeight(
           e.height,
@@ -239,10 +239,28 @@ function useChatKeyboard(
           offset,
         );
 
+        if (freeze.value) {
+          return;
+        }
+
         padding.value = effective;
       },
     },
     [inverted, keyboardLiftBehavior, offset, extraContentPadding],
+  );
+
+  useAnimatedReaction(
+    () => freeze.value,
+    (isFrozen, wasFrozen) => {
+      if (!isFrozen && wasFrozen === true) {
+        padding.value = getEffectiveHeight(
+          currentHeight.value,
+          targetKeyboardHeight.value,
+          offset,
+        );
+      }
+    },
+    [offset],
   );
 
   return {

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
@@ -1,4 +1,8 @@
-import { scrollTo, useSharedValue } from "react-native-reanimated";
+import {
+  scrollTo,
+  useAnimatedReaction,
+  useSharedValue,
+} from "react-native-reanimated";
 
 import { useKeyboardHandler } from "../../../hooks";
 import useScrollState from "../../hooks/useScrollState";
@@ -82,13 +86,10 @@ function useChatKeyboard(
       onStart: (e) => {
         "worklet";
 
-        if (freeze.value) {
-          return;
-        }
-
         if (e.height > 0) {
           // eslint-disable-next-line react-compiler/react-compiler
           targetKeyboardHeight.value = e.height;
+          currentHeight.value = e.height;
           closing.value = false;
         } else {
           closing.value = true;
@@ -128,6 +129,10 @@ function useChatKeyboard(
           minimumPaddingAbsorbed,
         );
 
+        if (freeze.value) {
+          return;
+        }
+
         if (inverted && e.duration === -1) {
           // Android inverted: skip post-interactive snap-back events
           // (duration === -1 means the keyboard is re-establishing its
@@ -166,10 +171,6 @@ function useChatKeyboard(
       onMove: (e) => {
         "worklet";
 
-        if (freeze.value) {
-          return;
-        }
-
         currentHeight.value = e.height;
 
         if (inverted) {
@@ -183,6 +184,10 @@ function useChatKeyboard(
             targetKeyboardHeight.value,
             offset,
           );
+
+          if (freeze.value) {
+            return;
+          }
 
           const minimumPaddingAbsorbed =
             getMinimumPaddingAbsorbed(
@@ -269,6 +274,10 @@ function useChatKeyboard(
             offset,
           );
 
+          if (freeze.value) {
+            return;
+          }
+
           const minimumPaddingAbsorbed =
             getMinimumPaddingAbsorbed(
               blankSpace.value,
@@ -340,15 +349,17 @@ function useChatKeyboard(
       onEnd: (e) => {
         "worklet";
 
-        if (freeze.value) {
-          return;
-        }
+        currentHeight.value = e.height;
 
         const effective = getEffectiveHeight(
           e.height,
           targetKeyboardHeight.value,
           offset,
         );
+
+        if (freeze.value) {
+          return;
+        }
 
         padding.value = effective;
 
@@ -359,6 +370,20 @@ function useChatKeyboard(
       },
     },
     [inverted, keyboardLiftBehavior, offset],
+  );
+
+  useAnimatedReaction(
+    () => freeze.value,
+    (isFrozen, wasFrozen) => {
+      if (!isFrozen && wasFrozen === true) {
+        padding.value = getEffectiveHeight(
+          currentHeight.value,
+          targetKeyboardHeight.value,
+          offset,
+        );
+      }
+    },
+    [offset],
   );
 
   return {


### PR DESCRIPTION
## Problem

In LegendList's keyboard integration when a user sends a message we want to do at the same time:
- Scroll the new message to the top
- Close the keyboard

So I am using `freeze` to disable KeyboardChatScrollView's scrolling to allow our scrollToEnd to run instead. But then that makes it never report an inset less than the keyboard height, because freezing made it stop calculating keyboard height. 

`KeyboardChatScrollView` currently returns early from keyboard handlers when `freeze` is true. If the keyboard closes while frozen, the hook can miss the terminal keyboard height and keep stale keyboard padding after `freeze` becomes false.

In that state, `onContentInsetChange` can stop at the previous keyboard padding instead of continuing down to `0`, even though `freeze` is already false.

## Screenshot

This is what it looks like before the fix, it reports inset shrinking while the blankSize shrinks, but to a minimum of keyboard size (288 in this case). So then there's a big bottomInset.

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 16 49 28" src="https://github.com/user-attachments/assets/34ba8159-6167-406f-a2b0-bd4e3e6e3d0c" />

## Solution

Keep tracking the latest keyboard height while frozen, but continue to skip layout and scroll writes during the frozen interval. When `freeze` transitions from true to false, recompute the effective padding from the latest observed keyboard height.

This keeps `freeze` scoped to applying keyboard-driven layout updates, not observing keyboard state.

## Notes

This intentionally reconciles padding only. It does not replay skipped scroll operations after unfreezing, because that could introduce visible jumps and is not needed for the stale inset issue.

## Test plan

- Verified manually in a Legend List chat repro on iOS and Android.
- `yarn test src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/index.ios.spec.ts src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/freeze.android.spec.ts --runInBand`
- `yarn lint --quiet src/components/KeyboardChatScrollView/useChatKeyboard/index.ios.ts src/components/KeyboardChatScrollView/useChatKeyboard/index.ts src/components/KeyboardChatScrollView/useChatKeyboard/__fixtures__/testUtils.ts src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/index.ios.spec.ts src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/freeze.android.spec.ts`
- `yarn typescript`
