### PR TITLE
fix: avoid treating `0` as "not available" data

### DIFF
--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -287,7 +287,7 @@ const KeyboardAwareScrollView = forwardRef<
 
       const customHeight = lastSelection.value?.selection.end.y;
 
-      if (!input.value?.layout || !customHeight) {
+      if (!input.value?.layout || customHeight === undefined) {
         return false;
       }
 


### PR DESCRIPTION
## 📜 Description

Don't treat `0` as missing data.

## 💡 Motivation and Context

When we do a comparison like `!variable` then it will be evaluated as `true` if `value===0`.

In case of https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1300 on iOS we were getting `0` as `end.y` coordinate, so `customHeight` was `0` and we made early return. But this early return should be executed only when we don't have enogh data to make a scroll.

So in this PR I change condition to `!== undefined`;

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1300

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- replace `!customHeight` with `customHeight !== undefined` condition;

## 🤔 How Has This Been Tested?

Tested manually in example app.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/d5de177f-7adf-4b8c-8003-75be5750d849">|<video src="https://github.com/user-attachments/assets/499c2f3a-7ca3-487e-b42f-f54a7c3d70bc">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
