### PR TITLE
fix(android): resolve enclosing scroll view when useNestedScrollViewAndroid is enabled

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
@@ -8,6 +8,7 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewTreeObserver.OnPreDrawListener
 import android.widget.EditText
+import androidx.core.widget.NestedScrollView
 import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.textinput.ReactEditText
 import com.reactnativekeyboardcontroller.log.Logger
@@ -105,7 +106,9 @@ val EditText.parentScrollViewTarget: Int
     while (currentView != null) {
       val parentView = currentView.parent as? View
 
-      if (parentView is ReactScrollView && parentView.scrollEnabled) {
+      if ((parentView is ReactScrollView && parentView.scrollEnabled) ||
+        parentView is NestedScrollView
+      ) {
         // If the parent is a vertical, scrollable ScrollView - return its id
         return parentView.id
       }


### PR DESCRIPTION
## 📜 Description

`EditText.parentScrollViewTarget` only matches `ReactScrollView`, but when the `useNestedScrollViewAndroid` feature flag is enabled RN renders the vertical scroll view as `ReactNestedScrollView`. The walk therefore never finds the enclosing scroll view and returns `-1`, so `KeyboardAwareScrollView`'s `maybeScroll` bails on the `parentScrollViewTarget !== scrollViewTarget` guard and the focused input is never scrolled above the keyboard.

`ReactNestedScrollView` is package-private, so it cannot be referenced by type from outside `com.facebook.react.views.scroll`. This matches its public superclass `androidx.core.widget.NestedScrollView` instead (which `ReactNestedScrollView` extends).

## 💡 Motivation and Context

Fixes the Android auto-scroll failure discussed in #1411 for apps that enable `useNestedScrollViewAndroid` (commonly turned on for nested scrolling inside native bottom sheets). With the flag on, `KeyboardAwareScrollView` stopped scrolling focused inputs into view on Android.

## 📢 Changelog

### Android

- Also match `NestedScrollView` (the public superclass of `ReactNestedScrollView`) in `parentScrollViewTarget`, so auto-scroll works when the `useNestedScrollViewAndroid` feature flag is enabled.

## 🤔 How Has This Been Tested?

Tested in a React Native 0.85 (New Architecture) app on a physical Pixel and an emulator with `useNestedScrollViewAndroid` enabled. Before: inputs near the bottom of a `KeyboardAwareScrollView` were covered by the keyboard, and `parentScrollViewTarget` logged as `-1`. After: focused inputs scroll above the keyboard as expected. iOS is unaffected.

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed