### PR TITLE
docs: remove duplicated words

### DIFF
--- a/docs/docs/guides/components-overview.mdx
+++ b/docs/docs/guides/components-overview.mdx
@@ -29,7 +29,7 @@ keywords:
 This guide provides a concise overview of the main UI components in `react-native-keyboard-controller`. Choose the right component to handle keyboard interactions smoothly and consistently across platforms.
 
 :::info Building a chat app?
-If you are building a chat application, check out the dedicated [guide](./building-chat-app) guide that explores pitfalls of building chat app layout and shows how to solve them using `KeyboardChatScrollView` component.
+If you are building a chat application, check out the dedicated [guide](./building-chat-app) that explores pitfalls of building chat app layout and shows how to solve them using [`KeyboardChatScrollView`](../api/components/keyboard-chat-scroll-view) component.
 :::
 
 ## [`KeyboardAvoidingView`](../api/components/keyboard-avoiding-view)

--- a/docs/versioned_docs/version-1.21.0/guides/components-overview.mdx
+++ b/docs/versioned_docs/version-1.21.0/guides/components-overview.mdx
@@ -29,7 +29,7 @@ keywords:
 This guide provides a concise overview of the main UI components in `react-native-keyboard-controller`. Choose the right component to handle keyboard interactions smoothly and consistently across platforms.
 
 :::info Building a chat app?
-If you are building a chat application, check out the dedicated [guide](./building-chat-app) guide that explores pitfalls of building chat app layout and shows how to solve them using `KeyboardChatScrollView` component.
+If you are building a chat application, check out the dedicated [guide](./building-chat-app) that explores pitfalls of building chat app layout and shows how to solve them using [`KeyboardChatScrollView`](../api/components/keyboard-chat-scroll-view) component.
 :::
 
 ## [`KeyboardAvoidingView`](../api/components/keyboard-avoiding-view)


### PR DESCRIPTION
## 📜 Description

Removed double `guide` word. Added link to `KeyboardCHatScrollView`.

## 💡 Motivation and Context

Double `guide` word sounds incorrect. Also added additional link to API reference.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- removed double `guide` word;
- added a link to `KeyboardChatScrollView` API;

## 🤔 How Has This Been Tested?

Tested manually via preview + locally.

## 📸 Screenshots (if appropriate):

<img width="980" height="140" alt="image" src="https://github.com/user-attachments/assets/596143b7-a134-44ce-8318-3e622b34755c" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
