### PR TITLE
fix: codegen import to ensure better compatibility with older RN versions

### DIFF
--- a/src/specs/ClippingScrollViewDecoratorViewNativeComponent.ts
+++ b/src/specs/ClippingScrollViewDecoratorViewNativeComponent.ts
@@ -1,4 +1,4 @@
-import { codegenNativeComponent } from "react-native";
+import codegenNativeComponent from "react-native/Libraries/Utilities/codegenNativeComponent";
 
 import type { HostComponent } from "react-native";
 import type { ViewProps } from "react-native";


### PR DESCRIPTION
## 📜 Description

Use old import of `codegenNativeComponent` from `react-native/Libraries/Utilities/codegenNativeComponent"` instead of `react-native` (because `react-native` import was added relatively recently).

## 💡 Motivation and Context

This matches the whole setup of all components included in this package. At sme point we will switch to `react-native` import, but in this case we'll drop minimal supported RN version and it needs to be reflected in documentation. For now just use old approach that gives a wider compatibility.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1585#issuecomment-5223569485

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- use old import of `codegenNativeComponent` from `react-native/Libraries/Utilities/codegenNativeComponent"`;

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="782" height="299" alt="image" src="https://github.com/user-attachments/assets/30725bd0-9c89-496a-9f21-f5c2bd02848c" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
