### PR TITLE
fix: stabilize unit tests

### DIFF
--- a/src/components/KeyboardAwareScrollView/__fixtures__/testUtils.tsx
+++ b/src/components/KeyboardAwareScrollView/__fixtures__/testUtils.tsx
@@ -137,6 +137,12 @@ export const renderKeyboardAwareScrollView = async (
     mockCapturedOnLayout.current?.({
       nativeEvent: { layout: { x: 0, y: 0, width: 390, height: 812 } },
     } as LayoutChangeEvent);
+
+    // Let `synchronize` continue after `await update`, then drain its scheduled frame.
+    await Promise.resolve();
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
   });
 };
 


### PR DESCRIPTION
## 📜 Description

Fixed noisy logs when running unit tests.

## 💡 Motivation and Context

We had these errors:

```bash
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/components/KeyboardAwareScrollView/__tests__/selectionOrder.spec.tsx.

    

      at mockState (src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:1180:10)
      at scrollTo (src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:9:28)
      at src/components/KeyboardAwareScrollView/index.tsx:4817:43
      at src/components/KeyboardAwareScrollView/index.tsx:4868:5
      at src/components/KeyboardAwareScrollView/index.tsx:4917:5
      at src/components/KeyboardAwareScrollView/index.tsx:5200:9
      at src/components/KeyboardAwareScrollView/index.tsx:5201:9
      at Timeout._onTimeout (node_modules/react-native-reanimated/src/mockedRequestAnimationFrame.ts:8:12)
/Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:9
      return (_mockState = mockState()).mockScrollTo.apply(_mockState, arguments);
                                                     ^

TypeError: Cannot read properties of undefined (reading 'apply')
    at scrollTo (/Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:9:54)
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:4817:43
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:4868:5
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:4917:5
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:5200:9
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:5201:9
    at Timeout._onTimeout (/Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/node_modules/react-native-reanimated/src/mockedRequestAnimationFrame.ts:8:12)
    at listOnTimeout (node:internal/timers:605:17)
    at processTimers (node:internal/timers:541:7)

Node.js v24.15.0

ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/components/KeyboardAwareScrollView/__tests__/selectionOrder.spec.tsx.

    

      at mockState (src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:1180:10)
      at scrollTo (src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:9:28)
      at src/components/KeyboardAwareScrollView/index.tsx:4817:43
      at src/components/KeyboardAwareScrollView/index.tsx:4868:5
      at src/components/KeyboardAwareScrollView/index.tsx:4917:5
      at src/components/KeyboardAwareScrollView/index.tsx:5200:9
      at src/components/KeyboardAwareScrollView/index.tsx:5201:9
      at Timeout._onTimeout (node_modules/react-native-reanimated/src/mockedRequestAnimationFrame.ts:8:12)
/Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:9
      return (_mockState = mockState()).mockScrollTo.apply(_mockState, arguments);
                                                     ^

TypeError: Cannot read properties of undefined (reading 'apply')
    at scrollTo (/Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:9:54)
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:4817:43
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:4868:5
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:4917:5
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:5200:9
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:5201:9
    at Timeout._onTimeout (/Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/node_modules/react-native-reanimated/src/mockedRequestAnimationFrame.ts:8:12)
    at listOnTimeout (node:internal/timers:605:17)
    at processTimers (node:internal/timers:541:7)

Node.js v24.15.0

ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/components/KeyboardAwareScrollView/__tests__/selectionOrder.spec.tsx.

    

      at mockState (src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:1180:10)
      at scrollTo (src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:9:28)
      at src/components/KeyboardAwareScrollView/index.tsx:4817:43
      at src/components/KeyboardAwareScrollView/index.tsx:4868:5
      at src/components/KeyboardAwareScrollView/index.tsx:4917:5
      at src/components/KeyboardAwareScrollView/index.tsx:5200:9
      at src/components/KeyboardAwareScrollView/index.tsx:5201:9
      at Timeout._onTimeout (node_modules/react-native-reanimated/src/mockedRequestAnimationFrame.ts:8:12)
/Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:9
      return (_mockState = mockState()).mockScrollTo.apply(_mockState, arguments);
                                                     ^

TypeError: Cannot read properties of undefined (reading 'apply')
    at scrollTo (/Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/__fixtures__/mocks.tsx:9:54)
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:4817:43
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:4868:5
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:4917:5
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:5200:9
    at /Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/src/components/KeyboardAwareScrollView/index.tsx:5201:9
    at Timeout._onTimeout (/Users/kirylziusko/IdeaProjects/react-native-keyboard-controller/node_modules/react-native-reanimated/src/mockedRequestAnimationFrame.ts:8:12)
    at listOnTimeout (node:internal/timers:605:17)
    at processTimers (node:internal/timers:541:7)

Node.js v24.15.0
 FAIL  src/components/KeyboardAwareScrollView/__tests__/selectionOrder.spec.tsx
  ● Test suite failed to run

    Jest worker encountered 4 child process exceptions, exceeding retry limit

      at ChildProcessWorker.initialize (node_modules/jest-worker/build/workers/ChildProcessWorker.js:181:21)
```

It happens because `KeyboardAwareScrollView` has async operations inside `useEffect` and sometimes we may end test earlier than operation completes.

In this PR I added act + microtask await to avoid those errors.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- wait for end of render before running a test;

## 🤔 How Has This Been Tested?

Tested locally via `yarn test src --coverage`.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="951" height="385" alt="image" src="https://github.com/user-attachments/assets/91e4cd7e-fec2-4017-8112-6fb4010d4e5d" />|<img width="958" height="650" alt="image" src="https://github.com/user-attachments/assets/6b812a04-6790-4625-ab04-790e6b78244f" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
