### PR TITLE
fix: request keyboard control only when keyboard will change its position (Android)

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/KeyboardGestureAreaReactViewGroup.kt
@@ -137,21 +137,25 @@ class KeyboardGestureAreaReactViewGroup(
         if (moveBy != 0) {
           controller.insetBy(moveBy)
         }
-      } else if (
-        !controller.isInsetAnimationRequestPending() &&
-        shouldStartRequest(
-          dy = dy,
-          imeVisible =
-            ViewCompat
-              .getRootWindowInsets(this)
-              ?.isVisible(WindowInsetsCompat.Type.ime()) == true,
-        )
-      ) {
-        // If we don't currently have control (and a request isn't pending),
-        // the IME is not shown, the user is scrolling up, and the view can't
-        // scroll up any more (i.e. over-scrolling), we can start to control
-        // the IME insets
-        controller.startControlRequest(this)
+      } else if (!controller.isInsetAnimationRequestPending()) {
+        val rootInsets = ViewCompat.getRootWindowInsets(this)
+        val moveBy =
+          this.interpolator.interpolate(
+            dy.roundToInt(),
+            this.getWindowHeight() - event.rawY.toInt(),
+            rootInsets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0,
+            offset,
+          )
+
+        if (
+          moveBy != 0 &&
+          shouldStartRequest(
+            dy = dy,
+            imeVisible = rootInsets?.isVisible(WindowInsetsCompat.Type.ime()) == true,
+          )
+        ) {
+          controller.startControlRequest(this)
+        }
       }
 
       // Lastly we record the event X, Y, and view's Y window position, for the


### PR DESCRIPTION
## 📜 Description

Fixed an issue with inability to scroll a `KeyboardChatScrollView` on Android when `KeyboardGestureArea` was used with `interpolator="ios"`.

## 💡 Motivation and Context

The issue was in fact that we were starting keyboard control request too early. As a result it emitted events `onStart`/`onMove`/`onEnd` when keyboard didn't change position. Current JS code expects to receive these events when position is getting actually changed - in this case we control scroll position and adjust it accordingly.

If we receive those events when keyboard is not moving then we'll try to change position and it will look like a missing momentum gesture, content flickering etc.

Before we were not able to catch this problem, because we didn't have an example where `useKeyboardHandler` acts as a stateful machine or has side effects. Now with `KeyboardChatScrollView` it's clear where the bug is, so we are fixing it. Before we were just mapping events to animated values to "translate" a view and it was working, because all three events were reporting actually correct values (like keyboard is shown).

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1405

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- request keyboard control only when keyboard position going to be changed;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro (API 36).

## 📸 Screenshots (if appropriate):

FlatList + non-inverted + whenAtEnd - Fabric app.

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/35924757-968c-4c54-bef8-8430e36ea382">|<video src="https://github.com/user-attachments/assets/8122bd6b-9451-46ba-b942-5bc43e5b0684">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
