### PR TITLE
fix: animated `extraContentPadding` scrolls only a fraction of the requested distance

### DIFF
--- a/src/components/KeyboardChatScrollView/useExtraContentPadding/__tests__/animatedRamp.spec.ts
+++ b/src/components/KeyboardChatScrollView/useExtraContentPadding/__tests__/animatedRamp.spec.ts
@@ -1,0 +1,149 @@
+import { sv } from "../../../../__fixtures__/sv";
+import { createRender, reactionEffect } from "../__fixtures__/setup";
+
+// A `withTiming` driven `extraContentPadding` produces many reaction frames
+// before a single native scroll event lands. Every frame must build on the
+// offset the previous frame commanded, otherwise only the last frame's delta
+// survives and the list scrolls a fraction of the requested distance.
+// see https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1540
+const RAMP = [
+  [4, 0],
+  [9, 4],
+  [14, 9],
+  [19, 14],
+  [22, 19],
+] as const;
+
+describe("useExtraContentPadding — animated (multi-frame) padding ramp", () => {
+  it("should accumulate every frame of the ramp (inverted)", () => {
+    const render = createRender();
+    const contentOffsetY = sv(0);
+
+    render({
+      extraContentPadding: sv(22),
+      keyboardPadding: sv(300),
+      scroll: sv(0),
+      layout: sv({ width: 390, height: 800 }),
+      size: sv({ width: 390, height: 2000 }),
+      contentOffsetY,
+      inverted: true,
+      keyboardLiftBehavior: "always",
+      freeze: false,
+    });
+
+    // no scroll event lands in between — `scroll` stays at 0 for all 5 frames
+    RAMP.forEach(([current, previous]) => reactionEffect(current, previous));
+
+    expect(contentOffsetY.value).toBe(-22);
+  });
+
+  it("should accumulate every frame of the ramp (non-inverted)", () => {
+    const render = createRender();
+    const contentOffsetY = sv(0);
+
+    render({
+      extraContentPadding: sv(22),
+      keyboardPadding: sv(300),
+      scroll: sv(0),
+      layout: sv({ width: 390, height: 800 }),
+      size: sv({ width: 390, height: 2000 }),
+      contentOffsetY,
+      inverted: false,
+      keyboardLiftBehavior: "always",
+      freeze: false,
+    });
+
+    RAMP.forEach(([current, previous]) => reactionEffect(current, previous));
+
+    expect(contentOffsetY.value).toBe(22);
+  });
+
+  it("should unwind symmetrically when the ramp animates back to 0 (inverted)", () => {
+    const render = createRender();
+    const contentOffsetY = sv(0);
+
+    render({
+      extraContentPadding: sv(0),
+      keyboardPadding: sv(300),
+      scroll: sv(0),
+      layout: sv({ width: 390, height: 800 }),
+      size: sv({ width: 390, height: 2000 }),
+      contentOffsetY,
+      inverted: true,
+      keyboardLiftBehavior: "always",
+      freeze: false,
+    });
+
+    RAMP.forEach(([current, previous]) => reactionEffect(current, previous));
+    expect(contentOffsetY.value).toBe(-22);
+
+    // …and back down to 0 — the shrink ramp must undo exactly what grew
+    [...RAMP]
+      .reverse()
+      .forEach(([current, previous]) => reactionEffect(previous, current));
+
+    expect(contentOffsetY.value).toBe(0);
+  });
+
+  it("should rebase on the observed offset when a real scroll event lands", () => {
+    const render = createRender();
+    const contentOffsetY = sv(0);
+    const scroll = sv(0);
+
+    render({
+      extraContentPadding: sv(20),
+      keyboardPadding: sv(300),
+      scroll,
+      layout: sv({ width: 390, height: 800 }),
+      size: sv({ width: 390, height: 2000 }),
+      contentOffsetY,
+      inverted: true,
+      keyboardLiftBehavior: "always",
+      freeze: false,
+    });
+
+    reactionEffect(10, 0);
+    expect(contentOffsetY.value).toBe(-10);
+
+    // the user drags the list — a native scroll event moves `scroll` somewhere
+    // unrelated to what we commanded. The next frame must honour it, exactly as
+    // it did before the compounding fix.
+    scroll.value = -100;
+
+    reactionEffect(20, 10);
+    expect(contentOffsetY.value).toBe(-110);
+
+    // and the next in-flight frame compounds from the new observed base again
+    reactionEffect(30, 20);
+    expect(contentOffsetY.value).toBe(-120);
+  });
+
+  it("should rebase on the observed offset when a real scroll event lands (non-inverted)", () => {
+    const render = createRender();
+    const contentOffsetY = sv(0);
+    const scroll = sv(0);
+
+    render({
+      extraContentPadding: sv(20),
+      keyboardPadding: sv(300),
+      scroll,
+      layout: sv({ width: 390, height: 800 }),
+      size: sv({ width: 390, height: 2000 }),
+      contentOffsetY,
+      inverted: false,
+      keyboardLiftBehavior: "always",
+      freeze: false,
+    });
+
+    reactionEffect(10, 0);
+    expect(contentOffsetY.value).toBe(10);
+
+    scroll.value = 500;
+
+    reactionEffect(20, 10);
+    expect(contentOffsetY.value).toBe(510);
+
+    reactionEffect(30, 20);
+    expect(contentOffsetY.value).toBe(520);
+  });
+});

--- a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
+++ b/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 import { Platform } from "react-native";
-import { scrollTo, useAnimatedReaction } from "react-native-reanimated";
+import {
+  scrollTo,
+  useAnimatedReaction,
+  useSharedValue,
+} from "react-native-reanimated";
 
 import { IS_FABRIC } from "../../../architecture";
 import { isScrollAtEnd, shouldShiftContent } from "../useChatKeyboard/helpers";
@@ -60,12 +64,28 @@ function useExtraContentPadding(options: UseExtraContentPaddingOptions): void {
     freeze,
   } = options;
 
+  // The offset we last asked the scroll view to move to, and the observed
+  // `scroll` value it was derived from. `scroll` is fed by native scroll
+  // events, but our own writes are programmatic (`contentOffsetY` through
+  // animatedProps on Fabric, a deferred `scrollTo` on Android), so a fast
+  // animation (e.g. `withTiming` on `extraContentPadding`) can run several
+  // reaction frames before a single scroll event lands. While that is the case
+  // `scroll` still reports the pre-animation offset and rebasing on it makes
+  // every frame throw away the previous frames' shifts.
+  const lastCommanded = useSharedValue<number | null>(null);
+  const lastObservedScroll = useSharedValue(0);
+
   const scrollToTarget = useCallback(
     (target: number) => {
       "worklet";
 
+      // Remember the command and the observed offset it was based on, so the
+      // next frame can tell whether a scroll event has landed since.
+      // eslint-disable-next-line react-compiler/react-compiler
+      lastCommanded.value = target;
+      lastObservedScroll.value = scroll.value;
+
       if (contentOffsetY && IS_FABRIC) {
-        // eslint-disable-next-line react-compiler/react-compiler
         contentOffsetY.value = target;
       } else if (OS === "android") {
         // Defer scrollTo so the animatedProps inset commit lands first;
@@ -82,7 +102,7 @@ function useExtraContentPadding(options: UseExtraContentPaddingOptions): void {
         scrollTo(scrollViewRef, 0, target, false);
       }
     },
-    [scrollViewRef, contentOffsetY],
+    [scrollViewRef, contentOffsetY, scroll, lastCommanded, lastObservedScroll],
   );
 
   useAnimatedReaction(
@@ -134,19 +154,30 @@ function useExtraContentPadding(options: UseExtraContentPaddingOptions): void {
         return;
       }
 
-      if (inverted) {
-        const target = Math.max(scroll.value - effectiveDelta, -currentTotal);
+      // Build on the offset we last commanded as long as no scroll event has
+      // landed since — that write is still in flight. As soon as `scroll`
+      // moves (a real user drag, or the native view reporting our own write
+      // back) we rebase on it, so an actual gesture always wins.
+      const base =
+        lastCommanded.value !== null &&
+        scroll.value === lastObservedScroll.value
+          ? lastCommanded.value
+          : scroll.value;
 
-        scrollToTarget(target);
+      let target: number;
+
+      if (inverted) {
+        target = Math.max(base - effectiveDelta, -currentTotal);
       } else {
         const maxScroll = Math.max(
           size.value.height - layout.value.height + currentTotal,
           0,
         );
-        const target = Math.min(scroll.value + effectiveDelta, maxScroll);
 
-        scrollToTarget(target);
+        target = Math.min(base + effectiveDelta, maxScroll);
       }
+
+      scrollToTarget(target);
     },
     [inverted, keyboardLiftBehavior],
   );


### PR DESCRIPTION
## 📜 Description

`useExtraContentPadding` recomputed the scroll target from `scroll.value` on **every** reaction frame:

https://github.com/kirillzyusko/react-native-keyboard-controller/blob/53ee845/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts#L137-L149

`scroll` is the *observed* offset, fed by native scroll events (`src/components/hooks/useScrollState.ts#L40-L47`). But the write this hook must build on is *programmatic* — `contentOffsetY.value = target` piped through animatedProps on Fabric, or a `requestAnimationFrame`-deferred `scrollTo` on Android.

When the reaction fires faster than scroll events land — exactly what a `withTiming`-driven `extraContentPadding` does — each frame rebases on a position that does not yet include the previous frames' shifts. Every frame therefore throws away its predecessors and **only the last frame's delta survives**.

This PR tracks the offset we last commanded together with the observed `scroll` it was derived from, and builds on the commanded value **only while `scroll` is unchanged**. As soon as a scroll event lands — a real user drag, or the native view reporting our own write back — the guard fails and we rebase on the observed offset exactly as before, so a gesture always wins.

## 💡 Motivation and Context

Fixes #1540.

Animating `extraContentPadding` with `withTiming` scrolls the list by a fraction of the requested distance. A second reporter in the same issue describes it as *"always scrolls exactly half as much as it should"* — the fraction is `lastFrameDelta / totalDelta`, which for a symmetric easing curve lands near half.

The bug is invisible when `extraContentPadding` is set as a single step (one reaction frame), which is why the existing suites did not catch it: every one of them drives the reaction exactly once.

<sub>Unrelated, noting it rather than changing it here: `totalPadding` in `KeyboardChatScrollView/index.tsx#L108-L113` clamps the inset to `layout.value.height`, while `useExtraContentPadding` computes `currentTotal` without that clamp — so the clamp used for the scroll target and the one used for the actual inset can disagree for very large padding values. Happy to open a separate issue/PR if you'd like it addressed.</sub>

## 📢 Changelog

### JS

- `useExtraContentPadding`: accumulate the scroll target across reaction frames instead of recomputing it from the (stale) observed scroll offset every frame.
- `useExtraContentPadding`: rebase on the observed offset as soon as a native scroll event lands, so user scrolling is unaffected.

## 🤔 How Has This Been Tested?

New unit test: `src/components/KeyboardChatScrollView/useExtraContentPadding/__tests__/animatedRamp.spec.ts`, built on the existing `__fixtures__/setup.ts` harness. It drives `reactionEffect` five times with a ramp (`0 → 4 → 9 → 14 → 19 → 22`) and **without** moving `scroll` — i.e. an animation running ahead of the scroll events.

**Before the fix** (`git checkout -- useExtraContentPadding/index.ts`, test kept):

```
FAIL src/components/KeyboardChatScrollView/useExtraContentPadding/__tests__/animatedRamp.spec.ts
  useExtraContentPadding — animated (multi-frame) padding ramp
    ✕ should accumulate every frame of the ramp (inverted)
    ✕ should accumulate every frame of the ramp (non-inverted)
    ✕ should unwind symmetrically when the ramp animates back to 0 (inverted)
    ✕ should rebase on the observed offset when a real scroll event lands
    ✕ should rebase on the observed offset when a real scroll event lands (non-inverted)

  ● should accumulate every frame of the ramp (inverted)

    expect(received).toBe(expected) // Object.is equality

    Expected: -22
    Received: -3

Tests: 5 failed, 5 total
```

`-3` is the last frame's delta (`22 - 19`) — the previous 19px of movement are lost. Expected is the full `-22`.

**After the fix:**

```
PASS src/components/KeyboardChatScrollView/useExtraContentPadding/__tests__/animatedRamp.spec.ts
  useExtraContentPadding — animated (multi-frame) padding ramp
    ✓ should accumulate every frame of the ramp (inverted)
    ✓ should accumulate every frame of the ramp (non-inverted)
    ✓ should unwind symmetrically when the ramp animates back to 0 (inverted)
    ✓ should rebase on the observed offset when a real scroll event lands
    ✓ should rebase on the observed offset when a real scroll event lands (non-inverted)

Tests: 5 passed, 5 total
```

Two of the five tests exist specifically to pin the *no-regression* half: they move `scroll` between frames and assert the target is computed from the observed offset, unchanged from `main`. Dropping the `scroll.value === lastObservedScroll.value` guard (i.e. always rebasing on the last command) makes exactly those two fail while the ramp tests still pass, so they are not vacuous.

Full suite, on this branch:

```
$ yarn typescript   # clean
$ yarn lint         # clean
$ npx jest src
Test Suites: 28 passed, 28 total
Tests:       219 passed, 219 total
```

`main` is `27 suites / 214 tests`; the delta is this PR's 1 suite / 5 tests. No existing test changed — they all drive `reactionEffect` once, so `lastCommanded` is `null` on their only frame and they take the `scroll.value` path exactly as before.

## 📸 Screenshots (if appropriate):

Not provided — the failure is a numeric scroll-offset discrepancy, and the Jest reproduction above pins it deterministically rather than relying on a recording. Happy to record a device video from `FabricExample` if that would help.

## 📝 Checklist

- [x] CI successfully passed <sub>(pending — `yarn typescript`, `yarn lint` and `npx jest src` are green locally)</sub>
- [x] I added new mocks and corresponding unit-tests if library API was changed
