### PR TITLE
fix: `KeyboardChatScrollView` crash on unmount

### DIFF
--- a/src/__tests__/internal.spec.ts
+++ b/src/__tests__/internal.spec.ts
@@ -1,0 +1,154 @@
+import { renderHook } from "@testing-library/react-native";
+
+import { useEventHandlerRegistration } from "../internal";
+import { findNodeHandle } from "../utils/findNodeHandle";
+
+type WorkletHandler = {
+  registerForEvents: jest.Mock<void, [number]>;
+  unregisterFromEvents: jest.Mock<void, [number]>;
+};
+type EventHandler = Parameters<
+  ReturnType<typeof useEventHandlerRegistration>
+>[0];
+
+const VIEW = 1;
+const VIEW_TAG = 42;
+
+jest.mock("../utils/findNodeHandle", () => ({
+  findNodeHandle: jest.fn(),
+}));
+
+const mockedFindNodeHandle = jest.mocked(findNodeHandle);
+
+/**
+ * Create a mocked worklet handler.
+ *
+ * @returns A worklet handler with mocked registration methods.
+ */
+function createWorkletHandler(): WorkletHandler {
+  return {
+    registerForEvents: jest.fn(),
+    unregisterFromEvents: jest.fn(),
+  };
+}
+
+/**
+ * Render the registration hook for a mutable view ref.
+ *
+ * @param viewTagRef - Ref containing the current view handle.
+ * @returns The handler registration function.
+ */
+function renderRegistration(viewTagRef: React.MutableRefObject<number | null>) {
+  return renderHook(() => useEventHandlerRegistration(viewTagRef)).result
+    .current;
+}
+
+beforeEach(() => {
+  mockedFindNodeHandle.mockImplementation((view) =>
+    view === null ? null : VIEW_TAG,
+  );
+});
+
+describe("useEventHandlerRegistration", () => {
+  it("should support a handler wrapped in workletEventHandler", () => {
+    const viewTagRef = { current: VIEW };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+
+    const cleanup = register({
+      workletEventHandler,
+    } as unknown as EventHandler);
+
+    expect(workletEventHandler.registerForEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
+
+    cleanup();
+
+    expect(workletEventHandler.unregisterFromEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
+  });
+
+  it("should support a direct worklet handler", () => {
+    const viewTagRef = { current: VIEW };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+
+    const cleanup = register(workletEventHandler as unknown as EventHandler);
+
+    expect(workletEventHandler.registerForEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
+
+    cleanup();
+
+    expect(workletEventHandler.unregisterFromEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
+  });
+
+  it("should attach handlers after the view becomes available", async () => {
+    const viewTagRef = { current: null as number | null };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+
+    const cleanup = register({
+      workletEventHandler,
+    } as unknown as EventHandler);
+
+    expect(workletEventHandler.registerForEvents).not.toHaveBeenCalled();
+
+    viewTagRef.current = VIEW;
+    await Promise.resolve();
+
+    expect(workletEventHandler.registerForEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
+
+    cleanup();
+  });
+
+  it("should attach handlers immediately when the view is available", () => {
+    const viewTagRef = { current: VIEW };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+
+    register({ workletEventHandler } as unknown as EventHandler);
+
+    expect(workletEventHandler.registerForEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
+  });
+
+  it("should remove handlers after the view ref is cleared", () => {
+    const viewTagRef = { current: VIEW as number | null };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+    const cleanup = register({
+      workletEventHandler,
+    } as unknown as EventHandler);
+
+    viewTagRef.current = null;
+    cleanup();
+
+    expect(workletEventHandler.unregisterFromEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
+  });
+
+  it("should not attach or remove handlers when the view is unavailable", async () => {
+    const viewTagRef = { current: null };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+    const cleanup = register({
+      workletEventHandler,
+    } as unknown as EventHandler);
+
+    await Promise.resolve();
+    cleanup();
+
+    expect(workletEventHandler.registerForEvents).not.toHaveBeenCalled();
+    expect(workletEventHandler.unregisterFromEvents).not.toHaveBeenCalled();
+  });
+});

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -37,6 +37,7 @@ export function useEventHandlerRegistration(
   const onRegisterHandler = (handler: EventHandlerProcessed<never, never>) => {
     const currentHandler =
       handler as unknown as WorkletHandlerOrWorkletHandlerObject;
+    let registeredViewTag: number | null = null;
     const attachWorkletHandlers = () => {
       const viewTag = findNodeHandle(viewTagRef.current);
 
@@ -52,6 +53,8 @@ export function useEventHandlerRegistration(
         } else {
           currentHandler.registerForEvents(viewTag);
         }
+
+        registeredViewTag = viewTag;
       }
     };
 
@@ -63,13 +66,13 @@ export function useEventHandlerRegistration(
     }
 
     return () => {
-      const viewTag = findNodeHandle(viewTagRef.current);
-
-      if (viewTag) {
+      if (registeredViewTag) {
         if ("workletEventHandler" in currentHandler) {
-          currentHandler.workletEventHandler.unregisterFromEvents(viewTag);
+          currentHandler.workletEventHandler.unregisterFromEvents(
+            registeredViewTag,
+          );
         } else {
-          currentHandler.unregisterFromEvents(viewTag);
+          currentHandler.unregisterFromEvents(registeredViewTag);
         }
       }
     };


### PR DESCRIPTION
## 📜 Description

Fixed a crash when cleaning up handlers for unmounted view.

## 💡 Motivation and Context

The regression has been introduced in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1209

Before we were storing an arrays of `id`s. In new PR we started to retrieve view id on demand (when it's unmounted). But when view is getting unmounted, then we may not be able to retrieve its data which will lead to the crash.

So in this PR I partially restore the old behavior - we also store the data in closure (variable defined outside of function). It fixes a crash. I also added unit tests to avoid problems in the future.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1577

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- don't read `viewTag` and call `findNodeHandle` in cleanup effect;

## 🤔 How Has This Been Tested?

Tested via e2e tests.

## 📸 Screenshots (if appropriate):

N/A

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
