### PR TITLE
fix: trigger full event lifecycle when keyboard is syncing on Android

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -393,8 +393,13 @@ class KeyboardAnimationCallback(
       "KeyboardController::" + if (!isKeyboardVisible) "keyboardDidHide" else "keyboardDidShow",
       getEventParams(keyboardHeight),
     )
-    // dispatch `onMove` to update RN animated value and `onEnd` to indicate that transition finished
-    listOf(KeyboardTransitionEvent.Move, KeyboardTransitionEvent.End).forEach { eventName ->
+    // dispatch full lifecycle of onStart/onMove/onEnd events to update RN animated value and
+    // keep imperative hooks like `useKeyboardHandler` in sync
+    listOf(
+      KeyboardTransitionEvent.Start,
+      KeyboardTransitionEvent.Move,
+      KeyboardTransitionEvent.End,
+    ).forEach { eventName ->
       context.dispatchEvent(
         eventPropagationView.id,
         KeyboardTransitionEvent(


### PR DESCRIPTION
## 📜 Description

Fixed an issue when closing a `Modal` triggers undesired scrolling in `KeyboardAwareScrollView`.

## 💡 Motivation and Context

The issue is because when `Modal` gets closed we dispatch only `onMove`/`onEnd` events. In `KeyboardAwareScrollView` in `onStart` method we have a lot of logic that computes current input position before keyboard animation, calculates offset etc. If we skip this stage, then `onMove`/`onEnd` may use values from previous keyboard interaction (so if keyboard was closed before and we scrolled for ~100px) we may scroll again, because values from `onStart` were not updated.

Technically that problem could be fixed in `KeyboardAwareScrollView` with additional conditions, but we use `useKeyboardHandler` hook in so many places/components, so if we would use this approach we potentially might need to replicate this fix in `KeyboardAvoidingView` and other components (and lib users would also need to do that if they use this hook in their projects).

So I think the correct fix is to fix inconsistency in native code.

Funny enough, but the new `syncKeyboardPosition` now becomes very similar to `onKeyboardResized`, especially since both functions are used in `onApplyWindowInsets` and I think that in the future these methods can be unified. Moreover the condition with detection keyboard resize or double keyboard position synchronization also can be unified and as a result we can make the codebase simpler. But this is the next step. First of all we need to merge/release this PR and keep an eye on possible bug reports about new bugs that caused by these changes 👀 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1501 https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1502

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- send `onStart` event too from `syncKeyboardPosition` function;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro (API 36, real device).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/0a08edd8-ed27-4ee4-9b77-c469516d9e85">|<video src="https://github.com/user-attachments/assets/ab430e99-202f-4595-b8c1-225fc7378b11">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
