### PR TITLE
fix: memory leak in `FocusedInputObserver` (Android)

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/listeners/FocusedInputObserver.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/listeners/FocusedInputObserver.kt
@@ -100,17 +100,7 @@ class FocusedInputObserver(
     OnGlobalFocusChangeListener { oldFocus, newFocus ->
       // unfocused or focus was changed
       if (newFocus == null || oldFocus != null) {
-        lastFocusedInput?.removeOnLayoutChangeListener(layoutListener)
-        lastFocusedInput?.let { input ->
-          val watcher = textWatcher
-          // remove it asynchronously to avoid crash in stripe input
-          // see https://github.com/stripe/stripe-android/issues/10178
-          input.post {
-            watcher?.let { input.removeTextChangedListener(it) }
-          }
-        }
-        selectionSubscription?.invoke()
-        lastFocusedInput = null
+        stopObservingFocusedInput()
       }
       if (newFocus is EditText) {
         lastFocusedInput = newFocus
@@ -163,6 +153,27 @@ class FocusedInputObserver(
 
   fun destroy() {
     view.viewTreeObserver.removeOnGlobalFocusChangeListener(focusListener)
+    stopObservingFocusedInput()
+  }
+
+  private fun stopObservingFocusedInput() {
+    val input = lastFocusedInput
+    val watcher = textWatcher
+    val unsubscribeFromSelectionChanges = selectionSubscription
+
+    lastFocusedInput = null
+    textWatcher = null
+    selectionSubscription = null
+
+    input?.removeOnLayoutChangeListener(layoutListener)
+    if (input != null && watcher != null) {
+      // remove it asynchronously to avoid crash in stripe input
+      // see https://github.com/stripe/stripe-android/issues/10178
+      input.post {
+        input.removeTextChangedListener(watcher)
+      }
+    }
+    unsubscribeFromSelectionChanges?.invoke()
   }
 
   private fun dispatchEventToJS(event: FocusedInputLayoutChangedEventData) {


### PR DESCRIPTION
## 📜 Description

Fixed memory leak described in https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1619

## 💡 Motivation and Context

On Android, `FocusedInputObserver.destroy()` previously removed only the global focus listener. If the observer was destroyed while an `EditText` was still focused, its input-specific listeners were never removed.

This can happen when a React Navigation native-stack screen is popped while its text input and keyboard are still active. Screen destruction does not always produce another global focus-change callback before the observer is destroyed.

The remaining selection subscription retained the following chain:

```text
FabricEventDispatcher.listeners
-> ModalAttachedWatcher
-> KeyboardAnimationCallback.layoutObserver
-> FocusedInputObserver.selectionSubscription
-> KeyboardControllerSelectionWatcher.editText
-> detached ReactEditText
-> destroyed native-stack views and fragments
```

Repeated navigation through this flow can therefore accumulate detached input views and native-stack screen objects.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1619

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- add `stopObservingFocusedInput` method;
- copy "unfocused or focus was changed" code into `stopObservingFocusedInput` method;
- call `stopObservingFocusedInput` from `destroy` and "unfocused or focus was changed" path;

## 🤔 How Has This Been Tested?

LeakCanary 2.14 was temporarily added to the Fabric example debug build. Tested manually on Pixel 8 Pro (API 35).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="1080" height="2220" alt="image" src="https://github.com/user-attachments/assets/794eb4ee-92f2-4b72-b5ad-f5fef06827d0" />|<img width="1080" height="2220" alt="image" src="https://github.com/user-attachments/assets/193696e8-f784-4c05-a799-974fa82b2480" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
