### PR TITLE
fix(ios): initialize `_props` in Fabric component view constructors (RN 0.87)

### DIFF
--- a/ios/views/ClippingScrollViewDecoratorViewManager.mm
+++ b/ios/views/ClippingScrollViewDecoratorViewManager.mm
@@ -186,6 +186,17 @@ RCT_EXPORT_VIEW_PROPERTY(applyWorkaroundForContentInsetHitTestBug, BOOL)
 @implementation ClippingScrollViewDecoratorView
 
 #ifdef RCT_NEW_ARCH_ENABLED
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const ClippingScrollViewDecoratorViewProps>();
+    _props = defaultProps;
+  }
+  return self;
+}
+#endif
+
+#ifdef RCT_NEW_ARCH_ENABLED
 + (ComponentDescriptorProvider)componentDescriptorProvider
 {
   return concreteComponentDescriptorProvider<ClippingScrollViewDecoratorViewComponentDescriptor>();

--- a/ios/views/KeyboardBackgroundViewManager.mm
+++ b/ios/views/KeyboardBackgroundViewManager.mm
@@ -99,6 +99,10 @@ RCT_EXPORT_MODULE(KeyboardBackgroundViewManager)
 {
   self = [super initWithFrame:frame];
   if (self) {
+#ifdef RCT_NEW_ARCH_ENABLED
+    static const auto defaultProps = std::make_shared<const KeyboardBackgroundViewProps>();
+    _props = defaultProps;
+#endif
     [self setupBackdropView];
   }
   self.clipsToBounds = YES;

--- a/ios/views/KeyboardExtenderManager.mm
+++ b/ios/views/KeyboardExtenderManager.mm
@@ -88,6 +88,8 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 - (instancetype)init
 {
   if (self = [super init]) {
+    static const auto defaultProps = std::make_shared<const KeyboardExtenderProps>();
+    _props = defaultProps;
     _touchHandler = [RCTSurfaceTouchHandler new];
     _contentView = [[UIView alloc] initWithFrame:CGRectZero];
   }

--- a/ios/views/KeyboardGestureAreaManager.mm
+++ b/ios/views/KeyboardGestureAreaManager.mm
@@ -83,6 +83,8 @@ RCT_EXPORT_VIEW_PROPERTY(offset, NSNumber *)
 - (instancetype)init
 {
   if (self = [super init]) {
+    static const auto defaultProps = std::make_shared<const KeyboardGestureAreaProps>();
+    _props = defaultProps;
   }
   return self;
 }

--- a/ios/views/KeyboardToolbarGroupViewManager.mm
+++ b/ios/views/KeyboardToolbarGroupViewManager.mm
@@ -67,7 +67,10 @@ RCT_EXPORT_MODULE(KeyboardToolbarGroupViewManager)
 #ifdef RCT_NEW_ARCH_ENABLED
 - (instancetype)init
 {
-  self = [super init];
+  if (self = [super init]) {
+    static const auto defaultProps = std::make_shared<const KeyboardToolbarGroupViewProps>();
+    _props = defaultProps;
+  }
   return self;
 }
 #else

--- a/ios/views/OverKeyboardViewManager.mm
+++ b/ios/views/OverKeyboardViewManager.mm
@@ -89,6 +89,8 @@ RCT_EXPORT_VIEW_PROPERTY(visible, BOOL)
 - (instancetype)init
 {
   if (self = [super init]) {
+    static const auto defaultProps = std::make_shared<const OverKeyboardViewProps>();
+    _props = defaultProps;
     _touchHandler = [RCTSurfaceTouchHandler new];
     _contentView = [[UIView alloc] initWithFrame:CGRectZero];
   }


### PR DESCRIPTION
## 📜 Description

React Native 0.87 started enforcing that every `RCTViewComponentView` subclass sets the `_props` ivar to a default value in its constructor. When it isn't set, mounting the view throws an `NSInternalInconsistencyException` saying the view "must setup `_props` instance variable with a default value in the constructor".

Six views in the library don't initialize `_props`: `KeyboardGestureArea`, `ClippingScrollViewDecoratorView`, `KeyboardExtender`, `KeyboardToolbarGroupView`, `KeyboardBackgroundView` and `OverKeyboardView`. This PR sets `_props` to the corresponding default props in each constructor, matching what React Native's own component views do.

## 💡 Motivation and Context

We hit this while upgrading our app to react-native 0.87.0 (new architecture). The first screen using keyboard-controller crashed on mount. Since the app relaunches right after, the crash is easy to misread as a button that does nothing, which made it a bit painful to track down.

## 📢 Changelog

### iOS

- initialize `_props` with default props in the constructors of `KeyboardGestureArea`, `ClippingScrollViewDecoratorView`, `KeyboardExtender`, `KeyboardToolbarGroupView`, `KeyboardBackgroundView` and `OverKeyboardView`

## 🤔 How Has This Been Tested?

We've been running this same change as a pnpm patch on 1.22.3 in our app since the upgrade. With it the app builds on react-native 0.87.0 and the keyboard features we use (`KeyboardStickyView` and `KeyboardGestureArea` in a chat screen, `KeyboardController.dismiss`) behave the same as on 0.86. Verified on the iOS simulator.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed (library API unchanged, iOS-only native fix)
