### PR TITLE
fix: jitter removed in  keyboard avoiding view behaviour

### DIFF
--- a/src/components/KeyboardAvoidingView/index.tsx
+++ b/src/components/KeyboardAvoidingView/index.tsx
@@ -120,11 +120,26 @@ const KeyboardAvoidingView = forwardRef<
       (layout: LayoutRectangle) => {
         "worklet";
 
-        if (
-          keyboard.isClosed.value ||
-          initialFrame.value === null ||
-          behavior !== "height"
-        ) {
+        // Reject out-of-order `automaticOffset` measurements to stop the onLayout flicker.
+        //
+        // With `automaticOffset`, every onLayout resolves the frame through an async
+        // native `viewPositionInWindow()` call. Those promises settle out of order, so
+        // a callback can arrive LATE carrying a stale, smaller `y`/`height` after a
+        // newer, larger one already landed. Since `initialFrame` is re-recorded on
+        // every onLayout and feeds `relativeKeyboardHeight()` (which drives the
+        // padding/offset), each stale value yanks the frame back down and produces the
+        // up-down jitter we saw while the keyboard opens.
+        //
+        // The view's bottom edge (`y + height`) only grows as the keyboard opens, so we
+        // accept a layout only when its bottom edge exceeds the stored one — this drops
+        // the late/stale callbacks and lets the frame ramp up monotonically and settle.
+        // The genuine resting frame is re-captured on the next `keyboard.isClosed` pass
+        // (or the first layout), so it never stays stuck at an inflated value across
+        // open/close cycles.
+        if (keyboard.isClosed.value || initialFrame.value === null) {
+          // eslint-disable-next-line react-compiler/react-compiler
+          initialFrame.value = layout;
+        } else if (behavior !== "height" && layout.y+layout.height > initialFrame.value.y+initialFrame.value.height) {
           // eslint-disable-next-line react-compiler/react-compiler
           initialFrame.value = layout;
         }


### PR DESCRIPTION
📜 Description

Fixes a flicker in KeyboardAvoidingView where, on Android with behavior="padding" (any non-"height" behavior) and automaticOffset={true}, the wrapped content jitters up and down while the keyboard opens instead of animating up smoothly once.

onLayoutWorklet re-records initialFrame on every onLayout for non-"height" behaviors. With automaticOffset, each onLayout resolves the frame through an async KeyboardControllerNative.viewPositionInWindow() call, and those promises settle out of order — a late callback delivers a stale, smaller y + height after a newer larger one already landed. Because initialFrame feeds relativeKeyboardHeight() (which drives paddingBottom), every stale dip yanks the frame back down and shows up as flicker.

This PR keeps the resting-frame capture on first layout / when the keyboard is closed, but while the keyboard is open it accepts a new layout only when its bottom edge (y + height) exceeds the stored one — the resting bottom edge only grows as the keyboard opens, so this discards the out-of-order/stale measurements and lets the frame settle monotonically.

💡 Motivation and Context

Fixes #<issue-number>.

Repro: KeyboardAvoidingView with behavior="padding", automaticOffset, and a content-sized child (no flex: 1) near the bottom of the screen. Logging initialFrame.value across one keyboard open showed height climbing 280 → 396 and y + height ramping 555 → 613 with out-of-order dips in between — confirming the keyboard signals were stable and the oscillation came entirely from the re-recorded frame. The change targets only that re-record path; position (which animates a separate inner view) and height (already frozen while open) are unaffected.

📢 Changelog

JS

- KeyboardAvoidingView: ignore out-of-order/stale automaticOffset (viewPositionInWindow) measurements in onLayoutWorklet — while the keyboard is open and behavior !== "height", initialFrame now updates only when the layout's bottom edge (y + height) grows, fixing the open-animation flicker on Android. Resting frame is still captured on the first layout and whenever keyboard.isClosed.

🤔 How Has This Been Tested?

Tested on a physical Android device and emulator:

- Env: RN 0.83.2, new architecture (Fabric), Hermes, react-native-keyboard-controller 1.21.0, react-native-reanimated 4.3.0.
- Setup: KeyboardAvoidingView with behavior="padding", automaticOffset, keyboardVerticalOffset={0}, wrapping a content-sized (no flex: 1) block near the bottom of the screen with a TextInput.
- Before: focusing the input made the content jitter up/down repeatedly; initialFrame.value.height oscillated (280 → 396 with out-of-order dips).
- After: content animates up once and settles; initialFrame updates monotonically and stops re-recording stale frames — no flicker.
- Sanity-checked behavior="position" and behavior="height" to confirm no behavior change for those paths.

Library public API is unchanged, so no new mocks were required.

📸 Screenshots (if appropriate):

Before Updating::
https://github.com/user-attachments/assets/c16b51a9-b96e-4446-a27f-714991bbb57e

After Updating::
https://github.com/user-attachments/assets/a3e1e7b3-0b0d-4a8a-83e0-ced261190e20



