### PR TITLE
ci: bump xcodes version

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -143,6 +143,7 @@ jobs:
       # needed for additional runtime installation
       - name: Install Xcodes
         run: |
+          brew update
           brew upgrade xcodes || brew install xcodes
           xcodes version
       - name: Install additional iOS runtimes

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -142,7 +142,7 @@ jobs:
         run: xcodebuild -version
       # needed for additional runtime installation
       - name: Install Xcodes
-        run: brew tap xcodesorg/made
+        run: brew install xcodesorg/made/xcodes
       - name: Install additional iOS runtimes
         if: ${{ matrix.devices.runtime != '' && matrix.devices.runtime != null }}
         uses: ./.github/actions/retry-sudo-with-timeout

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -142,7 +142,9 @@ jobs:
         run: xcodebuild -version
       # needed for additional runtime installation
       - name: Install Xcodes
-        run: brew install xcodesorg/made/xcodes
+        run: |
+          brew upgrade xcodes || brew install xcodes
+          xcodes version
       - name: Install additional iOS runtimes
         if: ${{ matrix.devices.runtime != '' && matrix.devices.runtime != null }}
         uses: ./.github/actions/retry-sudo-with-timeout


### PR DESCRIPTION
## 📜 Description

`2.0.2` version (current on CI) has an issue with dynamic archive extraction. Use `latest` (2.0.3) version with actual bugfix.

## 💡 Motivation and Context

We need to use latest version so that bug doesn't affect us. For that we need to run `brew update` to fetch latest metadata, and then upgrade or install (in case if runner doesn't have installed package).

I also added version logging (helpful for further debugging).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- use `xcode@2.0.3` instead of `xcode@2.0.2`

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="832" height="706" alt="image" src="https://github.com/user-attachments/assets/e560bd58-421d-4e66-ae53-d77964449bd9" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
