### PR TITLE
fix(android): skip explicit `kotlin-android` plugin when AGP 9 built-in Kotlin is enabled

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,8 +35,20 @@ def reactNativeArchitectures() {
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
+// AGP 9 ships built-in Kotlin support, which is on by default but can be disabled
+// via the `android.builtInKotlin` Gradle property.
+def hasBuiltInKotlinSupport() {
+  def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  def builtInKotlin = project.findProperty('android.builtInKotlin')
+
+  return agpMajorVersion >= 9 && (builtInKotlin == null || builtInKotlin.toString().toBoolean())
+}
+
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+// applying `kotlin-android` on top of AGP's built-in Kotlin support fails the build
+if (!hasBuiltInKotlinSupport()) {
+  apply plugin: 'kotlin-android'
+}
 apply from: "$projectDir/react-native-helpers.gradle"
 
 if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,21 +35,13 @@ def reactNativeArchitectures() {
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
-// AGP 9 ships built-in Kotlin support, which is on by default but can be disabled
-// via the `android.builtInKotlin` Gradle property.
-def hasBuiltInKotlinSupport() {
-  def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
-  def builtInKotlin = project.findProperty('android.builtInKotlin')
-
-  return agpMajorVersion >= 9 && (builtInKotlin == null || builtInKotlin.toString().toBoolean())
-}
-
 apply plugin: 'com.android.library'
+apply from: "$projectDir/react-native-helpers.gradle"
+
 // applying `kotlin-android` on top of AGP's built-in Kotlin support fails the build
-if (!hasBuiltInKotlinSupport()) {
+if (!project.ext.hasBuiltInKotlinSupport(com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION)) {
   apply plugin: 'kotlin-android'
 }
-apply from: "$projectDir/react-native-helpers.gradle"
 
 if (isNewArchitectureEnabled()) {
   apply plugin: 'com.facebook.react'

--- a/android/react-native-helpers.gradle
+++ b/android/react-native-helpers.gradle
@@ -44,3 +44,14 @@ project.ext.shouldConsumeReactNativeFromMavenCentral = { ->
 project.ext.shouldUseBaseReactPackage = { ->
   return REACT_NATIVE_MINOR_VERSION >= 74
 }
+
+// AGP 9 ships built-in Kotlin support, which is on by default but can be disabled
+// via the `android.builtInKotlin` Gradle property. The AGP version is passed in
+// because `com.android.Version` lives on the buildscript classpath of
+// `build.gradle`, which scripts applied with `apply from:` do not inherit.
+project.ext.hasBuiltInKotlinSupport = { agpVersion ->
+  def agpMajorVersion = agpVersion.tokenize('.')[0].toInteger()
+  def builtInKotlin = project.findProperty('android.builtInKotlin')
+
+  return agpMajorVersion >= 9 && (builtInKotlin == null || builtInKotlin.toString().toBoolean())
+}


### PR DESCRIPTION
## 📜 Description

`android/build.gradle` applies `kotlin-android` unconditionally. Since AGP 9.0 the Android Gradle Plugin provides Kotlin support itself, and applying the standalone Kotlin plugin on top of it makes configuration of this module fail.

This PR keeps `apply plugin: 'kotlin-android'` for every AGP version that needs it, and skips it only when AGP's built-in Kotlin is actually in play:

```groovy
// AGP 9 ships built-in Kotlin support, which is on by default but can be disabled
// via the `android.builtInKotlin` Gradle property.
def hasBuiltInKotlinSupport() {
  def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
  def builtInKotlin = project.findProperty('android.builtInKotlin')

  return agpMajorVersion >= 9 && (builtInKotlin == null || builtInKotlin.toString().toBoolean())
}

apply plugin: 'com.android.library'
// applying `kotlin-android` on top of AGP's built-in Kotlin support fails the build
if (!hasBuiltInKotlinSupport()) {
  apply plugin: 'kotlin-android'
}
```

## 💡 Motivation and Context

**(a) The symptom.** On a project built with AGP 9, configuring this module fails with one of:

```
Failed to apply plugin 'org.jetbrains.kotlin.android'.
> Cannot add extension with name 'kotlin', as there is an extension already registered with that name.
```

```
Failed to apply plugin 'org.jetbrains.kotlin.android'
> The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0.
```

There is no consumer-side workaround other than pinning AGP 8 or globally disabling built-in Kotlin, so the fix has to live in the library.

**(b) Why the condition has that shape.** Built-in Kotlin is not simply "AGP >= 9" — it is a flag:

- It exists only from AGP 9.0.
- It is **on by default** in AGP 9.0.
- A consumer can opt out with `android.builtInKotlin=false` in `gradle.properties` (documented as a temporary escape hatch that goes away in AGP 10).

So both halves are required. Dropping the property check would break every project that opted out — they need the explicit plugin. Dropping the version check would skip the plugin on AGP 8, where nothing else provides Kotlin. The `builtInKotlin == null` branch covers "property not set", which is the default-on case. References: [Migrate to built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin), [AGP 9.0 release notes](https://developer.android.com/build/releases/agp-9-0-0-release-notes).

**(c) Nothing changes on older AGP.** For any AGP major below 9, `hasBuiltInKotlinSupport()` short-circuits to `false` and `kotlin-android` is applied exactly as before — same plugin, same position in the script, same `kotlin_version` resolution and `kotlin-stdlib` dependency.

`com.android.Version` is safe to read here: this file already uses `com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION` a few lines below to gate `namespace` / `buildFeatures.buildConfig` behind AGP 7+, and the call happens after `apply plugin: 'com.android.library'`, so the AGP classes are on the classpath.

## 📢 Changelog

### Android

- Do not apply the standalone `kotlin-android` plugin when AGP 9's built-in Kotlin support is enabled, which unblocks building this library with AGP 9.

## 🤔 How Has This Been Tested?

- Verified the modified `android/build.gradle` still parses as Groovy.
- Verified the guard's evaluation directly, by running the same Groovy in a Gradle build script with the AGP version string supplied as a parameter, across `7.2.2` / `8.13.0` / `9.0.0` / `9.0.0-alpha01` / `10.1.2` and with `android.builtInKotlin` unset / `true` / `false`. Results match the truth table below; qualifier versions such as `9.0.0-alpha01` parse correctly because only the first `.`-separated token is read.
- The `hasBuiltInKotlinSupport()` truth table:

  | AGP | `android.builtInKotlin` | `kotlin-android` applied |
  | --- | --- | --- |
  | 8.x | unset / `true` / `false` | ✅ yes (unchanged) |
  | 9.x | unset | ❌ no (AGP provides Kotlin) |
  | 9.x | `true` | ❌ no (AGP provides Kotlin) |
  | 9.x | `false` | ✅ yes (consumer opted out) |

- I did not run the full `android/` Gradle build against AGP 9 in CI here — the repository's Android jobs currently build against the pinned `REACT_NATIVE_VERSION` / AGP of the example app, so this path is not exercised by CI. Happy to add an AGP 9 build matrix entry if you'd like it in the same PR.

## 📸 Screenshots (if appropriate):

Not applicable — build script only.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
