### PR TITLE
fix: UTF-16 encoding in `onTextChangedHandler`

### DIFF
--- a/ios/views/KeyboardControllerView.mm
+++ b/ios/views/KeyboardControllerView.mm
@@ -108,7 +108,7 @@ using namespace facebook::react;
                 self->_eventEmitter)
                 ->onFocusedInputTextChanged(
                     facebook::react::KeyboardControllerViewEventEmitter::OnFocusedInputTextChanged{
-                        .text = std::string([text UTF8String])});
+                        .text = std::string([text UTF8String] ?: "")});
 
             FocusedInputTextChangedEvent *textChangedEvent =
                 [[FocusedInputTextChangedEvent alloc] initWithReactTag:@(self.tag) text:text];


### PR DESCRIPTION
## 📜 Description

Fixed a crash on iOS when passing invalid UTF-16 sequence to `onTextChangedHandler`.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I can not reliably reproduce this issue when just interacting with simulator/phone. The problem is clearly reproducible when string contains UTF‑16 surrogate. But UTF‑16 surrogate is not a typeable character on its own 🤷‍♂️ 

I've tried to enter/delete emojis, Chinese hieroglyphs but none of them led to crash. So the only way to verify a fix was adding this code:

```objc
#if DEBUG
          const unichar invalidUTF16[] = {0xD800};
          text = [NSString stringWithCharacters:invalidUTF16 length:1];
#endif
```

After that typing in any input led to crash.

To fix this problem I added `?: ""` elvis operator. If we get `null` string (missing/can not be represented value), then we simply return empty string. It fixes a crash 🤞 

> [!NOTE]
> I also tried to change signature of event in `spec` file, but it doesn't help because the crash stems from `std::string` call.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1573

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added `?: ""` to avoid passing `null` reference to `std::string`;

## 🤔 How Has This Been Tested?

Tested locally on iPhone 17 Pro (iOS 26.2).

## 📸 Screenshots (if appropriate):

<img width="1724" height="853" alt="image" src="https://github.com/user-attachments/assets/fc369d65-794f-4aec-9921-7ba057138e8c" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
