### PR TITLE
fix(android): keep `StatusBar` proxy alive on react-native 0.87

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarModuleProxy.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarModuleProxy.kt
@@ -31,10 +31,16 @@ class StatusBarModuleProxy(
       instance = constructor.newInstance(reactContext)
 
       setHiddenMethod = clazz.getMethod("setHidden", Boolean::class.java)
-      setColorMethod = clazz.getMethod("setColor", Double::class.java, Boolean::class.java)
-      setTranslucentMethod = clazz.getMethod("setTranslucent", Boolean::class.java)
       setStyleMethod = clazz.getMethod("setStyle", String::class.java)
       getConstantsMethod = clazz.getMethod("getConstants")
+
+      // `setColor` and `setTranslucent` were removed from `StatusBarModule` in RN 0.87, so we look
+      // them up optionally - otherwise a single `NoSuchMethodException` would abort the whole
+      // initialization and leave every other method (and the module instance) unresolved.
+      setColorMethod =
+        runCatching { clazz.getMethod("setColor", Double::class.java, Boolean::class.java) }.getOrNull()
+      setTranslucentMethod =
+        runCatching { clazz.getMethod("setTranslucent", Boolean::class.java) }.getOrNull()
     } catch (e: Exception) {
       Logger.w(TAG, "Failed to initialize StatusBarModule via reflection", e)
     }


### PR DESCRIPTION
## 📜 Description

`StatusBarModuleProxy` resolved all five `StatusBarModule` methods eagerly inside a single `try` block. Two of them no longer exist on react-native 0.87, so the first `NoSuchMethodException` aborts the whole `init` and the outer `catch` swallows it — leaving *every* proxied method (and the module instance itself) unresolved.

This PR resolves the two removed methods with `runCatching`, so a missing method no longer takes the rest of the proxy down with it.

```kotlin
setHiddenMethod = clazz.getMethod("setHidden", Boolean::class.java)
setStyleMethod = clazz.getMethod("setStyle", String::class.java)
getConstantsMethod = clazz.getMethod("getConstants")

// `setColor` and `setTranslucent` were removed from `StatusBarModule` in RN 0.87, ...
setColorMethod =
  runCatching { clazz.getMethod("setColor", Double::class.java, Boolean::class.java) }.getOrNull()
setTranslucentMethod =
  runCatching { clazz.getMethod("setTranslucent", Boolean::class.java) }.getOrNull()
```

The backing fields are already declared as `Method?` and every call site already goes through `?.invoke(...)`, so no other change is needed.

## 💡 Motivation and Context

`StatusBarModule.setColor(double, boolean)` and `setTranslucent(boolean)` were removed in react-native 0.87:

- 0.86 — [`StatusBarModule.kt`](https://github.com/facebook/react-native/blob/v0.86.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt) declares `setColor(colorDouble: Double, animated: Boolean)` and `setTranslucent(translucent: Boolean)` alongside `setHidden` / `setStyle`.
- 0.87 — [`StatusBarModule.kt`](https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt) no longer declares either of them; of the methods this proxy looks up, only `setHidden` and `setStyle` remain.

The JS spec matches — on 0.87 [`NativeStatusBarManagerAndroid`](https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/src/private/specs_DEPRECATED/modules/NativeStatusBarManagerAndroid.js) only exposes `getConstants`, `setStyle` and `setHidden`.

`getConstants` itself is unaffected: it is not declared on `StatusBarModule`, it is inherited from [`BaseJavaModule`](https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java) (still `public` on 0.87), so `getMethod("getConstants")` keeps resolving and it stays a required lookup here.

Because of the eager lookups on [`StatusBarModuleProxy.kt#L34-L35`](https://github.com/kirillzyusko/react-native-keyboard-controller/blob/main/android/src/main/java/com/reactnativekeyboardcontroller/modules/statusbar/StatusBarModuleProxy.kt#L34-L35), the failure is not limited to the two removed APIs — `setHidden`, `setStyle` and `getConstants` are assigned *after* them, so they never get assigned at all, and `instance` stays usable but orphaned. The only visible symptom is a single `Failed to initialize StatusBarModule via reflection` warning in logcat, which makes it easy to misread as harmless.

### Reproduction conditions

- Android, react-native >= 0.87, this library installed.
- Any code path that reaches the status bar proxy (e.g. `KeyboardProvider` restoring the status bar around keyboard transitions, or JS calling `StatusBar` APIs that the library proxies).
- Before this change: warning in logcat, and the proxy silently does nothing.
- After this change: `setHidden` / `setStyle` / `getConstants` are proxied as usual; `setColor` / `setTranslucent` become no-ops on 0.87+, which matches react-native, where those APIs no longer exist.

## 📢 Changelog

### Android

- Resolve `StatusBarModule.setColor` and `StatusBarModule.setTranslucent` optionally, so that their removal in react-native 0.87 does not disable the entire `StatusBarModuleProxy`.

## 🤔 How Has This Been Tested?

- Verified against the react-native sources that the two methods exist on `v0.86.0` and are gone on `v0.87.0` (links above).
- `ktlint "android/src/**/*.kt"` (1.3.1) — passes.
- `detekt-cli --config detekt.yml --build-upon-default-config` (1.23.1, run from `android/`) — passes.
- The equivalent change has been running as a local patch of this library in an Android app on react-native 0.87 (new architecture, edge-to-edge). Without it the proxy fails to initialize and the `Failed to initialize StatusBarModule via reflection` warning appears; with it the proxy initializes and `setHidden` / `setStyle` / `getConstants` work again. `setColor` and `setTranslucent` stay no-ops, which is expected — react-native itself no longer implements them on 0.87.
- No behavior change is possible on older react-native versions: `getMethod` still succeeds there, so `runCatching { ... }.getOrNull()` returns exactly the same `Method` it returned before. The only difference is assignment order inside `init`, which nothing depends on.

## 📸 Screenshots (if appropriate):

Not applicable — no visual API change.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
