### PR TITLE
fix: detach `KeyboardExtender` from every attached view

### DIFF
--- a/ios/observers/movement/KeyboardTrackingView.swift
+++ b/ios/observers/movement/KeyboardTrackingView.swift
@@ -80,7 +80,9 @@ public final class KeyboardTrackingView: UIView {
 
     guard let topView = topViewController?.view else { return }
 
-    if currentAttachedView === topView { return }
+    if currentAttachedView === topView {
+      return
+    }
 
     isAttaching = true
     removeFromSuperview()

--- a/ios/views/KeyboardExtenderManager.mm
+++ b/ios/views/KeyboardExtenderManager.mm
@@ -62,6 +62,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 @implementation KeyboardExtender {
   UIView *_contentView;
   UIView *_sharedInputAccessoryView;
+  NSHashTable<UIView<UITextInput> *> *_attachedInputs;
   BOOL _isObserving;
 #ifdef RCT_NEW_ARCH_ENABLED
   RCTSurfaceTouchHandler *_touchHandler;
@@ -91,17 +92,16 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
     static const auto defaultProps = std::make_shared<const KeyboardExtenderProps>();
     _props = defaultProps;
     _touchHandler = [RCTSurfaceTouchHandler new];
-    _contentView = [[UIView alloc] initWithFrame:CGRectZero];
-  }
 #else
 - (instancetype)initWithBridge:(RCTBridge *)bridge
 {
   self = [super initWithFrame:CGRectZero];
   if (self) {
     _touchHandler = [[RCTTouchHandler alloc] initWithBridge:bridge];
-    _contentView = [[UIView alloc] initWithFrame:CGRectZero];
-  }
 #endif
+    _contentView = [[UIView alloc] initWithFrame:CGRectZero];
+    _attachedInputs = [NSHashTable weakObjectsHashTable];
+  }
   [_touchHandler attachToView:_contentView];
   [self startObserving];
   return self;
@@ -198,6 +198,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
   } else if ([input isKindOfClass:[UITextView class]]) {
     ((UITextView *)input).inputAccessoryView = _sharedInputAccessoryView;
   }
+  [_attachedInputs addObject:input];
 
   // Refresh input view to apply changes
   [input reloadInputViews];
@@ -205,13 +206,9 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 
 - (void)detachInputAccessoryView
 {
-  // Remove the accessory view from the current text input
-  UIResponder *firstResponder = [UIResponder current];
-  if ([firstResponder isKindOfClass:[UITextField class]] ||
-      [firstResponder isKindOfClass:[UITextView class]]) {
-    UIView<UITextInput> *textInput = (UIView<UITextInput> *)firstResponder;
+  // Remove the accessory view from every text input this extender attached to
+  for (UIView<UITextInput> *textInput in _attachedInputs.allObjects) {
     if (textInput.inputAccessoryView == _sharedInputAccessoryView) {
-      // Assign the inputAccessoryView
       if ([textInput isKindOfClass:[UITextField class]]) {
         ((UITextField *)textInput).inputAccessoryView = nil;
       } else if ([textInput isKindOfClass:[UITextView class]]) {
@@ -220,6 +217,7 @@ RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
       [textInput reloadInputViews];
     }
   }
+  [_attachedInputs removeAllObjects];
 }
 
 // MARK: touch handling


### PR DESCRIPTION
## 📜 Description

Tracks every text input that receives the shared `KeyboardExtender` accessory view and detaches that accessory from all of them when the extender is disabled or recycled.

Inputs are held weakly, and an accessory is cleared only when it is still this extender's shared instance. This avoids retaining text inputs and avoids removing an accessory that another owner has since installed.

## 💡 Motivation and Context

Previously, `detachInputAccessoryView` inspected only `[UIResponder current]`. If input A received the accessory, then resigned while input B became first responder, disabling the extender cleared B but left A pointing to the shared container. A detach therefore did not actually detach every input previously touched by the extender.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1622

## 📢 Changelog

### iOS

- track attached text inputs in a weak `NSHashTable`.
- detach the shared accessory from every live input that still owns it;
- format code according to new swiftlint;
- unified code in constructor;

## 🤔 How Has This Been Tested?

Tested in `FabricExample` on iPhone 17 Pro simulator running iOS 26.2.

I temporarily adapted the example to match the linked reproduction exactly:

1. Focus **Input A**.
2. Focus **Input B** without dismissing the keyboard.
3. Set the extender's `enabled` prop to `false` while B remains focused.
4. Focus A again.

Native probe result with the stock implementation, immediately after step 3:

```text
Input A inputAccessoryView=<shared container>  <-- stale
Input B inputAccessoryView=nil
```

Native probe result with this fix, immediately after step 3:

```text
Input A inputAccessoryView=nil
Input B inputAccessoryView=nil
```

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/029e7df0-d962-42c7-af86-efc864fc528d

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
