### PR TITLE
fix: reanimated 3.0 compatibility

### DIFF
--- a/src/__tests__/internal.spec.ts
+++ b/src/__tests__/internal.spec.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 });
 
 describe("useEventHandlerRegistration", () => {
-  it("should support a handler wrapped in workletEventHandler", () => {
+  it("should support the handler shape from Reanimated 3.8 and newer", () => {
     const viewTagRef = { current: VIEW };
     const workletEventHandler = createWorkletHandler();
     const register = renderRegistration(viewTagRef);
@@ -70,12 +70,14 @@ describe("useEventHandlerRegistration", () => {
     );
   });
 
-  it("should support a direct worklet handler", () => {
+  it("should support the ref handler shape from Reanimated 3.0 through 3.7", () => {
     const viewTagRef = { current: VIEW };
     const workletEventHandler = createWorkletHandler();
     const register = renderRegistration(viewTagRef);
 
-    const cleanup = register(workletEventHandler as unknown as EventHandler);
+    const cleanup = register({
+      current: workletEventHandler,
+    } as unknown as EventHandler);
 
     expect(workletEventHandler.registerForEvents).toHaveBeenCalledWith(
       VIEW_TAG,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -12,8 +12,10 @@ type WorkletHandler = {
   unregisterFromEvents: (viewTag: number) => void;
 };
 
-type WorkletHandlerOrWorkletHandlerObject =
-  | WorkletHandler
+type WorkletHandlerContainer =
+  | {
+      current: WorkletHandler;
+    }
   | {
       workletEventHandler: WorkletHandler;
     };
@@ -35,8 +37,7 @@ export function useEventHandlerRegistration(
   viewTagRef: React.MutableRefObject<ComponentOrHandle>,
 ) {
   const onRegisterHandler = (handler: EventHandlerProcessed<never, never>) => {
-    const currentHandler =
-      handler as unknown as WorkletHandlerOrWorkletHandlerObject;
+    const currentHandler = handler as unknown as WorkletHandlerContainer;
     let registeredViewTag: number | null = null;
     const attachWorkletHandlers = () => {
       const viewTag = findNodeHandle(viewTagRef.current);
@@ -50,8 +51,8 @@ export function useEventHandlerRegistration(
       if (viewTag) {
         if ("workletEventHandler" in currentHandler) {
           currentHandler.workletEventHandler.registerForEvents(viewTag);
-        } else {
-          currentHandler.registerForEvents(viewTag);
+        } else if ("current" in currentHandler) {
+          currentHandler.current.registerForEvents(viewTag);
         }
 
         registeredViewTag = viewTag;
@@ -71,8 +72,8 @@ export function useEventHandlerRegistration(
           currentHandler.workletEventHandler.unregisterFromEvents(
             registeredViewTag,
           );
-        } else {
-          currentHandler.unregisterFromEvents(registeredViewTag);
+        } else if ("current" in currentHandler) {
+          currentHandler.current.unregisterFromEvents(registeredViewTag);
         }
       }
     };

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -51,7 +51,7 @@ export function useEventHandlerRegistration(
       if (viewTag) {
         if ("workletEventHandler" in currentHandler) {
           currentHandler.workletEventHandler.registerForEvents(viewTag);
-        } else if ("current" in currentHandler) {
+        } else {
           currentHandler.current.registerForEvents(viewTag);
         }
 
@@ -72,7 +72,7 @@ export function useEventHandlerRegistration(
           currentHandler.workletEventHandler.unregisterFromEvents(
             registeredViewTag,
           );
-        } else if ("current" in currentHandler) {
+        } else {
           currentHandler.current.unregisterFromEvents(registeredViewTag);
         }
       }


### PR DESCRIPTION
## 📜 Description

Fixed package compatibility for reanimated version lower than 3.7.0

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

On Reanimated `3.7.0-` the `useEvent` handler returns `ref` (with `current` property). After reanimated 3.8.0 it returns an object that contains `workletEventHandler`. Somehow in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1209 I thought that it returns the event handler directly (not in ref). So I declared the object as object-or-direct-handler.

In https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1585#issuecomment-5223569485 I realized that I made a mistake, so in this PR I eliminated a dead code and fixed compatibility.

Follow up for https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1209 (something that had to be implemented there from the beginning).

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1585#issuecomment-5223569485

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- rename `WorkletHandlerOrWorkletHandlerObject` to `WorkletHandlerContainer`;
- replace `currentHandler.*` with `currentHandler.current.*`;
- updated titles of unit tests;

## 🤔 How Has This Been Tested?

Tested via this PR (e2e tests).

## 📸 Screenshots (if appropriate):

<img width="817" height="299" alt="image" src="https://github.com/user-attachments/assets/c6a398fc-f011-4c21-bde9-c6b328bc7c4c" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
