### PR TITLE
fix: cancel deferred worklet registration after cleanup

### DIFF
--- a/src/__tests__/internal.spec.ts
+++ b/src/__tests__/internal.spec.ts
@@ -49,6 +49,11 @@ beforeEach(() => {
   );
 });
 
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.useRealTimers();
+});
+
 describe("useEventHandlerRegistration", () => {
   it("should support the handler shape from Reanimated 3.8 and newer", () => {
     const viewTagRef = { current: VIEW };
@@ -121,6 +126,63 @@ describe("useEventHandlerRegistration", () => {
     expect(workletEventHandler.registerForEvents).toHaveBeenCalledWith(
       VIEW_TAG,
     );
+  });
+
+  it("should retry attaching handlers when the view tag becomes available", () => {
+    jest.useFakeTimers();
+    mockedFindNodeHandle
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(VIEW_TAG);
+    const viewTagRef = { current: VIEW };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+
+    register({ workletEventHandler } as unknown as EventHandler);
+
+    expect(workletEventHandler.registerForEvents).not.toHaveBeenCalled();
+
+    jest.runAllTimers();
+
+    expect(workletEventHandler.registerForEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
+  });
+
+  it("should cancel a pending attachment during cleanup", () => {
+    jest.useFakeTimers();
+    mockedFindNodeHandle.mockReturnValueOnce(null);
+    const cancelAnimationFrame = jest.spyOn(global, "cancelAnimationFrame");
+    const viewTagRef = { current: VIEW };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+
+    const cleanup = register({
+      workletEventHandler,
+    } as unknown as EventHandler);
+
+    cleanup();
+
+    expect(cancelAnimationFrame).toHaveBeenCalledTimes(1);
+
+    jest.runOnlyPendingTimers();
+
+    expect(workletEventHandler.registerForEvents).not.toHaveBeenCalled();
+  });
+
+  it("should ignore a deferred attachment after cleanup", async () => {
+    const viewTagRef = { current: null as number | null };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+    const cleanup = register({
+      workletEventHandler,
+    } as unknown as EventHandler);
+
+    cleanup();
+    viewTagRef.current = VIEW;
+    await Promise.resolve();
+
+    expect(workletEventHandler.registerForEvents).not.toHaveBeenCalled();
   });
 
   it("should remove handlers after the view ref is cleared", () => {

--- a/src/__tests__/internal.spec.ts
+++ b/src/__tests__/internal.spec.ts
@@ -44,6 +44,7 @@ function renderRegistration(viewTagRef: React.MutableRefObject<number | null>) {
 }
 
 beforeEach(() => {
+  mockedFindNodeHandle.mockReset();
   mockedFindNodeHandle.mockImplementation((view) =>
     view === null ? null : VIEW_TAG,
   );
@@ -128,48 +129,6 @@ describe("useEventHandlerRegistration", () => {
     );
   });
 
-  it("should retry attaching handlers when the view tag becomes available", () => {
-    jest.useFakeTimers();
-    mockedFindNodeHandle
-      .mockReturnValueOnce(null)
-      .mockReturnValueOnce(null)
-      .mockReturnValueOnce(VIEW_TAG);
-    const viewTagRef = { current: VIEW };
-    const workletEventHandler = createWorkletHandler();
-    const register = renderRegistration(viewTagRef);
-
-    register({ workletEventHandler } as unknown as EventHandler);
-
-    expect(workletEventHandler.registerForEvents).not.toHaveBeenCalled();
-
-    jest.runAllTimers();
-
-    expect(workletEventHandler.registerForEvents).toHaveBeenCalledWith(
-      VIEW_TAG,
-    );
-  });
-
-  it("should cancel a pending attachment during cleanup", () => {
-    jest.useFakeTimers();
-    mockedFindNodeHandle.mockReturnValueOnce(null);
-    const cancelAnimationFrame = jest.spyOn(global, "cancelAnimationFrame");
-    const viewTagRef = { current: VIEW };
-    const workletEventHandler = createWorkletHandler();
-    const register = renderRegistration(viewTagRef);
-
-    const cleanup = register({
-      workletEventHandler,
-    } as unknown as EventHandler);
-
-    cleanup();
-
-    expect(cancelAnimationFrame).toHaveBeenCalledTimes(1);
-
-    jest.runOnlyPendingTimers();
-
-    expect(workletEventHandler.registerForEvents).not.toHaveBeenCalled();
-  });
-
   it("should ignore a deferred attachment after cleanup", async () => {
     const viewTagRef = { current: null as number | null };
     const workletEventHandler = createWorkletHandler();
@@ -183,6 +142,51 @@ describe("useEventHandlerRegistration", () => {
     await Promise.resolve();
 
     expect(workletEventHandler.registerForEvents).not.toHaveBeenCalled();
+  });
+
+  it("should not resolve a tag or warn after provider teardown", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const viewTagRef = { current: null };
+    const workletEventHandler = createWorkletHandler();
+    const register = renderRegistration(viewTagRef);
+    const cleanup = register({
+      workletEventHandler,
+    } as unknown as EventHandler);
+
+    cleanup();
+    await Promise.resolve();
+
+    expect(mockedFindNodeHandle).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(workletEventHandler.registerForEvents).not.toHaveBeenCalled();
+    expect(workletEventHandler.unregisterFromEvents).not.toHaveBeenCalled();
+  });
+
+  it("should keep a later registration active after an earlier one is cancelled", async () => {
+    const viewTagRef = { current: null as number | null };
+    const workletEventHandler = createWorkletHandler();
+    const handler = { workletEventHandler } as unknown as EventHandler;
+    const register = renderRegistration(viewTagRef);
+    const cancelFirstRegistration = register(handler);
+
+    cancelFirstRegistration();
+
+    const cleanup = register(handler);
+
+    viewTagRef.current = VIEW;
+    await Promise.resolve();
+
+    expect(workletEventHandler.registerForEvents).toHaveBeenCalledTimes(1);
+    expect(workletEventHandler.registerForEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
+
+    cleanup();
+
+    expect(workletEventHandler.unregisterFromEvents).toHaveBeenCalledTimes(1);
+    expect(workletEventHandler.unregisterFromEvents).toHaveBeenCalledWith(
+      VIEW_TAG,
+    );
   });
 
   it("should remove handlers after the view ref is cleared", () => {

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -7,6 +7,8 @@ import type { EventHandlerProcessed } from "react-native-reanimated";
 
 type ComponentOrHandle = Parameters<typeof findNodeHandle>[0];
 
+const REGISTRATION_RETRY_COUNT = 2;
+
 type WorkletHandler = {
   registerForEvents: (viewTag: number) => void;
   unregisterFromEvents: (viewTag: number) => void;
@@ -39,8 +41,25 @@ export function useEventHandlerRegistration(
   const onRegisterHandler = (handler: EventHandlerProcessed<never, never>) => {
     const currentHandler = handler as unknown as WorkletHandlerContainer;
     let registeredViewTag: number | null = null;
-    const attachWorkletHandlers = () => {
+    let registrationFrame: number | null = null;
+    let isRegistrationCancelled = false;
+    const attachWorkletHandlers = (
+      remainingRetries = REGISTRATION_RETRY_COUNT,
+    ) => {
+      if (isRegistrationCancelled) {
+        return;
+      }
+
       const viewTag = findNodeHandle(viewTagRef.current);
+
+      if (!viewTag && remainingRetries > 0) {
+        registrationFrame = requestAnimationFrame(() => {
+          registrationFrame = null;
+          attachWorkletHandlers(remainingRetries - 1);
+        });
+
+        return;
+      }
 
       if (__DEV__ && !viewTag) {
         console.warn(
@@ -67,6 +86,12 @@ export function useEventHandlerRegistration(
     }
 
     return () => {
+      isRegistrationCancelled = true;
+
+      if (registrationFrame !== null) {
+        cancelAnimationFrame(registrationFrame);
+      }
+
       if (registeredViewTag) {
         if ("workletEventHandler" in currentHandler) {
           currentHandler.workletEventHandler.unregisterFromEvents(

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -7,8 +7,6 @@ import type { EventHandlerProcessed } from "react-native-reanimated";
 
 type ComponentOrHandle = Parameters<typeof findNodeHandle>[0];
 
-const REGISTRATION_RETRY_COUNT = 2;
-
 type WorkletHandler = {
   registerForEvents: (viewTag: number) => void;
   unregisterFromEvents: (viewTag: number) => void;
@@ -41,25 +39,13 @@ export function useEventHandlerRegistration(
   const onRegisterHandler = (handler: EventHandlerProcessed<never, never>) => {
     const currentHandler = handler as unknown as WorkletHandlerContainer;
     let registeredViewTag: number | null = null;
-    let registrationFrame: number | null = null;
     let isRegistrationCancelled = false;
-    const attachWorkletHandlers = (
-      remainingRetries = REGISTRATION_RETRY_COUNT,
-    ) => {
+    const attachWorkletHandlers = () => {
       if (isRegistrationCancelled) {
         return;
       }
 
       const viewTag = findNodeHandle(viewTagRef.current);
-
-      if (!viewTag && remainingRetries > 0) {
-        registrationFrame = requestAnimationFrame(() => {
-          registrationFrame = null;
-          attachWorkletHandlers(remainingRetries - 1);
-        });
-
-        return;
-      }
 
       if (__DEV__ && !viewTag) {
         console.warn(
@@ -87,10 +73,6 @@ export function useEventHandlerRegistration(
 
     return () => {
       isRegistrationCancelled = true;
-
-      if (registrationFrame !== null) {
-        cancelAnimationFrame(registrationFrame);
-      }
 
       if (registeredViewTag) {
         if ("workletEventHandler" in currentHandler) {


### PR DESCRIPTION
## 📜 Description

Cancel deferred worklet registration after cleanup. Remove the frame retries.

## 💡 Motivation and Context

Related to #1612. A parent layout effect can remove a consumer before its queued registration runs. The handler then attaches after cleanup. Removing the provider too causes the unresolved tag warning.

The earlier late-tag explanation was not established. This fixes the reproduced cleanup race; the original app's symptoms remain unverified.

Code for reproduction:

```tsx
import React, {
  StrictMode,
  useEffect,
  useId,
  useLayoutEffect,
  useState,
} from "react";
import {
  Button,
  Keyboard,
  StyleSheet,
  Text,
  TextInput,
  View,
} from "react-native";
import {
  KeyboardAwareScrollView,
  KeyboardProvider,
  KeyboardToolbar,
  useKeyboardHandler,
} from "react-native-keyboard-controller";
import { runOnJS } from "react-native-reanimated";

type Mode = "normal" | "consumer" | "provider" | "scroll";
type Trace = {
  event: string;
  time: number;
  id?: number | string;
  hasRef?: boolean;
  tag?: number | null;
  height?: number;
  afterUnmount?: boolean;
};
const runtime = globalThis as typeof globalThis & {
  __rnkcTrace: Trace[];
  __rnkcRemount: () => void;
  __rnkcStrict: (value: boolean) => void;
  __rnkcMode: (value: Mode) => void;
  __rnkcDismiss: () => void;
};

runtime.__rnkcTrace = [];
const mounted = new Set<string>();
const styles = StyleSheet.create({
  root: { flex: 1, paddingTop: 80, paddingHorizontal: 20 },
  input: { borderWidth: 1, padding: 16, marginVertical: 8 },
});

function recordEvent(id: string, height: number) {
  runtime.__rnkcTrace.push({
    event: "keyboard",
    id,
    height,
    afterUnmount: !mounted.has(id),
    time: performance.now(),
  });
}

function Consumer() {
  const id = useId();

  useKeyboardHandler(
    {
      onEnd: (event) => {
        "worklet";
        runOnJS(recordEvent)(id, event.height);
      },
    },
    [],
  );
  useLayoutEffect(() => {
    mounted.add(id);

    return () => {
      mounted.delete(id);
    };
  }, [id]);

  return (
    <TextInput
      placeholder="Live consumer input"
      style={styles.input}
      testID="repro-input"
    />
  );
}

function Case({ mode }: { mode: Mode }) {
  const [show, setShow] = useState(true);

  useLayoutEffect(() => {
    if (mode === "consumer" || mode === "provider") {
      setShow(false);
    }
  }, [mode]);

  if (mode === "provider" && !show) {
    return <Text>Provider and consumer have unmounted</Text>;
  }

  return (
    <KeyboardProvider preload={false}>
      {show ? <Consumer /> : <Text>Consumer has unmounted</Text>}
      {mode === "scroll" ? (
        <KeyboardAwareScrollView>
          <TextInput placeholder="Scroll input" style={styles.input} />
          <KeyboardToolbar />
        </KeyboardAwareScrollView>
      ) : (
        <TextInput
          placeholder="Control input without a handler"
          style={styles.input}
          testID="control-input"
        />
      )}
    </KeyboardProvider>
  );
}
export default function RegistrationRepro() {
  const [cycle, setCycle] = useState(0);
  const [strict, setStrict] = useState(false);
  const [mode, setMode] = useState<Mode>("normal");
  const [summary, setSummary] = useState("");

  useEffect(() => {
    runtime.__rnkcRemount = () => setCycle((value) => value + 1);
    runtime.__rnkcStrict = setStrict;
    runtime.__rnkcMode = setMode;
    runtime.__rnkcDismiss = Keyboard.dismiss;
    const timer = setInterval(() => {
      const events = runtime.__rnkcTrace.filter(
        (event) => event.event === "keyboard",
      );

      setSummary(
        "Live callbacks: " +
          events.filter((event) => !event.afterUnmount).length +
          " / After unmount: " +
          events.filter((event) => event.afterUnmount).length,
      );
    }, 200);

    return () => clearInterval(timer);
  }, []);
  const provider = <Case key={mode + cycle} mode={mode} />;

  return (
    <View style={styles.root}>
      <Text>Issue 1612: native lifecycle reproduction</Text>
      <Text>
        Mode: {mode} / cycle {cycle} / strict {String(strict)}
      </Text>
      <Text testID="callback-counts">{summary}</Text>
      <Button title="Normal consumer" onPress={() => setMode("normal")} />
      <Button
        title="Unmount consumer during layout"
        onPress={() => setMode("consumer")}
      />
      <Button
        title="Unmount provider during layout"
        onPress={() => setMode("provider")}
      />
      <Button title="Remount" onPress={() => setCycle((value) => value + 1)} />
      <Button title="Dismiss keyboard" onPress={Keyboard.dismiss} />
      {strict ? <StrictMode>{provider}</StrictMode> : provider}
    </View>
  );
}
```

Closes #1612

## 📢 Changelog

### JS

- Skip cancelled registrations.

## 🤔 How Has This Been Tested?

- iOS/Fabric, RN 0.81.4: stale attachments fell from 51/51 to 0/51; revert confirmed.
- 263 tests passed across library and examples; TypeScript, lint, and iOS Debug build passed.
- RN 0.86.3, Android, Paper, and release builds untested natively.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/b0150b81-f85b-48f5-849d-37ed11d0b76b">|<video src="https://github.com/user-attachments/assets/f8f64c8a-0255-493b-809e-b00af3162534">|
|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/fbfc6786-ab47-4d67-9887-4786931c71b2" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/a8f795ad-7aef-45b9-9562-d8456b84ecc4" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
