### PR TITLE
fix: KeyboardStickyView jumps on first keyboard appearance on iOS

### DIFF
--- a/src/animated.tsx
+++ b/src/animated.tsx
@@ -158,17 +158,22 @@ export const KeyboardProvider = (props: KeyboardProviderProps) => {
       heightSV.value = -event.height;
     }
   };
+  // On iOS the values were historically driven by the one-shot
+  // `onKeyboardMoveStart` event: the final height was written once and the
+  // visual smoothness relied on that write being adopted by UIKit's in-flight
+  // keyboard animation transaction (implicit CoreAnimation animation). On the
+  // first keyboard show after app launch the event/worklet pipeline is cold and
+  // the write lands outside the animation transaction, so views driven by these
+  // values teleport to the final position while the keyboard is still animating.
+  // Driving iOS from the per-frame `onKeyboardMove` stream (interpolated
+  // natively from the keyboard's own CA animation) removes that dependency;
+  // `onKeyboardMoveEnd` guarantees the final value even if ticks are dropped.
   const keyboardHandler = useAnimatedKeyboardHandler(
     {
-      onKeyboardMoveStart: (event: NativeEvent) => {
-        "worklet";
-
-        updateSharedValues(event, ["ios"]);
-      },
       onKeyboardMove: (event: NativeEvent) => {
         "worklet";
 
-        updateSharedValues(event, ["android"]);
+        updateSharedValues(event, ["android", "ios"]);
       },
       onKeyboardMoveInteractive: (event: NativeEvent) => {
         "worklet";
@@ -178,7 +183,7 @@ export const KeyboardProvider = (props: KeyboardProviderProps) => {
       onKeyboardMoveEnd: (event: NativeEvent) => {
         "worklet";
 
-        updateSharedValues(event, ["android"]);
+        updateSharedValues(event, ["android", "ios"]);
       },
     },
     [],
@@ -223,10 +228,9 @@ export const KeyboardProvider = (props: KeyboardProviderProps) => {
         style={styles.container}
         // on*Reanimated prop must precede animated handlers to work correctly
         onKeyboardMoveReanimated={keyboardHandler}
-        onKeyboardMoveStart={OS === "ios" ? onKeyboardMove : undefined}
-        onKeyboardMove={OS === "android" ? onKeyboardMove : undefined}
+        onKeyboardMove={onKeyboardMove}
         onKeyboardMoveInteractive={onKeyboardMove}
-        onKeyboardMoveEnd={OS === "android" ? onKeyboardMove : undefined}
+        onKeyboardMoveEnd={onKeyboardMove}
         onFocusedInputLayoutChangedReanimated={inputLayoutHandler}
       >
         {children}


### PR DESCRIPTION
## 📜 Description

Fixes `KeyboardStickyView` (and anything else driven by the `reanimated`/`animated` context values) teleporting to its final position on the **first keyboard appearance after app launch** on iOS, instead of animating together with the keyboard. Subsequent keyboard appearances in the same process are unaffected.

## 💡 Motivation and Context

On iOS the context values are driven by the **one-shot `onKeyboardMoveStart` event**: the final `height`/`progress` are written once at `keyboardWillShow` time, and the visual smoothness relies on that write being applied while UIKit's keyboard animation transaction is still in flight, so the transform change is implicitly animated by CoreAnimation with the keyboard's own curve.

On the very first keyboard show after app launch the event → worklet → style-application pipeline is cold (worklet/event-handler initialization, screen just mounted, busy main thread). The one-shot write then lands **outside** the animation transaction, so the sticky view snaps to the final position in a single frame while the keyboard is still animating up — the button visibly *leads* the keyboard. Once the pipeline is warm, the write lands inside the transaction and everything looks perfect, which is why only the first show per process is affected.

I verified the mechanism by logging inside `updateSharedValues`: on iOS the reanimated values receive exactly **one** update per transition (`height=308, progress=1.0` at will-show), while the native per-frame pipeline (`KeyboardMovementObserver.updateKeyboardFrame`, display link + CA animation extraction) emits a correct interpolated stream that was simply discarded by the platform filters — even on a cold first show.

The fix drives iOS from the per-frame `onKeyboardMove` stream plus `onKeyboardMoveEnd`, the same wiring Android uses. The per-frame values come from the native display link that samples/interpolates the keyboard's actual CA animation, so the sticky view follows the keyboard's real animated position without depending on implicit animation adoption. `onKeyboardMoveEnd` still guarantees the final value if any ticks are dropped.

Related cold-start report: #338 (first load after fresh install, iOS).

## 📢 Changelog

### JS

- iOS: drive `reanimated`/`animated` context values from per-frame `onKeyboardMove` + `onKeyboardMoveEnd` events instead of the one-shot `onKeyboardMoveStart` (fixes first-show jump of `KeyboardStickyView` and other consumers)

## 🤔 How Has This Been Tested?

- Reproduced in a production app (Expo 54 / RN 0.81.4, new arch, iOS 26): fresh launch → navigate to a sign-in screen with an auto-focused input + `KeyboardStickyView` footer → footer jumps to final position while the keyboard animates (screen recording of the report matches the one-shot signature: button leads the keyboard).
- With this change, worklet logging shows a full per-frame ramp (~90 updates per show/hide cycle, `progress` 0.04 → 1.0 following the keyboard spring), and frame-by-frame analysis of a screen recording (30/60 fps) shows the footer rising in lockstep with the keyboard on the first show of a fresh process, and on all subsequent shows.
- `yarn typescript`, `yarn lint`, `yarn test` (all 202 library tests pass; the `docs/` and `FabricExample/` suite failures are pre-existing module-resolution issues in workspaces without installed deps).

## 📝 Checklist

- [ ] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed (no API change — event wiring only)
