### PR TITLE
fix: quote Xcode bundle script paths

### DIFF
--- a/example/ios/KeyboardControllerExample.xcodeproj/project.pbxproj
+++ b/example/ios/KeyboardControllerExample.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"";
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n\"$WITH_ENVIRONMENT\" \"$REACT_NATIVE_XCODE\"";
 		};
 		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## 📜 Description

Invoke the React Native Xcode helper scripts as separately quoted arguments so example builds work from checkout paths containing spaces.

## 📢 Changelog

### iOS

- support spaces in the example checkout path during bundling

## 🤔 How Has This Been Tested?

- built directly from /Documents/Open Source/react-native-keyboard-controller
- installed and launched the result on iPhone 17 / iOS 26.5 Simulator

## 📝 Checklist

- [x] CI successfully passed
- [x] Simulator tested