### PR TITLE
fix: reanimated bundle mode compatibility for `KeyboardChatScrollView`

### DIFF
--- a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
+++ b/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
@@ -29,6 +29,8 @@ type UseExtraContentPaddingOptions = {
   freeze: SharedValue<boolean>;
 };
 
+const OS = Platform.OS;
+
 /**
  * Hook that reacts to `extraContentPadding` changes and conditionally
  * adjusts the scroll position using `scrollTo` on both iOS and Android.
@@ -65,7 +67,7 @@ function useExtraContentPadding(options: UseExtraContentPaddingOptions): void {
       if (contentOffsetY && IS_FABRIC) {
         // eslint-disable-next-line react-compiler/react-compiler
         contentOffsetY.value = target;
-      } else if (Platform.OS === "android") {
+      } else if (OS === "android") {
         // Defer scrollTo so the animatedProps inset commit lands first;
         // otherwise the native ScrollView clamps to the old range.
         requestAnimationFrame(() => {


### PR DESCRIPTION
## 📜 Description

Fixed an issue that is caused by deep workletization when using `KeyboardChatScrollView`.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Same fix that we did in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/395 (but now only targeting `KeyboardChatScrollView`).

Ideally would be to cover such things with custom eslint plugin, but I don't have resources for creating one, so just replicating fix again 🤷‍♂️ 

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1555

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- avoid using `Platfrom.OS` directly in worklet because such construction tries to bundle whole react-native into worklet;

## 🤔 How Has This Been Tested?

Tested via CI.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
