### PR TITLE
fix(KeyboardChatScrollView): keep contentOffset in the initial animatedProps evaluation (Reanimated 4.6 scroll jump)

### DIFF
--- a/src/components/ScrollViewWithBottomPadding/index.tsx
+++ b/src/components/ScrollViewWithBottomPadding/index.tsx
@@ -16,6 +16,7 @@ import type { ScrollViewProps } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 
 const OS = Platform.OS;
+const ZERO_CONTENT_OFFSET = { x: 0, y: 0 };
 const ReanimatedClippingScrollView =
   OS === "android"
     ? Reanimated.createAnimatedComponent(ClippingScrollView)
@@ -75,6 +76,8 @@ const ScrollViewWithBottomPadding = forwardRef<
     ref,
   ) => {
     const prevContentOffsetY = useSharedValue<number | null>(null);
+    // Mirrored on the initial evaluation instead of omitting the key (see below).
+    const initialContentOffset = rest.contentOffset ?? ZERO_CONTENT_OFFSET;
 
     const insets = useDerivedValue(() => {
       const dynamicTop = inverted ? bottomPadding.value : 0;
@@ -149,12 +152,20 @@ const ScrollViewWithBottomPadding = forwardRef<
         const curr = contentOffsetY.value;
 
         if (prevContentOffsetY.value === null) {
-          // Swallow the initial evaluation: emitting `contentOffset {x:0,y:0}`
-          // in the first animatedProps run overrides the wrapped ScrollView's
-          // own `contentOffset` prop on Fabric (e.g. a list's initial scroll
-          // offset), making the list mount scrolled to the top natively.
+          // Initial evaluation. The key has to be present here: Reanimated's
+          // settled-props sync (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS, on
+          // by default in 4.x) partitions the settled bag by the keys of this
+          // first run. A key missing from it is filed as style, so the settled
+          // `contentOffset` never reaches the React props, the registry entry
+          // is dropped, and the next React commit (a keystroke in a chat
+          // composer, for instance) resets the native offset to 0 while
+          // `contentInset` stays. Emitting `{x:0,y:0}` blindly would override
+          // the wrapped ScrollView's own `contentOffset` prop on Fabric (a
+          // list's initial scroll offset), so mirror that prop: React already
+          // committed the same value, so natively this is a no-op.
           // eslint-disable-next-line react-compiler/react-compiler
           prevContentOffsetY.value = curr;
+          result.contentOffset = initialContentOffset;
         } else if (curr !== prevContentOffsetY.value) {
           prevContentOffsetY.value = curr;
           result.contentOffset = { x: 0, y: curr };


### PR DESCRIPTION
## 📃 Description

On iOS with Reanimated 4.6.0, a `KeyboardChatScrollView` loses its scroll position a couple of seconds after the keyboard opens. `contentOffset.y` snaps to `0` while `contentInset.top` stays at the keyboard height, so the newest messages end up behind the keyboard. My setup is an inverted `FlatList` passing `KeyboardChatScrollView` as `renderScrollComponent`, with a controlled `TextInput` in the composer.

![scroll jump](https://github.com/eduardoborges/rnkc-scroll-jump-repro/blob/main/docs/jump.gif?raw=true)

Standalone repro: https://github.com/eduardoborges/rnkc-scroll-jump-repro (RN 0.87, Reanimated 4.6.0, worklets 0.12.1, keyboard-controller 1.22.4). Open the keyboard, wait about 2 seconds, then type one character. The metrics bar goes from `y=-313 inset.top=403` to `y=0 inset.top=403`, and the "newest message" bubble disappears behind the keyboard.

### What I think is happening

Two changes that are each reasonable on their own:

1. #1496 stopped emitting `contentOffset` on the first evaluation of the `useAnimatedProps` in `ScrollViewWithBottomPadding`, so a wrapped list's own initial `contentOffset` isn't overridden. As a side effect, `contentOffset` is no longer part of the mapper's initial key set.
2. Reanimated 4.6.0 (software-mansion/react-native-reanimated#10140, fixing #10134) changed how `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` syncs values back to React. When an update settles, the settled bag is partitioned by the keys of the mapper's initial evaluation (`animatedPropsKeys` in `AnimatedComponent._syncStylePropsBackToReact`). Keys in that set become React props. Everything else is treated as style.

After the keyboard shift settles, `contentInset` comes back as a prop, but `contentOffset` is missing from the initial key set, so it gets filed as style and dropped, and the registry entry for the view is released. A later React commit that touches the ScrollView then applies `contentOffset {0,0}`. In my case that commit is the composer's `setState` on a keystroke, which is why typing is what makes it jump.

Reanimated before 4.6.0 doesn't partition at all (it spread the whole bag, which is what #10134 was about), so the example app on Reanimated 3.19.2 never hits this.

I'm confident about (1) and (2). The last step, the commit that reapplies `{0,0}`, I got from measuring on device rather than from reading the source, so treat that part as observed instead of proven.

### Fix

Keep `contentOffset` in the first evaluation, but emit the wrapped ScrollView's own `contentOffset` prop (`rest.contentOffset ?? {x:0,y:0}`) instead of a blind `{0,0}`. React already committed that value, so nothing moves natively and the #1496 case still works. The only difference is that `contentOffset` now belongs to the mapper's initial key set, so Reanimated classifies the settled offset as a prop.

One trade-off: with the key in the initial evaluation, Reanimated's `PropsFilter` applies the initial `contentOffset` over an inline `contentOffset` prop on every render until the first settled sync. Someone who changes the `contentOffset` prop after mount would see that change overridden. `KeyboardChatScrollView` already owns `contentOffset` on iOS, so I doubt anyone does that, but it is a behavior change.

## 🧐 What to verify

- Chat example, once it runs Reanimated 4.6: open the keyboard, wait a couple of seconds, type. The list should stay where it is.
- Keyboard open and close shifts, `extraContentPadding` changes, and interactive dismiss should behave as before, since the initial emission is a value React already committed.
- The #1496 case: a wrapped ScrollView with a non-zero `contentOffset` prop should still mount at that offset on Fabric.

Measured on an iPhone 15 Pro Max (RN 0.87, Reanimated 4.6.0, worklets 0.12.1). Before the change, the newest bubble drops from y≈433 to y≈826, which puts it under the keyboard. After it, the bubble stays at y≈433.
