### PR TITLE
fix: strict api compatibility

### DIFF
--- a/FabricExample/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
+++ b/FabricExample/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
@@ -7,8 +7,8 @@ import {
 } from "react-native";
 import {
   KeyboardChatScrollView,
-  KeyboardController,
   type KeyboardChatScrollViewRef,
+  KeyboardController,
 } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 

--- a/FabricExample/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
+++ b/FabricExample/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
@@ -8,6 +8,7 @@ import {
 import {
   KeyboardChatScrollView,
   KeyboardController,
+  type KeyboardChatScrollViewRef,
 } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -23,15 +24,11 @@ import type { SharedValue } from "react-native-reanimated";
 
 type VirtualizedListScrollViewProps = ScrollViewProps & {
   extraContentPadding?: SharedValue<number>;
-  chatScrollViewRef?: { current: VirtualizedListScrollViewRef | null };
+  chatScrollViewRef?: { current: KeyboardChatScrollViewRef | null };
 };
 
-export type VirtualizedListScrollViewRef = React.ElementRef<
-  typeof KeyboardChatScrollView
->;
-
 const VirtualizedListScrollView = forwardRef<
-  VirtualizedListScrollViewRef,
+  KeyboardChatScrollViewRef,
   VirtualizedListScrollViewProps
 >(
   (
@@ -44,16 +41,16 @@ const VirtualizedListScrollView = forwardRef<
     ref,
   ) => {
     const setScrollViewRef = useCallback(
-      (instance: VirtualizedListScrollViewRef | null) => {
+      (instance: KeyboardChatScrollViewRef | null) => {
         if (chatScrollViewRef) {
           // eslint-disable-next-line react-compiler/react-compiler
           chatScrollViewRef.current =
-            instance as VirtualizedListScrollViewRef | null;
+            instance as KeyboardChatScrollViewRef | null;
         }
       },
       [chatScrollViewRef],
     );
-    const combinedRef: RefCallback<VirtualizedListScrollViewRef> = useCallback(
+    const combinedRef: RefCallback<KeyboardChatScrollViewRef> = useCallback(
       (instance) => {
         if (typeof ref === "function") {
           ref(instance);

--- a/FabricExample/src/screens/Examples/KeyboardChatScrollView/index.tsx
+++ b/FabricExample/src/screens/Examples/KeyboardChatScrollView/index.tsx
@@ -20,6 +20,7 @@ import {
   KeyboardEffects,
   KeyboardGestureArea,
   KeyboardStickyView,
+  type KeyboardChatScrollViewRef,
 } from "react-native-keyboard-controller";
 import { useSharedValue } from "react-native-reanimated";
 import {
@@ -38,15 +39,13 @@ import styles, {
   contentContainerStyle,
   invertedContentContainerStyle,
 } from "./styles";
-import VirtualizedListScrollView, {
-  type VirtualizedListScrollViewRef,
-} from "./VirtualizedListScrollView";
+import VirtualizedListScrollView from "./VirtualizedListScrollView";
 
 import type { LayoutChangeEvent, ScrollViewProps } from "react-native";
 
 function KeyboardChatScrollViewPlayground() {
-  const chatScrollViewRef = useRef<VirtualizedListScrollViewRef | null>(null);
-  const scrollRef = useRef<VirtualizedListScrollViewRef>(null);
+  const chatScrollViewRef = useRef<KeyboardChatScrollViewRef | null>(null);
+  const scrollRef = useRef<KeyboardChatScrollViewRef>(null);
   const [text, setText] = useState("");
   const [inputHeight, setInputHeight] = useState(TEXT_INPUT_HEIGHT);
   const extraContentPadding = useSharedValue(0);

--- a/FabricExample/src/screens/Examples/KeyboardChatScrollView/index.tsx
+++ b/FabricExample/src/screens/Examples/KeyboardChatScrollView/index.tsx
@@ -17,10 +17,10 @@ import {
   View,
 } from "react-native";
 import {
+  type KeyboardChatScrollViewRef,
   KeyboardEffects,
   KeyboardGestureArea,
   KeyboardStickyView,
-  type KeyboardChatScrollViewRef,
 } from "react-native-keyboard-controller";
 import { useSharedValue } from "react-native-reanimated";
 import {

--- a/docs/docs/api/components/keyboard-chat-scroll-view.mdx
+++ b/docs/docs/api/components/keyboard-chat-scroll-view.mdx
@@ -229,15 +229,16 @@ First, create a wrapper component:
 
 ```tsx title="VirtualizedListScrollView.tsx"
 import React, { forwardRef } from "react";
-import { KeyboardChatScrollView } from "react-native-keyboard-controller";
+import {
+  KeyboardChatScrollView,
+  type KeyboardChatScrollViewRef,
+} from "react-native-keyboard-controller";
 
 import type { ScrollViewProps } from "react-native";
 import type { KeyboardChatScrollViewProps } from "react-native-keyboard-controller";
 
-type Ref = React.ElementRef<typeof KeyboardChatScrollView>;
-
 const VirtualizedListScrollView = forwardRef<
-  Ref,
+  KeyboardChatScrollViewRef,
   ScrollViewProps & KeyboardChatScrollViewProps
 >((props, ref) => {
   return (
@@ -374,44 +375,48 @@ React Native's `FlatList.scrollToEnd()` calculates the scroll offset using `visi
 
 ```tsx ChatScrollView.tsx
 import { forwardRef, useCallback } from "react";
-import { KeyboardChatScrollView } from "react-native-keyboard-controller";
+import {
+  KeyboardChatScrollView,
+  type KeyboardChatScrollViewRef,
+} from "react-native-keyboard-controller";
 
 import type { RefCallback } from "react";
 import type { ScrollViewProps } from "react-native";
 
-type ChatScrollViewRef = React.ElementRef<typeof KeyboardChatScrollView>;
 type ChatScrollViewProps = ScrollViewProps & {
-  chatScrollViewRef?: { current: ChatScrollViewRef | null };
+  chatScrollViewRef?: { current: KeyboardChatScrollViewRef | null };
 };
 
-const ChatScrollView = forwardRef<ChatScrollViewRef, ChatScrollViewProps>(
-  ({ chatScrollViewRef, ...props }, ref) => {
-    const combinedRef: RefCallback<ChatScrollViewRef> = useCallback(
-      (instance) => {
-        // forward to FlatList's internal ref
-        if (typeof ref === "function") {
-          ref(instance);
-        } else if (ref) {
-          ref.current = instance;
-        }
+const ChatScrollView = forwardRef<
+  KeyboardChatScrollViewRef,
+  ChatScrollViewProps
+>(({ chatScrollViewRef, ...props }, ref) => {
+  const combinedRef: RefCallback<KeyboardChatScrollViewRef> = useCallback(
+    (instance) => {
+      // forward to FlatList's internal ref
+      if (typeof ref === "function") {
+        ref(instance);
+      } else if (ref) {
+        ref.current = instance;
+      }
 
-        // forward to the user-provided ref
-        if (chatScrollViewRef) {
-          chatScrollViewRef.current = instance as ChatScrollViewRef | null;
-        }
-      },
-      [ref, chatScrollViewRef],
-    );
+      // forward to the user-provided ref
+      if (chatScrollViewRef) {
+        chatScrollViewRef.current =
+          instance as KeyboardChatScrollViewRef | null;
+      }
+    },
+    [ref, chatScrollViewRef],
+  );
 
-    return <KeyboardChatScrollView ref={combinedRef} {...props} />;
-  },
-);
+  return <KeyboardChatScrollView ref={combinedRef} {...props} />;
+});
 ```
 
 Then use it with `FlatList` via `renderScrollComponent`:
 
 ```tsx
-const chatScrollViewRef = useRef<ChatScrollViewRef>(null);
+const chatScrollViewRef = useRef<KeyboardChatScrollViewRef>(null);
 
 const renderScrollComponent = useCallback(
   (props: ScrollViewProps) => (

--- a/docs/docs/guides/building-chat-app.mdx
+++ b/docs/docs/guides/building-chat-app.mdx
@@ -415,18 +415,19 @@ Create a wrapper that passes `KeyboardChatScrollView` props down:
 
 ```tsx title="VirtualizedListScrollView.tsx"
 import React, { forwardRef } from "react";
-import { KeyboardChatScrollView } from "react-native-keyboard-controller";
+import {
+  KeyboardChatScrollView,
+  type KeyboardChatScrollViewRef,
+} from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import type { ScrollViewProps } from "react-native";
 import type { KeyboardChatScrollViewProps } from "react-native-keyboard-controller";
 
-type Ref = React.ElementRef<typeof KeyboardChatScrollView>;
-
 const BOTTOM_OFFSET = 8; // distance from safe area to input
 
 const VirtualizedListScrollView = forwardRef<
-  Ref,
+  KeyboardChatScrollViewRef,
   ScrollViewProps & KeyboardChatScrollViewProps
 >((props, ref) => {
   const { bottom } = useSafeAreaInsets();
@@ -527,6 +528,7 @@ import {
   KeyboardChatScrollView,
   KeyboardGestureArea,
   KeyboardStickyView,
+  type KeyboardChatScrollViewRef,
 } from "react-native-keyboard-controller";
 import { useSharedValue, withTiming } from "react-native-reanimated";
 import {
@@ -536,14 +538,12 @@ import {
 
 import type { KeyboardChatScrollViewProps } from "react-native-keyboard-controller";
 
-type Ref = React.ElementRef<typeof KeyboardChatScrollView>;
-
 const MARGIN = 8;
 const INPUT_HEIGHT = 42;
 
 // Wrapper for virtualized lists
 const ChatScrollView = forwardRef<
-  Ref,
+  KeyboardChatScrollViewRef,
   ScrollViewProps & KeyboardChatScrollViewProps
 >((props, ref) => {
   const { bottom } = useSafeAreaInsets();

--- a/docs/versioned_docs/version-1.22.0/api/components/keyboard-chat-scroll-view.mdx
+++ b/docs/versioned_docs/version-1.22.0/api/components/keyboard-chat-scroll-view.mdx
@@ -229,15 +229,16 @@ First, create a wrapper component:
 
 ```tsx title="VirtualizedListScrollView.tsx"
 import React, { forwardRef } from "react";
-import { KeyboardChatScrollView } from "react-native-keyboard-controller";
+import {
+  KeyboardChatScrollView,
+  type KeyboardChatScrollViewRef,
+} from "react-native-keyboard-controller";
 
 import type { ScrollViewProps } from "react-native";
 import type { KeyboardChatScrollViewProps } from "react-native-keyboard-controller";
 
-type Ref = React.ElementRef<typeof KeyboardChatScrollView>;
-
 const VirtualizedListScrollView = forwardRef<
-  Ref,
+  KeyboardChatScrollViewRef,
   ScrollViewProps & KeyboardChatScrollViewProps
 >((props, ref) => {
   return (
@@ -374,44 +375,48 @@ React Native's `FlatList.scrollToEnd()` calculates the scroll offset using `visi
 
 ```tsx ChatScrollView.tsx
 import { forwardRef, useCallback } from "react";
-import { KeyboardChatScrollView } from "react-native-keyboard-controller";
+import {
+  KeyboardChatScrollView,
+  type KeyboardChatScrollViewRef,
+} from "react-native-keyboard-controller";
 
 import type { RefCallback } from "react";
 import type { ScrollViewProps } from "react-native";
 
-type ChatScrollViewRef = React.ElementRef<typeof KeyboardChatScrollView>;
 type ChatScrollViewProps = ScrollViewProps & {
-  chatScrollViewRef?: { current: ChatScrollViewRef | null };
+  chatScrollViewRef?: { current: KeyboardChatScrollViewRef | null };
 };
 
-const ChatScrollView = forwardRef<ChatScrollViewRef, ChatScrollViewProps>(
-  ({ chatScrollViewRef, ...props }, ref) => {
-    const combinedRef: RefCallback<ChatScrollViewRef> = useCallback(
-      (instance) => {
-        // forward to FlatList's internal ref
-        if (typeof ref === "function") {
-          ref(instance);
-        } else if (ref) {
-          ref.current = instance;
-        }
+const ChatScrollView = forwardRef<
+  KeyboardChatScrollViewRef,
+  ChatScrollViewProps
+>(({ chatScrollViewRef, ...props }, ref) => {
+  const combinedRef: RefCallback<KeyboardChatScrollViewRef> = useCallback(
+    (instance) => {
+      // forward to FlatList's internal ref
+      if (typeof ref === "function") {
+        ref(instance);
+      } else if (ref) {
+        ref.current = instance;
+      }
 
-        // forward to the user-provided ref
-        if (chatScrollViewRef) {
-          chatScrollViewRef.current = instance as ChatScrollViewRef | null;
-        }
-      },
-      [ref, chatScrollViewRef],
-    );
+      // forward to the user-provided ref
+      if (chatScrollViewRef) {
+        chatScrollViewRef.current =
+          instance as KeyboardChatScrollViewRef | null;
+      }
+    },
+    [ref, chatScrollViewRef],
+  );
 
-    return <KeyboardChatScrollView ref={combinedRef} {...props} />;
-  },
-);
+  return <KeyboardChatScrollView ref={combinedRef} {...props} />;
+});
 ```
 
 Then use it with `FlatList` via `renderScrollComponent`:
 
 ```tsx
-const chatScrollViewRef = useRef<ChatScrollViewRef>(null);
+const chatScrollViewRef = useRef<KeyboardChatScrollViewRef>(null);
 
 const renderScrollComponent = useCallback(
   (props: ScrollViewProps) => (

--- a/docs/versioned_docs/version-1.22.0/guides/building-chat-app.mdx
+++ b/docs/versioned_docs/version-1.22.0/guides/building-chat-app.mdx
@@ -415,18 +415,19 @@ Create a wrapper that passes `KeyboardChatScrollView` props down:
 
 ```tsx title="VirtualizedListScrollView.tsx"
 import React, { forwardRef } from "react";
-import { KeyboardChatScrollView } from "react-native-keyboard-controller";
+import {
+  KeyboardChatScrollView,
+  type KeyboardChatScrollViewRef,
+} from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import type { ScrollViewProps } from "react-native";
 import type { KeyboardChatScrollViewProps } from "react-native-keyboard-controller";
 
-type Ref = React.ElementRef<typeof KeyboardChatScrollView>;
-
 const BOTTOM_OFFSET = 8; // distance from safe area to input
 
 const VirtualizedListScrollView = forwardRef<
-  Ref,
+  KeyboardChatScrollViewRef,
   ScrollViewProps & KeyboardChatScrollViewProps
 >((props, ref) => {
   const { bottom } = useSafeAreaInsets();
@@ -527,6 +528,7 @@ import {
   KeyboardChatScrollView,
   KeyboardGestureArea,
   KeyboardStickyView,
+  type KeyboardChatScrollViewRef,
 } from "react-native-keyboard-controller";
 import { useSharedValue, withTiming } from "react-native-reanimated";
 import {
@@ -536,14 +538,12 @@ import {
 
 import type { KeyboardChatScrollViewProps } from "react-native-keyboard-controller";
 
-type Ref = React.ElementRef<typeof KeyboardChatScrollView>;
-
 const MARGIN = 8;
 const INPUT_HEIGHT = 42;
 
 // Wrapper for virtualized lists
 const ChatScrollView = forwardRef<
-  Ref,
+  KeyboardChatScrollViewRef,
   ScrollViewProps & KeyboardChatScrollViewProps
 >((props, ref) => {
   const { bottom } = useSafeAreaInsets();

--- a/example/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
+++ b/example/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
@@ -7,8 +7,8 @@ import {
 } from "react-native";
 import {
   KeyboardChatScrollView,
-  KeyboardController,
   type KeyboardChatScrollViewRef,
+  KeyboardController,
 } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 

--- a/example/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
+++ b/example/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx
@@ -8,6 +8,7 @@ import {
 import {
   KeyboardChatScrollView,
   KeyboardController,
+  type KeyboardChatScrollViewRef,
 } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -23,15 +24,11 @@ import type { SharedValue } from "react-native-reanimated";
 
 type VirtualizedListScrollViewProps = ScrollViewProps & {
   extraContentPadding?: SharedValue<number>;
-  chatScrollViewRef?: { current: VirtualizedListScrollViewRef | null };
+  chatScrollViewRef?: { current: KeyboardChatScrollViewRef | null };
 };
 
-export type VirtualizedListScrollViewRef = React.ElementRef<
-  typeof KeyboardChatScrollView
->;
-
 const VirtualizedListScrollView = forwardRef<
-  VirtualizedListScrollViewRef,
+  KeyboardChatScrollViewRef,
   VirtualizedListScrollViewProps
 >(
   (
@@ -44,16 +41,16 @@ const VirtualizedListScrollView = forwardRef<
     ref,
   ) => {
     const setScrollViewRef = useCallback(
-      (instance: VirtualizedListScrollViewRef | null) => {
+      (instance: KeyboardChatScrollViewRef | null) => {
         if (chatScrollViewRef) {
           // eslint-disable-next-line react-compiler/react-compiler
           chatScrollViewRef.current =
-            instance as VirtualizedListScrollViewRef | null;
+            instance as KeyboardChatScrollViewRef | null;
         }
       },
       [chatScrollViewRef],
     );
-    const combinedRef: RefCallback<VirtualizedListScrollViewRef> = useCallback(
+    const combinedRef: RefCallback<KeyboardChatScrollViewRef> = useCallback(
       (instance) => {
         if (typeof ref === "function") {
           ref(instance);

--- a/example/src/screens/Examples/KeyboardChatScrollView/index.tsx
+++ b/example/src/screens/Examples/KeyboardChatScrollView/index.tsx
@@ -20,6 +20,7 @@ import {
   KeyboardEffects,
   KeyboardGestureArea,
   KeyboardStickyView,
+  type KeyboardChatScrollViewRef,
 } from "react-native-keyboard-controller";
 import { useSharedValue, withTiming } from "react-native-reanimated";
 import {
@@ -38,15 +39,13 @@ import styles, {
   contentContainerStyle,
   invertedContentContainerStyle,
 } from "./styles";
-import VirtualizedListScrollView, {
-  type VirtualizedListScrollViewRef,
-} from "./VirtualizedListScrollView";
+import VirtualizedListScrollView from "./VirtualizedListScrollView";
 
 import type { LayoutChangeEvent, ScrollViewProps } from "react-native";
 
 function KeyboardChatScrollViewPlayground() {
-  const chatScrollViewRef = useRef<VirtualizedListScrollViewRef | null>(null);
-  const scrollRef = useRef<VirtualizedListScrollViewRef>(null);
+  const chatScrollViewRef = useRef<KeyboardChatScrollViewRef | null>(null);
+  const scrollRef = useRef<KeyboardChatScrollViewRef>(null);
   const textInputRef = useRef<TextInput>(null);
   const textRef = useRef("");
   const [inputHeight, setInputHeight] = useState(TEXT_INPUT_HEIGHT);

--- a/example/src/screens/Examples/KeyboardChatScrollView/index.tsx
+++ b/example/src/screens/Examples/KeyboardChatScrollView/index.tsx
@@ -17,10 +17,10 @@ import {
   View,
 } from "react-native";
 import {
+  type KeyboardChatScrollViewRef,
   KeyboardEffects,
   KeyboardGestureArea,
   KeyboardStickyView,
-  type KeyboardChatScrollViewRef,
 } from "react-native-keyboard-controller";
 import { useSharedValue, withTiming } from "react-native-reanimated";
 import {

--- a/src/components/KeyboardAwareScrollView/types.ts
+++ b/src/components/KeyboardAwareScrollView/types.ts
@@ -1,4 +1,5 @@
 import type { AnimatedScrollViewComponent } from "../ScrollViewWithBottomPadding";
+import type { ComponentRef } from "react";
 import type { ScrollView, ScrollViewProps } from "react-native";
 
 export type KeyboardAwareScrollViewMode = "insets" | "layout";
@@ -26,4 +27,4 @@ export type KeyboardAwareScrollViewProps = {
 } & ScrollViewProps;
 export type KeyboardAwareScrollViewRef = {
   assureFocusedInputVisible: () => void;
-} & ScrollView;
+} & ComponentRef<typeof ScrollView>;

--- a/src/components/KeyboardChatScrollView/index.tsx
+++ b/src/components/KeyboardChatScrollView/index.tsx
@@ -16,16 +16,19 @@ import { useEndVisible } from "./useEndVisible";
 import { useExtraContentPadding } from "./useExtraContentPadding";
 import { useFrozenPadding } from "./useFrozenPadding";
 
-import type { KeyboardChatScrollViewProps } from "./types";
+import type {
+  KeyboardChatScrollViewProps,
+  KeyboardChatScrollViewRef,
+} from "./types";
 import type { LayoutChangeEvent } from "react-native";
 
 const ZERO_CONTENT_PADDING = makeMutable(0);
 const ZERO_BLANK_SPACE = makeMutable(0);
 
-const KeyboardChatScrollView = forwardRef<
-  Reanimated.ScrollView,
-  React.PropsWithChildren<KeyboardChatScrollViewProps>
->(
+const KeyboardChatScrollView: React.ForwardRefExoticComponent<
+  React.PropsWithChildren<KeyboardChatScrollViewProps> &
+    React.RefAttributes<KeyboardChatScrollViewRef>
+> = forwardRef<KeyboardChatScrollViewRef, KeyboardChatScrollViewProps>(
   (
     {
       children,

--- a/src/components/KeyboardChatScrollView/types.ts
+++ b/src/components/KeyboardChatScrollView/types.ts
@@ -3,8 +3,11 @@ import type {
   ScrollViewContentInsets,
 } from "../ScrollViewWithBottomPadding";
 import type { KeyboardLiftBehavior } from "./useChatKeyboard/types";
-import type { ScrollViewProps } from "react-native";
+import type { ComponentRef } from "react";
+import type { ScrollView, ScrollViewProps } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
+
+export type KeyboardChatScrollViewRef = ComponentRef<typeof ScrollView>;
 
 export type KeyboardChatScrollViewProps = {
   /** Custom component for `ScrollView`. Default is `ScrollView`. */

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,4 +16,7 @@ export type {
   KeyboardAwareScrollViewRef,
 } from "./KeyboardAwareScrollView/types";
 export type { KeyboardToolbarProps } from "./KeyboardToolbar";
-export type { KeyboardChatScrollViewProps } from "./KeyboardChatScrollView/types";
+export type {
+  KeyboardChatScrollViewProps,
+  KeyboardChatScrollViewRef,
+} from "./KeyboardChatScrollView/types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export {
 } from "./components";
 export type {
   KeyboardChatScrollViewProps,
+  KeyboardChatScrollViewRef,
   KeyboardAvoidingViewProps,
   KeyboardStickyViewProps,
   KeyboardAwareScrollViewMode,


### PR DESCRIPTION
## 📜 Description

Fixed compatibility of `KeyboardAwareScrollView`/`KeyboardChatScrollView` with `react-native-strict-api`.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

React Native’s `react-native-strict-api` export condition exposes `ScrollView` as a function component rather than a class. Our existing ref types relied on class-instance typing:

- `KeyboardAwareScrollViewRef` intersected with `ScrollView`
- `KeyboardChatScrollView` exposed Reanimated’s `AnimatedScrollView` ref type, which internally relies on the same pattern

Under strict API, those types lose imperative methods such as `scrollTo`, `scrollToEnd`, and `measure`. The runtime ref is still valid; this is a TypeScript declaration issue.

This change derives the native `ScrollView` instance type with `React.ComponentRef<typeof ScrollView>` and exposes it as `KeyboardChatScrollViewRef`. It keeps the public ref API correct in both classic and strict-API React Native typings.

Possible alternatives:

- Keep `React.ElementRef<typeof KeyboardChatScrollView>` in consumers: this works only when the component’s own public ref declaration is correct. It cannot fix the broken inferred ref type under strict API.
- Type the ref as `ScrollView`: this works with classic React Native declarations but fails under strict API because `ScrollView` becomes a component type, not its instance type.
- Expose Reanimated’s `AnimatedScrollView`: this preserves the existing issue because Reanimated’s type is built on the classic `ScrollView` class shape.
- Use consumer-side casts or wrapper components: this is a workaround, but pushes library typing details to every consumer.
- Fix Reanimated’s declarations upstream: worthwhile independently, but does not remove our responsibility to expose a stable public ref type.

We chose `ComponentRef<typeof ScrollView>` because it resolves to the actual imperative instance in both typing modes, matches the runtime ref shape, and provides a simple exported type for consumers:
`useRef<KeyboardChatScrollViewRef>(null)`.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1559

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `KeyboardChatScrollViewRef` (similar to `KeyboardAwareScrollViewRef`);
- change ref signatures so that they are compatible with both strict and non-strict API;

### Docs

- use  `KeyboardChatScrollViewRef` instead of self derived ref;

## 🤔 How Has This Been Tested?

Tested with following code:

```tsx
import { useRef } from "react";
import {
  KeyboardAwareScrollView,
  KeyboardChatScrollView,
} from "react-native-keyboard-controller";

import type { KeyboardAwareScrollViewRef } from "react-native-keyboard-controller";

type KeyboardChatScrollViewRef = React.ElementRef<
  typeof KeyboardChatScrollView
>;

export function StrictApiReproduction() {
  const ref = useRef<KeyboardAwareScrollViewRef>(null);

  return (
    <KeyboardAwareScrollView
      ref={ref}
      onLayout={() => {
        ref.current?.assureFocusedInputVisible();
        ref.current?.scrollTo({ animated: true, y: 0 });
        ref.current?.scrollToEnd({ animated: true });
      }}
    />
  );
}

export function StrictApiKeyboardChatScrollViewReproduction() {
  const ref = useRef<KeyboardChatScrollViewRef>(null);

  return (
    <KeyboardChatScrollView
      ref={ref}
      onLayout={() => {
        ref.current?.scrollTo({ animated: true, y: 0 });
        ref.current?.scrollToEnd({ animated: true });
      }}
    />
  );
}
```

And following `tsconfig.json` in `example`:

```json
{
  "extends": "@react-native/typescript-config",
  "compilerOptions": {
    "customConditions": ["react-native-strict-api", "react-native"]
  },
  "include": ["**/*.ts", "**/*.tsx"],
  "exclude": ["**/node_modules", "**/Pods"]
}
```

## 📸 Screenshots (if appropriate):

### KeyboardAwareScrollView

|Before|After|
|-------|-----|
|<img width="1088" height="373" alt="Screenshot 2026-07-21 at 10 46 32" src="https://github.com/user-attachments/assets/80fd86e9-d4d2-41cf-a221-54a0d50a87cd" />|<img width="726" height="370" alt="Screenshot 2026-07-21 at 10 48 17" src="https://github.com/user-attachments/assets/73232e16-b9d9-46fa-b265-7cc0a92d7851" />|

### KeyboardChatScrollView

|Before|After|
|-------|-----|
|<img width="1323" height="347" alt="Screenshot 2026-07-21 at 11 16 31" src="https://github.com/user-attachments/assets/de3ea478-a76e-4a96-b24b-9d2d99c8cbbd" />|<img width="736" height="339" alt="Screenshot 2026-07-21 at 11 02 20" src="https://github.com/user-attachments/assets/bb154d29-bff4-4add-80d0-f92f2cd091e4" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
