### PR TITLE
fix(ios): ignore keyboard events that don't originate from this app

### DIFF
--- a/ios/extensions/Notification.swift
+++ b/ios/extensions/Notification.swift
@@ -14,6 +14,10 @@ extension Notification {
 
     return (duration, keyboardFrame)
   }
+
+  var isLocalKeyboardEvent: Bool {
+    (userInfo?[UIResponder.keyboardIsLocalUserInfoKey] as? Bool) != false
+  }
 }
 
 extension Notification.Name {

--- a/ios/extensions/Notification.swift
+++ b/ios/extensions/Notification.swift
@@ -15,8 +15,9 @@ extension Notification {
     return (duration, keyboardFrame)
   }
 
-  var isLocalKeyboardEvent: Bool {
-    (userInfo?[UIResponder.keyboardIsLocalUserInfoKey] as? Bool) != false
+  var canBeSafelyIgnored: Bool {
+    UIResponder.isKeyboardPreloading
+      || (userInfo?[UIResponder.keyboardIsLocalUserInfoKey] as? Bool) == false
   }
 }
 

--- a/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
+++ b/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
@@ -8,6 +8,7 @@
 extension KeyboardMovementObserver {
   @objc func keyboardWillAppear(_ notification: Notification) {
     guard !UIResponder.isKeyboardPreloading else { return }
+    guard notification.isLocalKeyboardEvent else { return }
 
     let (duration, frame) = notification.keyboardMetaData()
     if let keyboardFrame = frame {
@@ -35,6 +36,7 @@ extension KeyboardMovementObserver {
 
   @objc func keyboardWillDisappear(_ notification: Notification) {
     guard !UIResponder.isKeyboardPreloading else { return }
+    guard notification.isLocalKeyboardEvent else { return }
     let (duration, _) = notification.keyboardMetaData()
     tag = UIResponder.current.reactViewTag
     self.notification = notification
@@ -56,6 +58,7 @@ extension KeyboardMovementObserver {
 
   @objc func keyboardDidAppear(_ notification: Notification) {
     guard !UIResponder.isKeyboardPreloading else { return }
+    guard notification.isLocalKeyboardEvent else { return }
 
     let (duration, frame) = notification.keyboardMetaData()
     if let keyboardFrame = frame {
@@ -83,6 +86,7 @@ extension KeyboardMovementObserver {
 
   @objc func keyboardDidDisappear(_ notification: Notification) {
     guard !UIResponder.isKeyboardPreloading else { return }
+    guard notification.isLocalKeyboardEvent else { return }
     let (duration, _) = notification.keyboardMetaData()
     tag = UIResponder.current.reactViewTag
 

--- a/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
+++ b/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
@@ -7,8 +7,7 @@
 
 extension KeyboardMovementObserver {
   @objc func keyboardWillAppear(_ notification: Notification) {
-    guard !UIResponder.isKeyboardPreloading else { return }
-    guard notification.isLocalKeyboardEvent else { return }
+    guard !notification.canBeSafelyIgnored else { return }
 
     let (duration, frame) = notification.keyboardMetaData()
     if let keyboardFrame = frame {
@@ -35,8 +34,7 @@ extension KeyboardMovementObserver {
   }
 
   @objc func keyboardWillDisappear(_ notification: Notification) {
-    guard !UIResponder.isKeyboardPreloading else { return }
-    guard notification.isLocalKeyboardEvent else { return }
+    guard !notification.canBeSafelyIgnored else { return }
     let (duration, _) = notification.keyboardMetaData()
     tag = UIResponder.current.reactViewTag
     self.notification = notification
@@ -57,8 +55,7 @@ extension KeyboardMovementObserver {
   }
 
   @objc func keyboardDidAppear(_ notification: Notification) {
-    guard !UIResponder.isKeyboardPreloading else { return }
-    guard notification.isLocalKeyboardEvent else { return }
+    guard !notification.canBeSafelyIgnored else { return }
 
     let (duration, frame) = notification.keyboardMetaData()
     if let keyboardFrame = frame {
@@ -85,8 +82,7 @@ extension KeyboardMovementObserver {
   }
 
   @objc func keyboardDidDisappear(_ notification: Notification) {
-    guard !UIResponder.isKeyboardPreloading else { return }
-    guard notification.isLocalKeyboardEvent else { return }
+    guard !notification.canBeSafelyIgnored else { return }
     let (duration, _) = notification.keyboardMetaData()
     tag = UIResponder.current.reactViewTag
 


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

If you open an application into a screen that uses a KeyboardAvoidingView while a keyboard is open on iOS (ie., from Spotlight Search, swiping), despite iOS dismissing the keyboard, the area will be reserved for the keyboard because it does not ignore external keyboard observations.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- ignore external keyboard movement observations

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

In a local version, I applied the same changes to a patched version, and tested the changes. 

## 📸 Screenshots (if appropriate):

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/ad4746d9-bac7-4b07-9130-9a622b513a3c" /> | <video src="https://github.com/user-attachments/assets/045b14e7-bde5-4eef-a630-9bda2a81c56f" /> | 

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
