### PR TITLE
fix: iOS compilation warning

### DIFF
--- a/ios/observers/FocusedInputObserver.swift
+++ b/ios/observers/FocusedInputObserver.swift
@@ -158,7 +158,7 @@ public class FocusedInputObserver: NSObject {
 
     FocusedInputHolder.shared.set(currentResponder as? TextInput)
 
-    let groupAncestor = ViewHierarchyNavigator.findGroupAncestor(currentResponder as? UIView)
+    let groupAncestor = ViewHierarchyNavigator.findGroupAncestor(currentResponder)
     let allInputFields = ViewHierarchyNavigator.getAllInputFields(root: groupAncestor)
     let currentIndex = allInputFields.firstIndex(where: { $0 == currentResponder }) ?? -1
 


### PR DESCRIPTION
## 📜 Description

Fixed compilation warning on iOS.

## 💡 Motivation and Context

This casting is not needed anymore. The function that returns data already returns it as `UIVIew?`.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- removed unnecessary `as? UIView` casting;

## 🤔 How Has This Been Tested?

Tested via building the app using XCode 26.5

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="292" height="95" alt="image" src="https://github.com/user-attachments/assets/55b2fcfa-dc0e-4cd3-938b-ee7ca66d53c7" />|<img width="297" height="119" alt="image" src="https://github.com/user-attachments/assets/d052549e-5ece-4dde-a985-0fb5addb6940" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
