### PR TITLE
fix: overscroll during interactive dismissal using `KeyboardChatScrollView` component

### DIFF
--- a/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/index.ios.spec.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/index.ios.spec.ts
@@ -67,6 +67,31 @@ describe("`useChatKeyboard` — iOS non-inverted + always", () => {
     expect(result.current.contentOffsetY!.value).toBe(100);
   });
 
+  it("should not set contentOffsetY after an interactive keyboard dismiss", () => {
+    const { result } = render({
+      inverted: false,
+      keyboardLiftBehavior: "always",
+    });
+
+    handlers.onStart({ height: KEYBOARD });
+    handlers.onMove({ height: KEYBOARD / 2 });
+    handlers.onEnd({ height: KEYBOARD });
+    expect(result.current.contentOffsetY!.value).toBe(KEYBOARD);
+
+    handlers.onInteractive({ height: KEYBOARD / 2 });
+    handlers.onStart({ height: 0 });
+
+    expect(result.current.padding.value).toBe(0);
+    // UIKit owns the native offset while the keyboard is dismissed interactively.
+    expect(result.current.contentOffsetY!.value).toBe(KEYBOARD);
+
+    handlers.onEnd({ height: 0 });
+
+    // check again just in case
+    expect(result.current.padding.value).toBe(0);
+    expect(result.current.contentOffsetY!.value).toBe(KEYBOARD);
+  });
+
   it("should handle keyboard resize (emoji toggle)", () => {
     mockOffset.value = 100;
     const { result } = render({

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/index.ios.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/index.ios.ts
@@ -50,6 +50,7 @@ function useChatKeyboard(
   const contentOffsetY = useSharedValue(0);
   const targetKeyboardHeight = useSharedValue(0);
   const prevAbsorption = useSharedValue(0);
+  const isInteractiveDismissal = useSharedValue(false);
 
   const {
     layout,
@@ -108,6 +109,17 @@ function useChatKeyboard(
           blankSpace.value,
           effective + extraContentPadding.value,
         );
+
+        // `onInteractive` owns the native scroll offset. When its final
+        // keyboardWillHide event arrives, consume the marker so this
+        // transition only removes the inset and does not scroll programmatically.
+        if (isInteractiveDismissal.value) {
+          isInteractiveDismissal.value = false;
+          padding.value = effective;
+          prevAbsorption.value = minimumPaddingAbsorbed;
+
+          return;
+        }
 
         // persistent mode: when keyboard shrinks, clamp to valid range
         if (
@@ -220,6 +232,11 @@ function useChatKeyboard(
           inverted,
           actualTotalPadding,
         );
+      },
+      onInteractive: () => {
+        "worklet";
+
+        isInteractiveDismissal.value = true;
       },
       onMove: () => {
         "worklet";


### PR DESCRIPTION
## 📜 Description

Fixed a problem with unexpected scroll when you close keyboard interactively using `KeyboardChatScrollView`.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The issue stems from the fact that we always update scroll position after starting keyboard movement. However we have one exception. If we dismiss keyboard interactively then scroll must be owned by UIKit, not by us. If we try to modify it the behavior will look unnatural.

So in this PR I added conditional code that skips the update when keyboard was dismissed interactively.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1564

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- don't update `contentOffsetY` after interactive dismissal;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 17 Pro (iOS 26.2).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/9e74f057-d107-482e-916b-abf9b3532626">|<video src="https://github.com/user-attachments/assets/a427e4e5-2cf5-4cc5-9d5d-7fc3ee90884b">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
