### PR TITLE
fix(android): support NestedScrollView in ClippingScrollViewDecoratorView

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
@@ -5,6 +5,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
+import androidx.core.widget.NestedScrollView
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativekeyboardcontroller.extensions.px
@@ -100,7 +101,7 @@ class ClippingScrollViewDecoratorView(
   }
 
   private fun shouldUsePaddingScrollWorkaround(
-    scrollView: ScrollView,
+    scrollView: ViewGroup,
     event: MotionEvent,
   ): Boolean {
     val contentView = scrollView.getChildAt(0) ?: return false
@@ -115,7 +116,7 @@ class ClippingScrollViewDecoratorView(
   }
 
   private fun dispatchWithExpandedContentRange(
-    scrollView: ScrollView,
+    scrollView: ViewGroup,
     event: MotionEvent,
   ): Boolean {
     val contentView = scrollView.getChildAt(0)
@@ -136,7 +137,7 @@ class ClippingScrollViewDecoratorView(
   }
 
   private fun isTouchInScrollContent(
-    scrollView: ScrollView,
+    scrollView: ViewGroup,
     event: MotionEvent,
   ): Boolean {
     val contentView = scrollView.getChildAt(0) ?: return false
@@ -158,11 +159,15 @@ class ClippingScrollViewDecoratorView(
     )
   }
 
-  private fun findScrollView(view: View?): ScrollView? {
-    var result: ScrollView? = null
+  private fun findScrollView(view: View?): ViewGroup? {
+    var result: ViewGroup? = null
 
-    if (view is ScrollView) {
-      result = view
+    // Match NestedScrollView too: with React Native's `useNestedScrollViewAndroid`
+    // feature flag (RN 0.85+), ScrollView renders as a NestedScrollView subclass
+    // (a FrameLayout, not an android.widget.ScrollView). Both extend the scroll
+    // range via bottom padding + clipToPadding=false the same way.
+    if (view is ScrollView || view is NestedScrollView) {
+      result = view as ViewGroup
     } else if (view is ViewGroup) {
       var i = 0
       while (i < view.childCount && result == null) {


### PR DESCRIPTION
## Problem

With React Native's `useNestedScrollViewAndroid` feature flag (RN 0.85+, facebook/react-native#55239), `ScrollView` renders as `ReactNestedScrollView`, which extends `androidx.core.widget.NestedScrollView` (a `FrameLayout`) — not `android.widget.ScrollView`.

`ClippingScrollViewDecoratorView.findScrollView` only matches `view is ScrollView`, so it returns null, `decorateScrollView()` silently no-ops, and `contentInsetBottom`/`contentInsetTop` are dropped entirely. In a `KeyboardChatScrollView` this means: list content hides behind the composer, and `blankSpace`/`extraContentPadding` have no effect on Android.

## Fix

Match `NestedScrollView` as well, and pass the found view around as `ViewGroup`. Every member used by the decorator and the padding-scroll workaround (`clipToPadding`, `getChildAt`, `setPadding`, `scrollBy`, `scrollY`, `canScrollVertically`, `getLocationOnScreen`) lives on `ViewGroup`/`View`, and `NestedScrollView` extends its scroll range via bottom padding + `clipToPadding = false` exactly like `ScrollView`.

`ReactNestedScrollView` itself is package-private, hence matching on the public androidx base class.

## Testing

Verified in a chat app (RN 0.85.3, new arch, `useNestedScrollViewAndroid` enabled) via patch-package: composer inset, keyboard padding, and `blankSpace` all apply again; behavior with the flag disabled (plain `ScrollView`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)