### PR TITLE
fix: applesimutils installation on CI

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -169,7 +169,7 @@ jobs:
           simulator-name: ${{ matrix.devices.iphone }}
           simulator-version: ${{ matrix.devices.os }}
       - name: Install AppleSimulatorUtils
-        run: brew tap wix/brew && brew install applesimutils
+        run: brew tap wix/brew && brew install wix/brew/applesimutils
       - name: Save yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 📜 Description

Fixed iOS e2e pipeline.

## 💡 Motivation and Context

Homebrew now requires explicit trust for third-party taps. So we need to replace the command with the fully qualified formula name.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- use fully qualified formula name;

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="977" height="310" alt="Screenshot 2026-06-26 at 16 22 18" src="https://github.com/user-attachments/assets/a78f7a64-33ba-4f46-bf19-0ca3c1e84a90" />|<img width="964" height="807" alt="Screenshot 2026-06-26 at 16 23 11" src="https://github.com/user-attachments/assets/f91ec4fe-a1cf-4f3b-bcef-21f6f7fc4e28" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
