### PR TITLE
fix: `KeyboardChatScrollView` + new reanimated compatibility

### DIFF
--- a/src/components/KeyboardChatScrollView/index.tsx
+++ b/src/components/KeyboardChatScrollView/index.tsx
@@ -68,6 +68,7 @@ const KeyboardChatScrollView: React.ForwardRefExoticComponent<
       offset,
       blankSpace,
       extraContentPadding,
+      initialContentOffsetY: rest.contentOffset?.y,
     });
 
     useExtraContentPadding({

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/index.ios.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/index.ios.ts
@@ -47,7 +47,7 @@ function useChatKeyboard(
 
   const padding = useSharedValue(0);
   const currentHeight = useSharedValue(0);
-  const contentOffsetY = useSharedValue(0);
+  const contentOffsetY = useSharedValue(options.initialContentOffsetY ?? 0);
   const targetKeyboardHeight = useSharedValue(0);
   const prevAbsorption = useSharedValue(0);
   const isInteractiveDismissal = useSharedValue(false);
@@ -58,7 +58,7 @@ function useChatKeyboard(
     offset: scroll,
     onLayout,
     onContentSizeChange,
-  } = useScrollState(scrollViewRef);
+  } = useScrollState(scrollViewRef, options.initialContentOffsetY);
 
   useKeyboardHandler(
     {

--- a/src/components/KeyboardChatScrollView/useChatKeyboard/types.ts
+++ b/src/components/KeyboardChatScrollView/useChatKeyboard/types.ts
@@ -8,6 +8,8 @@ type UseChatKeyboardOptions = {
   keyboardLiftBehavior: KeyboardLiftBehavior;
   freeze: SharedValue<boolean>;
   offset: number;
+  /** Initial JS scroll position, before the native scroll handler is attached. */
+  initialContentOffsetY?: number;
   blankSpace: SharedValue<number>;
   /** Extra content padding shared value — needed on iOS to correctly clamp contentOffset. */
   extraContentPadding: SharedValue<number>;

--- a/src/components/ScrollViewWithBottomPadding/index.tsx
+++ b/src/components/ScrollViewWithBottomPadding/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useEffect } from "react";
 import { Platform } from "react-native";
 import Reanimated, {
   runOnJS,
@@ -74,7 +74,17 @@ const ScrollViewWithBottomPadding = forwardRef<
     },
     ref,
   ) => {
+    const { contentOffset } = rest;
     const prevContentOffsetY = useSharedValue<number | null>(null);
+
+    // Reanimated owns this prop, so subsequent JS requests use the same value.
+    // Depend on y: a new object with the same vertical position is not a request.
+    useEffect(() => {
+      if (contentOffsetY) {
+        // eslint-disable-next-line react-compiler/react-compiler
+        contentOffsetY.value = contentOffset?.y ?? 0;
+      }
+    }, [contentOffsetY, contentOffset?.y]);
 
     const insets = useDerivedValue(() => {
       const dynamicTop = inverted ? bottomPadding.value : 0;
@@ -146,18 +156,13 @@ const ScrollViewWithBottomPadding = forwardRef<
       };
 
       if (contentOffsetY) {
-        const curr = contentOffsetY.value;
+        const y = contentOffsetY.value;
 
-        if (prevContentOffsetY.value === null) {
-          // Swallow the initial evaluation: emitting `contentOffset {x:0,y:0}`
-          // in the first animatedProps run overrides the wrapped ScrollView's
-          // own `contentOffset` prop on Fabric (e.g. a list's initial scroll
-          // offset), making the list mount scrolled to the top natively.
-          // eslint-disable-next-line react-compiler/react-compiler
-          prevContentOffsetY.value = curr;
-        } else if (curr !== prevContentOffsetY.value) {
-          prevContentOffsetY.value = curr;
-          result.contentOffset = { x: 0, y: curr };
+        // Emit the initialized offset once, then only when the target changes.
+        // Inset-only updates must not replay the previous scroll command.
+        if (y !== prevContentOffsetY.value) {
+          prevContentOffsetY.value = y;
+          result.contentOffset = { x: contentOffset?.x ?? 0, y };
         }
       }
 
@@ -169,6 +174,7 @@ const ScrollViewWithBottomPadding = forwardRef<
       scrollIndicatorInsets?.left,
       inverted,
       contentOffsetY,
+      contentOffset?.x,
     ]);
 
     return (

--- a/src/components/ScrollViewWithBottomPadding/index.tsx
+++ b/src/components/ScrollViewWithBottomPadding/index.tsx
@@ -77,8 +77,6 @@ const ScrollViewWithBottomPadding = forwardRef<
     const { contentOffset } = rest;
     const prevContentOffsetY = useSharedValue<number | null>(null);
 
-    // Reanimated owns this prop, so subsequent JS requests use the same value.
-    // Depend on y: a new object with the same vertical position is not a request.
     useEffect(() => {
       if (contentOffsetY) {
         // eslint-disable-next-line react-compiler/react-compiler

--- a/src/components/hooks/useScrollState.ts
+++ b/src/components/hooks/useScrollState.ts
@@ -30,8 +30,11 @@ type ScrollEvent = {
   };
 };
 
-const useScrollState = (ref: AnimatedRef<Reanimated.ScrollView>) => {
-  const offset = useSharedValue(0);
+const useScrollState = (
+  ref: AnimatedRef<Reanimated.ScrollView>,
+  initialOffset = 0,
+) => {
+  const offset = useSharedValue(initialOffset);
   const layout = useSharedValue({ width: 0, height: 0 });
   const size = useSharedValue({ width: 0, height: 0 });
 


### PR DESCRIPTION
## 📜 Description

Fix iOS `KeyboardChatScrollView` scroll jumps with Reanimated 4.6 while preserving initial and subsequent JS `contentOffset.y` values.

Initialize the existing offset shared value and scroll state from `contentOffset.y`, include the initialized `contentOffset` in the first `useAnimatedProps` evaluation, and synchronize later JS changes into the same shared value with `useEffect`.

The `prevContentOffsetY` guard remains: inset-only updates must not replay a previous scroll command.

## 💡 Motivation and Context

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1623 https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1609

[#1496](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1496) fixed an initial-position regression by skipping the first animated `contentOffset` evaluation. Before that fix, our shared value started at `0`, so the first animated props overwrote a JS offset such as `{ x: 0, y: 500 }` with `{ x: 0, y: 0 }`.

The upstream history explains why this became a problem now. [Reanimated #8529](https://github.com/software-mansion/react-native-reanimated/pull/8529) introduced synchronization of settled animation values back to React. Before [Reanimated #10140](https://github.com/software-mansion/react-native-reanimated/pull/10140), that synchronization spread the entire settled bag into both props and style, so a late `contentOffset` still reached the native component as a prop. [Reanimated #10140](https://github.com/software-mansion/react-native-reanimated/pull/10140) correctly separated the two to prevent animated styles from leaking into unrelated component props. It exposed our dependency on that previous behavior.

Skipping that prop now causes a problem with Reanimated 4.6's settled-animation synchronization. Reanimated identifies animated **props** by the keys present in their initial evaluation. A `contentOffset` introduced only during keyboard movement is absent from those keys, so it is synchronized as a **style** instead of a top-level prop. Once Reanimated releases the settled entry from its props registry, a subsequent React commit can reset the native offset. Typing into a controlled input exposes this as the list dropping behind the keyboard (#1623).

The replacement addresses both cases:

- **Mount:** JS `y = 500` seeds both the animated target and the tracked scroll position. The first animated props contain `contentOffset: { x: 0, y: 500 }`, so they preserve the requested position and identify the prop to Reanimated.
- **Later JS update:** changing the prop to `y = 700` updates the existing shared value through `useEffect`; the animated props then apply `700`.
- **Keyboard movement and later React commits:** Reanimated synchronizes the settled offset as a prop, preserving the keyboard-adjusted position.

## 📢 Changelog

### JS

- Initialize `KeyboardChatScrollView`'s animated offset and scroll state from the supplied `contentOffset.y`.
- Synchronize subsequent JS `contentOffset.y` updates with the animated offset.

### iOS

- Fix the list jumping behind the keyboard after React commits with Reanimated 4.6.
- Preserve nonzero initial scroll offsets without skipping the initial animated prop.

## 🤔 How Has This Been Tested?

Recordings use `FabricExample`, a dedicated iPhone 17 simulator running **iOS 26.2**, and **Metro 8084**. Native build/dependencies come from `feat/rn-0.87` (React Native 0.87.1, React 19.2.3, Reanimated 4.6.0, Worklets 0.12.1). After the two baseline recordings, the checkout is switched to `feat/kcsv-new-rea-compatibility` for the fixed recordings, retaining the same native build and installed dependencies.

The native app was built successfully with Xcode. The same demo source and Metro configuration were retained for all recordings; the library changes are the five files in this PR (`869a0c4`). No changes to Reanimated were introduced for the comparison.

Runtime flags: `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS=true`, `USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS=true`, and `DISABLE_COMMIT_PAUSING_MECHANISM=false`. The reproduction branch already includes a native patch making `pauseReanimatedCommits()` a no-op; that patch stayed identical in every recording. These are results for that reproduction environment.

Temporary logging captured native `onScroll` events and Reanimated's initial animated props, settled state, and outgoing React props. The loggers only recorded values; they did not update React state or scroll the list.

| Case | Before | With this PR |
| --- | --- | --- |
| #1496: mount with JS `y=500` | With the original #1496 skip removed, initial animated props contain `y=0`; the video starts at row 1 instead of row 9. | Initial animated props contain `y=500`; row 9 is visible immediately. |
| Later JS offset update | — | Changing JS `y` to `700` produces a native scroll event at `700` and `settledProps.contentOffset.y=700`. |
| #1623: open keyboard, wait for settling, then type `Test` | With the original #1496 fix present, native `y` changes from `-317` to `0` on typing. `contentInset.top` stays `318`; the latest messages fall behind the keyboard. | The last native offset stays `-317`, with no reset event; the latest messages remain above the keyboard during typing. |
| Settled classification in #1623 | `contentOffset` is absent from the initial keys and ends up in `settledStyle`. | The initial keys include `contentOffset`; `settledProps` and outgoing React props retain `{ x: 0, y: -317 }`. |

### Code used for #1496

A focused temporary `FabricExample/src/PR1629OffsetExample.tsx` screen was used. The first button mounts the list with `y = 500`; the second changes the JS prop to `700`. Each row is 60 points high, making the starting position visible in the recording. The full screen is included below so the initial-offset and later-update checks can be repeated.

<details>
<summary>PR1629OffsetExample.tsx</summary>

```tsx
import React, { useState } from "react";
import { Button, StatusBar, StyleSheet, Text, View } from "react-native";
import {
  KeyboardChatScrollView,
  KeyboardProvider,
} from "react-native-keyboard-controller";
import {
  SafeAreaProvider,
  SafeAreaView,
  initialWindowMetrics,
} from "react-native-safe-area-context";

function OffsetExample() {
  const [mounted, setMounted] = useState(false);
  const [y, setY] = useState(500);

  return (
    <SafeAreaView style={styles.screen}>
      <Text style={styles.title}>Initial contentOffset · #1496</Text>
      <Text style={styles.label}>JS contentOffset: {`{ x: 0, y: ${y} }`}</Text>
      <View style={styles.buttons}>
        <Button title="Mount at 500" onPress={() => setMounted(true)} />
        <Button title="JS offset → 700" onPress={() => setY(700)} />
      </View>
      {mounted ? (
        <KeyboardChatScrollView
          automaticallyAdjustContentInsets={false}
          contentInsetAdjustmentBehavior="never"
          contentOffset={{ x: 0, y }}
          testID="offset.scroll"
          onScroll={(event) => {
            console.log("[PR1629 offset]", event.nativeEvent.contentOffset.y);
          }}
        >
          {Array.from({ length: 40 }, (_, index) => (
            <View key={index} style={styles.row}>
              <Text style={styles.rowText}>
                Row {index + 1} · y = {index * 60}
              </Text>
            </View>
          ))}
        </KeyboardChatScrollView>
      ) : (
        <View style={styles.empty}>
          <Text style={styles.hint}>Mount with y = 500.</Text>
          <Text style={styles.hint}>Row 9 should be at the top.</Text>
        </View>
      )}
    </SafeAreaView>
  );
}

export default function App() {
  return (
    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
      <KeyboardProvider>
        <StatusBar barStyle="dark-content" />
        <OffsetExample />
      </KeyboardProvider>
    </SafeAreaProvider>
  );
}

const styles = StyleSheet.create({
  screen: { flex: 1, backgroundColor: "white" },
  title: { fontSize: 21, fontWeight: "600", padding: 16 },
  label: { fontSize: 16, paddingHorizontal: 16, paddingBottom: 12 },
  buttons: {
    flexDirection: "row",
    justifyContent: "space-around",
    paddingBottom: 12,
  },
  empty: { flex: 1, alignItems: "center", justifyContent: "center" },
  hint: { fontSize: 18, color: "#526173", marginBottom: 8 },
  row: {
    height: 60,
    backgroundColor: "#e8eff8",
    borderBottomWidth: 2,
    borderBottomColor: "white",
    justifyContent: "center",
    paddingHorizontal: 20,
  },
  rowText: { fontSize: 18, color: "#172c49" },
});
```

</details>

### Code used for #1623

Used the existing **Chat Kit / `KeyboardChatScrollViewPlayground`** example:

- `FabricExample/src/screens/Examples/KeyboardChatScrollView/index.tsx`
- `FabricExample/src/screens/Examples/KeyboardChatScrollView/VirtualizedListScrollView.tsx`
- Existing `data.ts`, `store.ts`, and `config.tsx` in that directory.

Open Chat Kit in its default mode first. After it mounts, select **Use Flat List**, enable **Toggle inverted**, and leave `keyboardLiftBehavior="always"`. For the recordings these same existing store setters were called through the debugger after mounting:

```ts
const config = useChatConfigStore.getState();
config.setMode("flat");
config.setInverted(true);
```

The example already uses a controlled `TextInput` (`value={text}`, `onChangeText={onInput}` → `setText(value)`) and a `FlatList` whose `renderScrollComponent` renders `KeyboardChatScrollView`. The latter receives `inverted`, `contentInsetAdjustmentBehavior="never"`, and `offset={bottom - MARGIN}`. On this simulator the configured offset is `34 - 16 = 18`. The recorded keyboard-adjusted position is `y=-317`, and the inverted list's effective top inset is `318`.

Focus the input, wait for the animation and settled synchronization, then type `Test`. Both chat videos begin with the keyboard already open and settled so the change caused by typing is easy to compare. Only an `onScroll` logger was added to the existing scroll wrapper, forwarding the event to the original callback.

## 📸 Screenshots (if appropriate):

### Before

<table>
<tr>
<th width="50%">#1496 — original fix removed</th>
<th width="50%">#1623 — original #1496 fix present</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/85af1a46-5090-4f7d-863e-caee676c8b5e

</td>
<td>

https://github.com/user-attachments/assets/2f913af0-3c9c-40d2-974c-f75d71e140a4

</td>
</tr>
<tr>
<td>JS requests <code>y=500</code>, but the first animated props overwrite it with <code>0</code>: row 1 appears.</td>
<td>After the keyboard settles, typing <code>Test</code> resets <code>y=-317</code> to <code>0</code>. The latest messages drop behind the keyboard while the inset stays <code>318</code>.</td>
</tr>
</table>

### After

<table>
<tr>
<th width="50%">#1496 — initial offset and later JS changes</th>
<th width="50%">#1623 — position survives React commits</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/ffc3d2f7-9e7e-4e2d-a2fe-48275e00c482

</td>
<td>

https://github.com/user-attachments/assets/5564be4d-635c-4114-b0db-4144f667178e

</td>
</tr>
<tr>
<td>Mounting preserves <code>y=500</code> (row 9). Updating the JS prop to <code>700</code> scrolls to the requested position.</td>
<td>The same input sequence keeps the latest messages above the keyboard, with the offset remaining <code>-317</code>.</td>
</tr>
</table>

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
