### PR TITLE
KeyboardAvoidingView/Flatlist Scrolling When Modal Opened After TextInput Blurred Android Fix

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -232,8 +232,8 @@ const KeyboardAwareScrollView = forwardRef<
         }
 
         // MW - if the keyboard is already hidden and the new height is 0, we don't need to do anything
-        // This was being triggered when a modal or bottom sheet was opened after focusing a field at the bottom of 
-        // the scrollview.
+        // This was being triggered when a modal or bottom sheet was opened after focusing a field at the bottom of
+        // the scrollview
         if (keyboardHeight.value === 0 && e === 0) {
           return false;
         }

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -231,6 +231,13 @@ const KeyboardAwareScrollView = forwardRef<
           return false;
         }
 
+        // MW - if the keyboard is already hidden and the new height is 0, we don't need to do anything
+        // This was being triggered when a modal or bottom sheet was opened after focusing a field at the bottom of 
+        // the scrollview.
+        if (keyboardHeight.value === 0 && e === 0) {
+          return false;
+        }
+
         // insets mode: `ScrollViewWithBottomPadding` extends scrollable area without
         // changing layout, so when the keyboard hides and we're at the end of the
         // ScrollView we must manually scroll back.
@@ -254,6 +261,7 @@ const KeyboardAwareScrollView = forwardRef<
       },
       [mode],
     );
+
     const performScrollWithPositionRestoration = useCallback(
       (newPosition: number) => {
         "worklet";
@@ -495,6 +503,7 @@ const KeyboardAwareScrollView = forwardRef<
 
           if (e.height === 0) {
             removeGhostPadding(e.height);
+            ghostViewSpace.value = -1;
           }
 
           keyboardHeight.value = e.height;


### PR DESCRIPTION
## 📜 Description
Gaurding removeGhostPadding scrollTo when the keyboard is closed and a modal is opened.

Adding example flatlist form to example application

## 💡 Motivation and Context
Need this fix for a production application.

I have opened a [bug report](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1501)

## 📢 Changelog
Added guard to removeGhostPadding

### JS
Added guard to removeGhostPadding

### iOS
No native changes.

### Android
No native changes.

## 🤔 How Has This Been Tested?
Ran through the exact steps to reproduce the issue outlines in the bug report and all is working as expected.

## 📸 Screenshots (if appropriate):
Have attached a video in the bug report - this no longer happens with this in place

## 📝 Checklist

- [/] CI successfully passed
- [/] I added new mocks and corresponding unit-tests if library API was changed
