### PR TITLE
fix(android): scale blankSpace absorption by its visible fraction

### DIFF
--- a/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/blankSpace.android.spec.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/__tests__/blankSpace.android.spec.ts
@@ -91,6 +91,32 @@ describe("blankSpace — Android non-inverted + always", () => {
     expect(mockScrollTo).toHaveBeenCalledWith(expect.anything(), 0, 100, false);
   });
 
+  it("partial visibility: absorbs only the visible portion of blankSpace", () => {
+    // Scrolled into the inset area, but not far enough to reveal all of it
+    // (pastContentEnd = 800+800-1500 = 100, fraction = 100/500 = 0.2)
+    mockSize.value = { width: 390, height: 1500 };
+    mockOffset.value = 800;
+    render({
+      inverted: false,
+      keyboardLiftBehavior: "always",
+      blankSpace: sv(500),
+    });
+
+    handlers.onStart({ height: KEYBOARD });
+    // visiblePadding = 0.2 * 500 = 100, minimumPaddingAbsorbed = 100
+    // scrollEff = max(0, 300 - 100) = 200
+    // actualTotalPadding = max(500, 300+0) = 500
+    // target = clampedScrollTarget(800, 200, 1500, 800, 500)
+    //        = min(max(800+200, 0), max(1500-800+500, 0)) = min(1000, 1200) = 1000
+    handlers.onMove({ height: KEYBOARD });
+    expect(mockScrollTo).toHaveBeenCalledWith(
+      expect.anything(),
+      0,
+      1000,
+      false,
+    );
+  });
+
   it("full absorption with extraContentPadding: absorbed = blankSpace - extraContentPadding", () => {
     // Small content so minimum padding fills viewport (pastContentEnd = 0+800-300 = 500, fraction = 1)
     mockSize.value = { width: 390, height: 300 };
@@ -188,6 +214,23 @@ describe("blankSpace — Android never behavior", () => {
 });
 
 describe("blankSpace — Android whenAtEnd behavior", () => {
+  it("partial visibility: full absorption when visiblePadding >= keyboard", () => {
+    // (pastContentEnd = 1000+800-1500 = 300, fraction = 300/500 = 0.6)
+    // visiblePadding = 300 >= keyboard = 300 -> full absorption -> no shift
+    mockSize.value = { width: 390, height: 1500 };
+    mockOffset.value = 1000;
+    render({
+      inverted: false,
+      keyboardLiftBehavior: "whenAtEnd",
+      blankSpace: sv(500),
+    });
+
+    handlers.onStart({ height: KEYBOARD });
+    // scrollEff = max(0, 300 - 300) = 0 -> sentinel -> no scroll
+    handlers.onMove({ height: KEYBOARD });
+    expect(mockScrollTo).not.toHaveBeenCalled();
+  });
+
   it("full absorption prevents scroll even when at end", () => {
     // Small content so minimum padding fills viewport (pastContentEnd = 0+800-300 = 500, fraction = 1)
     // Position at end: 0 + 800 >= 300 - 20

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
@@ -116,13 +116,10 @@ function useChatKeyboard(
           blankSpace.value,
           inverted,
         );
-        const minimumPaddingAbsorbed =
-          visibleFraction >= 1
-            ? getMinimumPaddingAbsorbed(
-                blankSpace.value,
-                extraContentPadding.value,
-              )
-            : 0;
+        const minimumPaddingAbsorbed = getMinimumPaddingAbsorbed(
+          visibleFraction * blankSpace.value,
+          extraContentPadding.value,
+        );
         const scrollEffective = getScrollEffective(
           effective,
           minimumPaddingAbsorbed,
@@ -135,7 +132,7 @@ function useChatKeyboard(
           return;
         } else if (e.height > 0) {
           // Android: keyboard opening — set padding + capture scroll position
-          minimumPaddingFractionOnOpen.value = visibleFraction >= 1 ? 1 : 0;
+          minimumPaddingFractionOnOpen.value = visibleFraction;
           padding.value = effective;
           offsetBeforeScroll.value = scroll.value;
 
@@ -184,11 +181,10 @@ function useChatKeyboard(
             offset,
           );
 
-          const minimumPaddingAbsorbed =
-            getMinimumPaddingAbsorbed(
-              blankSpace.value,
-              extraContentPadding.value,
-            ) * minimumPaddingFractionOnOpen.value;
+          const minimumPaddingAbsorbed = getMinimumPaddingAbsorbed(
+            blankSpace.value * minimumPaddingFractionOnOpen.value,
+            extraContentPadding.value,
+          );
           const scrollEffective = getScrollEffective(
             effective,
             minimumPaddingAbsorbed,
@@ -269,11 +265,10 @@ function useChatKeyboard(
             offset,
           );
 
-          const minimumPaddingAbsorbed =
-            getMinimumPaddingAbsorbed(
-              blankSpace.value,
-              extraContentPadding.value,
-            ) * minimumPaddingFractionOnOpen.value;
+          const minimumPaddingAbsorbed = getMinimumPaddingAbsorbed(
+            blankSpace.value * minimumPaddingFractionOnOpen.value,
+            extraContentPadding.value,
+          );
           const scrollEffective = getScrollEffective(
             effective,
             minimumPaddingAbsorbed,


### PR DESCRIPTION
## 📜 Description

On Android, `blankSpace` absorption is switched on and off by a boolean test instead of being scaled, so a partially visible `blankSpace` absorbs nothing at all.

`getVisibleMinimumPaddingFraction` returns a continuous `0..1` value, and the comment sitting above the call in both platform files says "Scale minimum padding absorption by how much of it is visible. Fully visible -> full absorption; fully off-screen -> no absorption." The iOS hook does exactly that:

```ts
// useChatKeyboard/index.ios.ts
const visiblePadding = visibleFraction * blankSpace.value;
const minimumPaddingAbsorbed = Math.max(0, visiblePadding - extraContentPadding.value);
```

The Android hook instead collapses the fraction to a boolean, in `onStart` and again through `minimumPaddingFractionOnOpen`, which `onMove` uses as a multiplier:

```ts
// useChatKeyboard/index.ts
const minimumPaddingAbsorbed =
  visibleFraction >= 1
    ? getMinimumPaddingAbsorbed(blankSpace.value, extraContentPadding.value)
    : 0;
...
minimumPaddingFractionOnOpen.value = visibleFraction >= 1 ? 1 : 0;
```

So for any `0 < visibleFraction < 1` Android absorbs `0` and shifts the content by the whole keyboard height, while iOS absorbs the visible part and shifts less (or not at all).

## 💡 Motivation and Context

Minimal reproduction, `KeyboardChatScrollView` with `blankSpace={500}`, `keyboardLiftBehavior="always"`, content height 1500, viewport 800, scrolled to 800 (so 100 of the 500 px inset is on screen, fraction `0.2`), keyboard 300:

- iOS absorbs `0.2 * 500 = 100`, scrolls by `300 - 100 = 200`, landing at `1000`.
- Android absorbs `0`, scrolls by `300`, landing at `1100`.

At fraction `0.6` with a 300 px keyboard the gap is more visible: the visible inset (300) covers the keyboard entirely, so iOS keeps the content still, and Android still jumps.

Both platforms behave identically at fraction `0` and `1`, which is why the existing tests did not catch it. Every Android `blankSpace` test is built so the fraction is exactly `1`, and the only partial-visibility cases in the suite are in `blankSpace.ios.spec.ts`.

## 📢 Changelog

### JS

- Android `useChatKeyboard` now scales `blankSpace` absorption by the visible fraction, matching the iOS implementation.

## 🤔 How Has This Been Tested?

Two tests added to `blankSpace.android.spec.ts`, mirroring the partial-visibility cases that already exist for iOS:

- `partial visibility: absorbs only the visible portion of blankSpace` asserts the exact scroll target, `scrollTo(ref, 0, 1000, false)`. Without the fix it is `1100`.
- `partial visibility: full absorption when visiblePadding >= keyboard` asserts no `scrollTo` at all. Without the fix `scrollTo(ref, 0, 1200, false)` is called.

Full JS suite before, 213 passing plus 1 pre-existing timeout flake in `keyboardSizeChange.spec.tsx` under parallel load. After, `yarn jest src --runInBand`, 27 suites and 216 tests passing. `yarn typescript` and `yarn lint` are clean.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
