### PR TITLE
refactor: guard `KeyboardLayoutGuide` path through config (instead of direct checks)

### DIFF
--- a/ios/core/KeyboardControllerConfiguration.swift
+++ b/ios/core/KeyboardControllerConfiguration.swift
@@ -1,0 +1,16 @@
+//
+//  KeyboardControllerConfiguration.swift
+//  Pods
+//
+//  Created by Kiryl Ziusko on 25/06/2026.
+//
+
+enum KeyboardControllerConfiguration {
+  static var usesKeyboardLayoutGuideTracking: Bool {
+    if #available(iOS 26.0, *) {
+      return true
+    }
+
+    return false
+  }
+}

--- a/ios/observers/movement/KeyboardTrackingView.swift
+++ b/ios/observers/movement/KeyboardTrackingView.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 /**
- * A compatibility view that resolves to `KeyboardView` on iOS < 26
- * and uses `keyboardLayoutGuide` on iOS 26+.
+ * A compatibility view that resolves to `KeyboardView` for the legacy path
+ * and uses `keyboardLayoutGuide` for configured iOS 26+ behavior.
  */
 public final class KeyboardTrackingView: UIView {
   private var keyboardView: UIView? {
@@ -69,6 +69,8 @@ public final class KeyboardTrackingView: UIView {
   }
 
   @objc public func attachToTopmostView(toWindow window: UIWindow? = nil) {
+    guard KeyboardControllerConfiguration.usesKeyboardLayoutGuideTracking else { return }
+
     var topViewController = window?.rootViewController
     if let rootVC = topViewController, let topView = rootVC.view, topView.window != nil {
       // ok, attach
@@ -120,7 +122,7 @@ public final class KeyboardTrackingView: UIView {
   }
 
   @objc var view: UIView? {
-    if #available(iOS 26.0, *) {
+    if KeyboardControllerConfiguration.usesKeyboardLayoutGuideTracking {
       return self
     } else {
       return keyboardView
@@ -135,7 +137,7 @@ public final class KeyboardTrackingView: UIView {
     let keyboardPosition = keyboardWindowH - keyboardFrameY
 
     // for `keyboardLayoutGuide` case we can just read keyboard position directly - no interpolation needed
-    if #available(iOS 26.0, *) {
+    if KeyboardControllerConfiguration.usesKeyboardLayoutGuideTracking {
       if keyboardPosition > keyboardHeight {
         return Self.invalidPosition
       }


### PR DESCRIPTION
## 📜 Description

Make configuration for `KeyboardTrackingView`.

## 💡 Motivation and Context

In `1.22.x` I want to re-write the algorithm for tracking keyboard (yes, again) and switch back to legacy path (it looks like I found a better way of managing things and I can deliver better experience than `KeyboardLayoutGuide`).

But at the same time I don't want to drop the current code with `KeyboardLayoutGuide`. So I decided to hide it under feature flag. If users discover regressions - they can just toggle feature flag and restore old behavior.

Also in future if my method stops to work again I can also toggle feature flag and use modern path (when `KeyboardLayoutGuide` will be stable).

To achieve this I added `KeyboardControllerConfiguration` with `usesKeyboardLayoutGuideTracking` field. And repalced corresponding `#available(iOS 26.0, *)` condition to `usesKeyboardLayoutGuideTracking` field. Such code helps us:
- reduce code fragmentation;
- control things from one place;
- simplify the codebase and maintenance in the future.

While refactoring it I also realised that we don't need to attach invisible `KeyboardLayoutGuide` on older iOS versions so I also guarded this code with `usesKeyboardLayoutGuideTracking` flag.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added `KeyboardControllerConfiguration` file;
- guard `KeyboardLayoutGuide` code under `usesKeyboardLayoutGuideTracking` flag;

## 🤔 How Has This Been Tested?

Tested via e2e test.

## 📸 Screenshots (if appropriate):

<img width="777" height="313" alt="Screenshot 2026-06-26 at 17 51 28" src="https://github.com/user-attachments/assets/d1f24f3d-509f-4dfa-a914-a9413ca84b25" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
