### PR TITLE
docs: mention missing animations in `KeyboardStickyView`/`KeyboardToolbar` and the recommended fix

### DIFF
--- a/docs/docs/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/docs/api/components/keyboard-sticky-view/index.mdx
@@ -69,3 +69,21 @@ An object containing next properties:
 
 - **closed** - additional offset to the view when keyboard is closed. Default value is `0`.
 - **opened** - additional offset to the view when keyboard is opened. Default value is `0`.
+
+## Troubleshooting
+
+### Missing animations on iOS (new arch only)
+
+Starting with version `1.21.7`, `KeyboardStickyView` uses Reanimated for its `translateY` animation. On iOS (New Architecture only), updating React state right before a keyboard event can cause this animation to be skipped entirely. This happens because a React commit can block Reanimated from applying its animated updates in the same frame.
+
+Common triggers include:
+
+- updating state in the `onFocus` callback of a `TextInput`;
+- updating state in response to the `keyboardWillShow` event;
+- using `KeyboardToolbar` or other components that trigger a state update before the keyboard appears.
+
+To fix this, enable the [DISABLE_COMMIT_PAUSING_MECHANISM](https://docs.swmansion.com/react-native-reanimated/docs/guides/feature-flags/#disable_commit_pausing_mechanism) feature flag. See the link for detailed setup instructions.
+
+:::info Do I need to enable this flag?
+This issue can occur even if the state update comes from a different screen (e.g. a parent navigator). To check, open the React Profiler and look for any React commits that happen just before the keyboard event — if you see one, you likely need this flag.
+:::

--- a/docs/docs/api/components/keyboard-toolbar/index.mdx
+++ b/docs/docs/api/components/keyboard-toolbar/index.mdx
@@ -636,3 +636,17 @@ If you found any bugs or inconsistent behavior comparing to old implementation a
 ## Limitations
 
 - The order of the navigation is defined by the view hierarchy (commonly referred to as the view-tree).
+
+## Troubleshooting
+
+### Missing animations on iOS (new arch only)
+
+Starting with version `1.21.7`, `KeyboardToolbar` uses the Reanimated-based `KeyboardStickyView` for its `translateY` animation. The toolbar also updates React state when the focused input changes. On iOS (New Architecture only), that React commit can block Reanimated from applying its animated updates in the same frame, causing the toolbar animation to be skipped entirely.
+
+The same issue can occur when your app updates state in an `onFocus` callback, in response to the `keyboardWillShow` event, or anywhere else immediately before the keyboard event.
+
+To fix this, enable the [DISABLE_COMMIT_PAUSING_MECHANISM](https://docs.swmansion.com/react-native-reanimated/docs/guides/feature-flags/#disable_commit_pausing_mechanism) feature flag. See the link for detailed setup instructions.
+
+:::info Do I need to enable this flag?
+This issue can occur even if the state update comes from a different screen (e.g. a parent navigator). To check, open the React Profiler and look for any React commits that happen just before the keyboard event — if you see one, you likely need this flag.
+:::

--- a/docs/versioned_docs/version-1.21.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.21.0/api/components/keyboard-sticky-view/index.mdx
@@ -69,3 +69,21 @@ An object containing next properties:
 
 - **closed** - additional offset to the view when keyboard is closed. Default value is `0`.
 - **opened** - additional offset to the view when keyboard is opened. Default value is `0`.
+
+## Troubleshooting
+
+### Missing animations on iOS (new arch only)
+
+Starting with version `1.21.7`, `KeyboardStickyView` uses Reanimated for its `translateY` animation. On iOS (New Architecture only), updating React state right before a keyboard event can cause this animation to be skipped entirely. This happens because a React commit can block Reanimated from applying its animated updates in the same frame.
+
+Common triggers include:
+
+- updating state in the `onFocus` callback of a `TextInput`;
+- updating state in response to the `keyboardWillShow` event;
+- using `KeyboardToolbar` or other components that trigger a state update before the keyboard appears.
+
+To fix this, enable the [DISABLE_COMMIT_PAUSING_MECHANISM](https://docs.swmansion.com/react-native-reanimated/docs/guides/feature-flags/#disable_commit_pausing_mechanism) feature flag. See the link for detailed setup instructions.
+
+:::info Do I need to enable this flag?
+This issue can occur even if the state update comes from a different screen (e.g. a parent navigator). To check, open the React Profiler and look for any React commits that happen just before the keyboard event — if you see one, you likely need this flag.
+:::

--- a/docs/versioned_docs/version-1.21.0/api/components/keyboard-toolbar/index.mdx
+++ b/docs/versioned_docs/version-1.21.0/api/components/keyboard-toolbar/index.mdx
@@ -636,3 +636,17 @@ If you found any bugs or inconsistent behavior comparing to old implementation a
 ## Limitations
 
 - The order of the navigation is defined by the view hierarchy (commonly referred to as the view-tree).
+
+## Troubleshooting
+
+### Missing animations on iOS (new arch only)
+
+Starting with version `1.21.7`, `KeyboardToolbar` uses the Reanimated-based `KeyboardStickyView` for its `translateY` animation. The toolbar also updates React state when the focused input changes. On iOS (New Architecture only), that React commit can block Reanimated from applying its animated updates in the same frame, causing the toolbar animation to be skipped entirely.
+
+The same issue can occur when your app updates state in an `onFocus` callback, in response to the `keyboardWillShow` event, or anywhere else immediately before the keyboard event.
+
+To fix this, enable the [DISABLE_COMMIT_PAUSING_MECHANISM](https://docs.swmansion.com/react-native-reanimated/docs/guides/feature-flags/#disable_commit_pausing_mechanism) feature flag. See the link for detailed setup instructions.
+
+:::info Do I need to enable this flag?
+This issue can occur even if the state update comes from a different screen (e.g. a parent navigator). To check, open the React Profiler and look for any React commits that happen just before the keyboard event — if you see one, you likely need this flag.
+:::

--- a/docs/versioned_docs/version-1.22.0/api/components/keyboard-sticky-view/index.mdx
+++ b/docs/versioned_docs/version-1.22.0/api/components/keyboard-sticky-view/index.mdx
@@ -69,3 +69,21 @@ An object containing next properties:
 
 - **closed** - additional offset to the view when keyboard is closed. Default value is `0`.
 - **opened** - additional offset to the view when keyboard is opened. Default value is `0`.
+
+## Troubleshooting
+
+### Missing animations on iOS (new arch only)
+
+Starting with version `1.21.7`, `KeyboardStickyView` uses Reanimated for its `translateY` animation. On iOS (New Architecture only), updating React state right before a keyboard event can cause this animation to be skipped entirely. This happens because a React commit can block Reanimated from applying its animated updates in the same frame.
+
+Common triggers include:
+
+- updating state in the `onFocus` callback of a `TextInput`;
+- updating state in response to the `keyboardWillShow` event;
+- using `KeyboardToolbar` or other components that trigger a state update before the keyboard appears.
+
+To fix this, enable the [DISABLE_COMMIT_PAUSING_MECHANISM](https://docs.swmansion.com/react-native-reanimated/docs/guides/feature-flags/#disable_commit_pausing_mechanism) feature flag. See the link for detailed setup instructions.
+
+:::info Do I need to enable this flag?
+This issue can occur even if the state update comes from a different screen (e.g. a parent navigator). To check, open the React Profiler and look for any React commits that happen just before the keyboard event — if you see one, you likely need this flag.
+:::

--- a/docs/versioned_docs/version-1.22.0/api/components/keyboard-toolbar/index.mdx
+++ b/docs/versioned_docs/version-1.22.0/api/components/keyboard-toolbar/index.mdx
@@ -636,3 +636,17 @@ If you found any bugs or inconsistent behavior comparing to old implementation a
 ## Limitations
 
 - The order of the navigation is defined by the view hierarchy (commonly referred to as the view-tree).
+
+## Troubleshooting
+
+### Missing animations on iOS (new arch only)
+
+Starting with version `1.21.7`, `KeyboardToolbar` uses the Reanimated-based `KeyboardStickyView` for its `translateY` animation. The toolbar also updates React state when the focused input changes. On iOS (New Architecture only), that React commit can block Reanimated from applying its animated updates in the same frame, causing the toolbar animation to be skipped entirely.
+
+The same issue can occur when your app updates state in an `onFocus` callback, in response to the `keyboardWillShow` event, or anywhere else immediately before the keyboard event.
+
+To fix this, enable the [DISABLE_COMMIT_PAUSING_MECHANISM](https://docs.swmansion.com/react-native-reanimated/docs/guides/feature-flags/#disable_commit_pausing_mechanism) feature flag. See the link for detailed setup instructions.
+
+:::info Do I need to enable this flag?
+This issue can occur even if the state update comes from a different screen (e.g. a parent navigator). To check, open the React Profiler and look for any React commits that happen just before the keyboard event — if you see one, you likely need this flag.
+:::


### PR DESCRIPTION
## 📜 Description

Recommend to enable `DISABLE_COMMIT_PAUSING_MECHANISM` feature flag in reanimated.

## 💡 Motivation and Context

`KeyboardStickyView` has been migrated to reanimated recently.

At the moment reanimated has a bug, when animation can be canceleld because react will perform another commit.

In this PR I recommend to enable specific feature flags to avoid this probelm. We recommended to turn this flag on for `KeyboardAvoidingView` and for `KeyboardChatScrollView`.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- recommend to enable `DISABLE_COMMIT_PAUSING_MECHANISM` if you are using `KeyboardStickyView`/`KeyboardToolbar` + new arch.

## 🤔 How Has This Been Tested?

Tested via deployed version.

## 📸 Screenshots (if appropriate):

<img width="1354" height="701" alt="image" src="https://github.com/user-attachments/assets/3446bc22-f9ac-4b9a-a7ec-d263f24b47ba" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
