### PR TITLE
fix: remove `java`-package prefix from `ClippingScrollViewDecoratorViewManager` class to avoid compilation errors

### DIFF
--- a/android/src/base/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
+++ b/android/src/base/java/com/reactnativekeyboardcontroller/KeyboardControllerPackage.kt
@@ -8,7 +8,6 @@ import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 import com.reactnativekeyboardcontroller.modules.KeyboardControllerModuleImpl
 import com.reactnativekeyboardcontroller.modules.statusbar.StatusBarManagerCompatModuleImpl
-import java.com.reactnativekeyboardcontroller.ClippingScrollViewDecoratorViewManager
 
 class KeyboardControllerPackage : BaseReactPackage() {
   override fun getModule(

--- a/android/src/fabric/java/com/reactnativekeyboardcontroller/ClippingScrollViewDecoratorViewManager.kt
+++ b/android/src/fabric/java/com/reactnativekeyboardcontroller/ClippingScrollViewDecoratorViewManager.kt
@@ -1,4 +1,4 @@
-package java.com.reactnativekeyboardcontroller
+package com.reactnativekeyboardcontroller
 
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager

--- a/android/src/paper/java/com/reactnativekeyboardcontroller/ClippingScrollViewDecoratorViewManager.kt
+++ b/android/src/paper/java/com/reactnativekeyboardcontroller/ClippingScrollViewDecoratorViewManager.kt
@@ -1,4 +1,4 @@
-package java.com.reactnativekeyboardcontroller
+package com.reactnativekeyboardcontroller
 
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager


### PR DESCRIPTION
## 📜 Description

Fix compilation for RN < 0.74 and library version 1.21.x 🤞 

## 💡 Motivation and Context

I think at early prototype stage I created file in Android Studio and it automatically added `java` prefix and additional import in `base` package.

I didn't notice it until https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1585 has been raised. In fact we don't need that `java` prefix (see how other managers are organized). So in this PR I removed unnecessary `java` prefix + removed unnecessary import in base package 🤞 It should fix compilation error on old RN versions that are using `turbo`-package variant.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1585

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- remove `java` from `ClippingScrollViewDecoratorManager` in `package` declaration;
- remove unnecessary `java.com.reactnativekeyboardcontroller.ClippingScrollViewDecoratorViewManager` import in base package.

## 🤔 How Has This Been Tested?

Tested via this PR. If something would be broken CI would fail for this PR too.

## 📸 Screenshots (if appropriate):

<img width="812" height="298" alt="image" src="https://github.com/user-attachments/assets/8547b0b0-f4d6-4564-a057-e1efda2eb3f6" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
