### PR TITLE
fix: iOS 27 example apps compatibility

### DIFF
--- a/FabricExample/ios/AppDelegate.swift
+++ b/FabricExample/ios/AppDelegate.swift
@@ -13,33 +13,51 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
- 
+
   var reactNativeDelegate: ReactNativeDelegate?
   var reactNativeFactory: RCTReactNativeFactory?
- 
+  private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
+    self.launchOptions = launchOptions
+
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
- 
+
     reactNativeDelegate = delegate
     reactNativeFactory = factory
- 
-    window = UIWindow(frame: UIScreen.main.bounds)
- 
-    factory.startReactNative(
+
+    return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    let configuration = UISceneConfiguration(
+      name: "Default Configuration",
+      sessionRole: connectingSceneSession.role
+    )
+    configuration.delegateClass = SceneDelegate.self
+    return configuration
+  }
+
+  func startReactNative(in window: UIWindow) {
+    self.window = window
+
+    reactNativeFactory?.startReactNative(
       withModuleName: "KeyboardControllerFabricExample",
       in: window,
       launchOptions: launchOptions
     )
- 
-    return true
   }
 }
- 
+
 class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     self.bundleURL()

--- a/FabricExample/ios/KeyboardControllerFabricExample.xcodeproj/project.pbxproj
+++ b/FabricExample/ios/KeyboardControllerFabricExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		080373072D56C9450013CC14 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080373062D56C9450013CC14 /* AppDelegate.swift */; };
+		080373092D56C9450013CC14 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080373082D56C9450013CC14 /* SceneDelegate.swift */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		6204C340D92F4647309CF60E /* libPods-KeyboardControllerFabricExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66C8C56FA822B62D28B0930A /* libPods-KeyboardControllerFabricExample.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
@@ -27,6 +28,7 @@
 /* Begin PBXFileReference section */
 		00E356EE1AD99517003FC87E /* KeyboardControllerFabricExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KeyboardControllerFabricExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		080373062D56C9450013CC14 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		080373082D56C9450013CC14 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* KeyboardControllerFabricExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KeyboardControllerFabricExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = KeyboardControllerFabricExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = KeyboardControllerFabricExample/Info.plist; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 			isa = PBXGroup;
 			children = (
 				080373062D56C9450013CC14 /* AppDelegate.swift */,
+				080373082D56C9450013CC14 /* SceneDelegate.swift */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
@@ -323,6 +326,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				080373072D56C9450013CC14 /* AppDelegate.swift in Sources */,
+				080373092D56C9450013CC14 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FabricExample/ios/KeyboardControllerFabricExample/Info.plist
+++ b/FabricExample/ios/KeyboardControllerFabricExample/Info.plist
@@ -37,6 +37,23 @@
 	<string></string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/FabricExample/ios/SceneDelegate.swift
+++ b/FabricExample/ios/SceneDelegate.swift
@@ -1,0 +1,29 @@
+//
+//  SceneDelegate.swift
+//  KeyboardControllerFabricExample
+//
+//  Created by Kiryl Ziusko on 08/02/2025.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard
+      let windowScene = scene as? UIWindowScene,
+      let appDelegate = UIApplication.shared.delegate as? AppDelegate
+    else {
+      return
+    }
+
+    let window = UIWindow(windowScene: windowScene)
+    self.window = window
+    appDelegate.startReactNative(in: window)
+  }
+}

--- a/example/ios/AppDelegate.swift
+++ b/example/ios/AppDelegate.swift
@@ -13,33 +13,51 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
- 
+
   var reactNativeDelegate: ReactNativeDelegate?
   var reactNativeFactory: RCTReactNativeFactory?
- 
+  private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
+    self.launchOptions = launchOptions
+
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
- 
+
     reactNativeDelegate = delegate
     reactNativeFactory = factory
- 
-    window = UIWindow(frame: UIScreen.main.bounds)
- 
-    factory.startReactNative(
+
+    return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    let configuration = UISceneConfiguration(
+      name: "Default Configuration",
+      sessionRole: connectingSceneSession.role
+    )
+    configuration.delegateClass = SceneDelegate.self
+    return configuration
+  }
+
+  func startReactNative(in window: UIWindow) {
+    self.window = window
+
+    reactNativeFactory?.startReactNative(
       withModuleName: "KeyboardControllerExample",
       in: window,
       launchOptions: launchOptions
     )
- 
-    return true
   }
 }
- 
+
 class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     self.bundleURL()

--- a/example/ios/KeyboardControllerExample.xcodeproj/project.pbxproj
+++ b/example/ios/KeyboardControllerExample.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		080373042D56C85B0013CC14 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080373032D56C85B0013CC14 /* AppDelegate.swift */; };
 		080373052D56C85B0013CC14 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080373032D56C85B0013CC14 /* AppDelegate.swift */; };
+		080373092D56D8000013CC14 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080373082D56D8000013CC14 /* SceneDelegate.swift */; };
+		0803730A2D56D8000013CC14 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080373082D56D8000013CC14 /* SceneDelegate.swift */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		4C39C56BAD484C67AA576FFA /* libPods-KeyboardControllerExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CA3E69C5B9553B26FBA2DF04 /* libPods-KeyboardControllerExample.a */; };
@@ -38,6 +40,7 @@
 		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
 		00E356EE1AD99517003FC87E /* KeyboardControllerExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KeyboardControllerExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		080373032D56C85B0013CC14 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		080373082D56D8000013CC14 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* KeyboardControllerExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KeyboardControllerExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = KeyboardControllerExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = KeyboardControllerExample/Info.plist; sourceTree = "<group>"; };
@@ -90,6 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				080373032D56C85B0013CC14 /* AppDelegate.swift */,
+				080373082D56D8000013CC14 /* SceneDelegate.swift */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
@@ -470,6 +474,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				080373052D56C85B0013CC14 /* AppDelegate.swift in Sources */,
+				080373092D56D8000013CC14 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -478,6 +483,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				080373042D56C85B0013CC14 /* AppDelegate.swift in Sources */,
+				0803730A2D56D8000013CC14 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/example/ios/KeyboardControllerExample/Info.plist
+++ b/example/ios/KeyboardControllerExample/Info.plist
@@ -37,6 +37,23 @@
 	<string></string>
 	<key>RCTNewArchEnabled</key>
 	<false/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/example/ios/SceneDelegate.swift
+++ b/example/ios/SceneDelegate.swift
@@ -1,0 +1,29 @@
+//
+//  SceneDelegate.swift
+//  KeyboardControllerExample
+//
+//  Created by Kiryl Ziusko on 08/02/2025.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard
+      let windowScene = scene as? UIWindowScene,
+      let appDelegate = UIApplication.shared.delegate as? AppDelegate
+    else {
+      return
+    }
+
+    let window = UIWindow(windowScene: windowScene)
+    self.window = window
+    appDelegate.startReactNative(in: window)
+  }
+}


### PR DESCRIPTION
## 📜 Description

Fixed app crash at app launch on iOS 27 for iOS example projects.

## 💡 Motivation and Context

The iOS example apps crashed on launch when built with the latest iOS SDK because UIKit now requires apps to adopt the `UIScene` lifecycle. The examples still created their main `UIWindow` directly from `AppDelegate` and did not declare a scene manifest.

This change migrates the example apps to scene-based lifecycle startup so they can launch correctly with the current SDK.

## 📢 Changelog

### iOS

- added `SceneDelegate` support for the example and Fabric example apps.
- added `UIApplicationSceneManifest` entries and moved React Native window startup into the scene lifecycle.

## 🤔 How Has This Been Tested?

Tested in example app (fabric/paper) on iOS 27.0 public beta (iPhone 17 Pro, simulator).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="1689" height="1026" alt="Screenshot 2026-06-15 at 16 44 47" src="https://github.com/user-attachments/assets/f5fc8c4d-d72d-47bf-b018-7288974315b4" />|<img width="340" height="751" alt="image" src="https://github.com/user-attachments/assets/c9318d0b-e8a6-47e9-a532-5bde6040c815" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
