### PR TITLE
fix: handle interactive dismissal during keyboard opening

### DIFF
--- a/ios/observers/movement/observer/KeyboardMovementObserver+Interactive.swift
+++ b/ios/observers/movement/observer/KeyboardMovementObserver+Interactive.swift
@@ -25,10 +25,6 @@ extension KeyboardMovementObserver {
     if UIResponder.isKeyboardPreloading {
       return
     }
-    // if we are currently animating keyboard -> we need to ignore values from KVO
-    if !displayLink.isPaused {
-      return
-    }
 
     if KeyboardEventsIgnorer.shared.shouldIgnore {
       return
@@ -45,6 +41,15 @@ extension KeyboardMovementObserver {
       // we don't need to trigger `onInteractive` handler for that
       // since it will be handled in `keyboardWillDisappear` function
       return
+    }
+
+    if !displayLink.isPaused {
+      // UIKit switched from the opening animation to interactive movement.
+      // Stop the display-link stream before emitting the observed position so
+      // only one tracker remains authoritative.
+      removeKeyboardWatcher()
+      onCancelAnimation()
+      animation = nil
     }
 
     prevKeyboardPosition = position

--- a/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
+++ b/ios/observers/movement/observer/KeyboardMovementObserver+Listeners.swift
@@ -28,6 +28,9 @@ extension KeyboardMovementObserver {
       onNotify("KeyboardController::keyboardWillShow", buildEventParams(self.keyboardHeight, duration, tag))
 
       setupKeyboardWatcher()
+      // Observe interactive movement while the opening animation is active so
+      // a user-driven interruption can hand off from display-link tracking.
+      setupKVObserver()
       initializeAnimation(fromValue: prevKeyboardPosition, toValue: self.keyboardHeight)
       scheduleDidEvent(height: self.keyboardHeight, duration: animation?.duration ?? CGFloat(duration) / 1000)
     }


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

 iOS uses two paths to track keyboard movement:

  - a `CADisplayLink` watcher samples normal keyboard show and hide animations;
  - KVO observes finger-controlled interactive movement.

  The KVO observer previously became active only after the keyboard finished opening.
  Its callback also discarded interactive positions whenever the display-link watcher
  was active.

  When a user started dismissing the keyboard before its opening animation finished,
  UIKit moved the keyboard interactively, but the library emitted no corresponding
  `onKeyboardMoveInteractive` events. Keyboard-attached content remained at its
  previous position and then jumped when a later lifecycle event arrived.

  This PR installs the KVO observer while the keyboard is opening. When the first valid
  interactive position arrives during an active display-link animation, the observer:

  1. stops the display-link watcher;
  2. cancels the active non-interactive animation;
  3. clears its animation state;
  4. emits the interactive position through the existing KVO path.

  This keeps one movement source authoritative during the transition from UIKit's
  automatic opening animation to finger-controlled dismissal.



## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
fixes issue #1563 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->


### iOS

  - Observe interactive keyboard movement while the opening animation is still active.
  - Hand keyboard tracking from the display-link watcher to KVO when the user
  interrupts the opening animation with an interactive gesture.
  - Prevent the normal and interactive tracking paths from emitting competing keyboard
  positions.

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
  Tested with the Fabric example app on a physical iPhone using the new architecture
  and Hermes.
  
 Verified the following flows:

  - normal keyboard opening without interaction;
  - interactive dismissal after waiting for the keyboard to finish opening;
  - immediate interactive dismissal while the keyboard is still opening;

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

https://github.com/user-attachments/assets/a20bb1d9-07c9-4039-b071-d778480eaa88



## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
