### PR TITLE
fix: stale `keyboardLayoutGuide` causes stuck subsequent animations

### DIFF
--- a/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
+++ b/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
@@ -91,6 +91,7 @@ extension KeyboardMovementObserver {
     onNotify("KeyboardController::keyboardDidHide", buildEventParams(0, duration, tag))
 
     removeKeyboardWatcher()
+    prevKeyboardPosition = 0
     animation = nil
   }
 


### PR DESCRIPTION
## 📜 Description

Fixed a problem when leaving a screen with an opened keyboard causes missing `onKeyboardMove` events for subsequent focus.

## 💡 Motivation and Context

The problem is hidden in fact, that if we leave a screen in native-stack with keyboard opened, then `keyboardLayoutGuide` is not animating back when keyboard gets hidden (see attached video). We update `prevKeyboardPosition` every frame, but since view is stuck after animation completion then subsequent initialization will initialize the animation from final to final value (i. e. from 335 to 335). As a result we will not emit any values because of this condition:

```swift
if animation.isFinished {
  return
}
```

So I decided simply reset the variable once keyboard is hidden.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1591

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- reset `prevKeyboardPosition` in `keyboardDidHide` handler;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 17 Pro (iOS 26.5).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/4129a777-6882-44c7-a89f-35bcbf6b500c">|<video src="https://github.com/user-attachments/assets/5830e6c5-c4ee-41a5-af0a-90713db64a54">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
