### PR TITLE
fix: defer focused input layout sync out of synchronous onStart dispatch

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -217,13 +217,12 @@ class KeyboardAnimationCallback(
       this.persistentKeyboardHeight = keyboardHeight
     }
 
-    layoutObserver?.syncUpLayout()
-
     // keyboard gets resized - we do not want to have a default animated transition
     // so we skip these animations
     val isKeyboardResized = keyboardHeight != 0.0 && prevKeyboardHeight != keyboardHeight
     val isKeyboardShown = isKeyboardVisible && prevKeyboardHeight != 0.0
     if (isKeyboardResized && isKeyboardShown && isResizeHandledInCallbackMethods) {
+      layoutObserver?.syncUpLayout()
       onKeyboardResized(keyboardHeight)
       animationsToSkip.add(animation)
 
@@ -477,6 +476,15 @@ class KeyboardAnimationCallback(
     val event = pendingStartEvent ?: return
 
     pendingStartEvent = null
+    // `FocusedInputLayoutChangedEvent` is delivered to Reanimated synchronously
+    // on the UI thread, just like the start event below. Dispatching it from
+    // within `onStart` runs inside `dispatchWindowInsetsAnimationStart`, where
+    // a synchronous Fabric mutation can reentrantly cancel a pending IME insets
+    // controller before AOSP calls `listener.onReady` (AOSP checks `isCancelled`
+    // only before dispatching `onStart` and never re-checks it afterwards), so
+    // the layout sync is flushed here together with the start event (keeping
+    // the original layout -> start dispatch order).
+    layoutObserver?.syncUpLayout()
     context.dispatchEvent(
       eventPropagationView.id,
       KeyboardTransitionEvent(

--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/KeyboardAnimationCallback.kt
@@ -168,7 +168,6 @@ class KeyboardAnimationCallback(
 
     if (isKeyboardFullyVisible && !isKeyboardSizeEqual && !isResizeHandledInCallbackMethods) {
       Logger.i(TAG, "onApplyWindowInsets: ${this.persistentKeyboardHeight} -> $keyboardHeight")
-      layoutObserver?.syncUpLayout()
       this.onKeyboardResized(keyboardHeight)
 
       return insets
@@ -222,7 +221,6 @@ class KeyboardAnimationCallback(
     val isKeyboardResized = keyboardHeight != 0.0 && prevKeyboardHeight != keyboardHeight
     val isKeyboardShown = isKeyboardVisible && prevKeyboardHeight != 0.0
     if (isKeyboardResized && isKeyboardShown && isResizeHandledInCallbackMethods) {
-      layoutObserver?.syncUpLayout()
       onKeyboardResized(keyboardHeight)
       animationsToSkip.add(animation)
 
@@ -426,6 +424,8 @@ class KeyboardAnimationCallback(
   private fun onKeyboardResized(keyboardHeight: Double) {
     duration = 0
 
+    layoutObserver?.syncUpLayout()
+
     context.emitEvent("KeyboardController::keyboardWillShow", getEventParams(keyboardHeight))
     listOf(
       KeyboardTransitionEvent.Start,
@@ -476,14 +476,6 @@ class KeyboardAnimationCallback(
     val event = pendingStartEvent ?: return
 
     pendingStartEvent = null
-    // `FocusedInputLayoutChangedEvent` is delivered to Reanimated synchronously
-    // on the UI thread, just like the start event below. Dispatching it from
-    // within `onStart` runs inside `dispatchWindowInsetsAnimationStart`, where
-    // a synchronous Fabric mutation can reentrantly cancel a pending IME insets
-    // controller before AOSP calls `listener.onReady` (AOSP checks `isCancelled`
-    // only before dispatching `onStart` and never re-checks it afterwards), so
-    // the layout sync is flushed here together with the start event (keeping
-    // the original layout -> start dispatch order).
     layoutObserver?.syncUpLayout()
     context.dispatchEvent(
       eventPropagationView.id,


### PR DESCRIPTION
## 📜 Description

Moves the `layoutObserver?.syncUpLayout()` call out of the synchronous `onStart` dispatch and flushes it in `flushPendingStartEvent()` instead — right before the deferred `Start` event, so the original `layout → start` event order is unchanged. The resize branch (`isResizeHandledInCallbackMethods`) keeps its synchronous sync, so its behavior is untouched.

## 💡 Motivation and Context

Fixes #1575.

#1461 deferred the `Start` transition event out of the `dispatchWindowInsetsAnimationStart` window because Reanimated processes it synchronously on the UI thread, and a synchronous Fabric mutation there can cancel a pending IME insets controller before AOSP calls `listener.onReady` — AOSP checks `isCancelled` only *before* dispatching `onStart` and never re-checks it afterwards ([`InsetsController.startAnimation`, android16-release ~L2151](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android16-release/core/java/android/view/InsetsController.java)).

`syncUpLayout()` still dispatches `FocusedInputLayoutChangedEvent` through that same window and the same Reanimated-synchronous channel (`useReanimatedFocusedInput` / `KeyboardAwareScrollView`). On Android 16+ the victim can be `ImeBackAnimationController` (predictive back IME dismiss), which starts its post-commit `ValueAnimator` inside `onReady` and crashes with `IllegalStateException: Can't change insets on an animation that is cancelled` on the first animator frame — observed in production on 1.21.14, which already includes #1461. Full stack and AOSP analysis in #1575.

## 📢 Changelog

### Android

- deferred `FocusedInputLayoutChangedEvent` dispatch from `onStart` to the pending-start-event flush (first `onProgress`/`onEnd`), preventing reentrant cancellation of a pending IME insets controller during predictive back dismissal

## 🤔 How Has This Been Tested?

- `ktlint` 1.3.1 (CI version) and `detekt` (repo config) pass locally; `yarn lint`, `yarn typescript`, `yarn test` all green (existing `KeyboardAwareScrollView` suites, which consume `FocusedInputLayoutChangedEvent`, still pass)
- The crash is a one-frame race with no deterministic repro (see #1575 / #1456 history); the mechanism is verified against AOSP source and matches the production stack frame-by-frame
- The change reuses the exact deferral pattern #1461 established, and preserves relative event ordering in both flush paths (`onProgress` and `onEnd`)

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed (N/A — no API change)
