### PR TITLE
fix: `KeyboardExtender` recycling on iOS

### DIFF
--- a/ios/views/KeyboardExtenderManager.mm
+++ b/ios/views/KeyboardExtenderManager.mm
@@ -117,7 +117,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
   _enabled = NO;
   [self detachInputAccessoryView];
   _sharedInputAccessoryView = nil;
-  
+
   // clean up listeners
   [self stopObserving];
 

--- a/ios/views/KeyboardExtenderManager.mm
+++ b/ios/views/KeyboardExtenderManager.mm
@@ -62,6 +62,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 @implementation KeyboardExtender {
   UIView *_contentView;
   UIView *_sharedInputAccessoryView;
+  BOOL _isObserving;
 #ifdef RCT_NEW_ARCH_ENABLED
   RCTSurfaceTouchHandler *_touchHandler;
 #else
@@ -100,29 +101,37 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
   }
 #endif
   [_touchHandler attachToView:_contentView];
-  [self setupObservers];
+  [self startObserving];
   return self;
 }
 
 - (void)dealloc
 {
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
+  [self stopObserving];
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
 - (void)prepareForRecycle
 {
+  // clean up local variables state
   _enabled = NO;
   [self detachInputAccessoryView];
   _sharedInputAccessoryView = nil;
+  
+  // clean up listeners
+  [self stopObserving];
 
   [super prepareForRecycle];
 }
 #endif
 
 // MARK: Listeners
-- (void)setupObservers
+- (void)startObserving
 {
+  if (_isObserving) {
+    return;
+  }
+
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(handleTextInputDidBeginEditing:)
                                                name:UITextFieldTextDidBeginEditingNotification
@@ -132,6 +141,19 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
                                            selector:@selector(handleTextInputDidBeginEditing:)
                                                name:UITextViewTextDidBeginEditingNotification
                                              object:nil];
+
+  _isObserving = YES;
+}
+
+- (void)stopObserving
+{
+  if (!_isObserving) {
+    return;
+  }
+
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+  _isObserving = NO;
 }
 
 - (void)handleTextInputDidBeginEditing:(NSNotification *)notification
@@ -233,6 +255,8 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 #ifdef RCT_NEW_ARCH_ENABLED
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
+  [self startObserving];
+
   const auto &newViewProps = *std::static_pointer_cast<const KeyboardExtenderProps>(props);
 
   if (newViewProps.enabled != self.enabled) {

--- a/ios/views/KeyboardExtenderManager.mm
+++ b/ios/views/KeyboardExtenderManager.mm
@@ -109,6 +109,17 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)prepareForRecycle
+{
+  _enabled = NO;
+  [self detachInputAccessoryView];
+  _sharedInputAccessoryView = nil;
+
+  [super prepareForRecycle];
+}
+#endif
+
 // MARK: Listeners
 - (void)setupObservers
 {


### PR DESCRIPTION
## 📜 Description

Prevent a crash on subsequent focus for input without `KeyboardExtender` when previous `KeyboardExtender` instance has been recycled.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The main problem stems from the fact that we still have active listener after view has been recycled. As a result we are trying to attach a view to other inputs, while original view has been recycled and not available anymore.

In this PR I added `prepareToRecycle` method where I:
- deactivate the instance;
- detach currently attached accessory instance;
- remove view-container that we attach;
- stop listening for global events, like "input start editing";

The important thing is that we start observing in multiple places: in constructor (init) and in `updateProps` (called again after recycling). To avoid multiple listeners mount I added `isObserving` variable.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1586

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- implemented `prepareForRecycle` for `KeyboardExtender` on iOS;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 17 Pro (iOS 26.2).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/aaa6fc79-a140-4148-80a9-17c2f927c205">|<video src="https://github.com/user-attachments/assets/cbf9e19f-7f31-4ed9-81c9-ec6c20a99c85">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
