### PR TITLE
fix: shadow node sync on iOS

### DIFF
--- a/ios/KeyboardControllerModule-Header.h
+++ b/ios/KeyboardControllerModule-Header.h
@@ -11,4 +11,5 @@
 @interface KeyboardController : RCTEventEmitter
 + (KeyboardController *)shared;
 - (void)sendEvent:(NSString *)name body:(id)body;
+- (void)keepShadowNodesInSync:(NSNumber *)reactTag;
 @end

--- a/ios/KeyboardControllerModule.mm
+++ b/ios/KeyboardControllerModule.mm
@@ -178,7 +178,7 @@ RCT_EXPORT_METHOD(viewPositionInWindow
 
 - (void)keepShadowNodesInSync:(NSNumber *)reactTag
 {
-  [self sendEvent:@"onUserDrivenAnimationEnded" body:@{ @"tags" : @[ reactTag ] }];
+  [self sendEvent:@"onUserDrivenAnimationEnded" body:@{@"tags" : @[ reactTag ]}];
 }
 
 - (NSArray<NSString *> *)supportedEvents

--- a/ios/KeyboardControllerModule.mm
+++ b/ios/KeyboardControllerModule.mm
@@ -176,6 +176,11 @@ RCT_EXPORT_METHOD(viewPositionInWindow
   }
 }
 
+- (void)keepShadowNodesInSync:(NSNumber *)reactTag
+{
+  [self sendEvent:@"onUserDrivenAnimationEnded" body:@{ @"tags" : @[ reactTag ] }];
+}
+
 - (NSArray<NSString *> *)supportedEvents
 {
   return @[
@@ -189,6 +194,8 @@ RCT_EXPORT_METHOD(viewPositionInWindow
     @"KeyboardController::layoutDidSynchronize",
     // window dimensions
     @"KeyboardController::windowDidResize",
+    // native Animated/Fabric shadow tree synchronization
+    @"onUserDrivenAnimationEnded",
   ];
 }
 

--- a/ios/views/KeyboardControllerView.mm
+++ b/ios/views/KeyboardControllerView.mm
@@ -188,6 +188,7 @@ using namespace facebook::react;
                           .progress = [progress doubleValue],
                           .duration = [duration intValue],
                           .target = [target intValue]});
+              [KeyboardController.shared keepShadowNodesInSync:@(self.tag)];
             }
             if ([event isEqualToString:@"onKeyboardMoveInteractive"]) {
               std::dynamic_pointer_cast<const facebook::react::KeyboardControllerViewEventEmitter>(


### PR DESCRIPTION
## 📜 Description

Synchronizes React Native's native `Animated` nodes with the Fabric shadow tree when an iOS keyboard animation ends.

The keyboard animation updates the view on the native side without causing a React render. Once the animation finishes, iOS now emits `onUserDrivenAnimationEnded` with the affected view tag. React Native's `Animated` integration responds by updating the animated props node and committing the final state back to Fabric. This mirrors the synchronization already performed on Android.

## 💡 Motivation and Context

This is iOS version of Android only PR https://github.com/kirillzyusko/react-native-keyboard-controller/pull/950

With Fabric, `useKeyboardAnimation()` and an `Animated.View` can move a pressable view visually while its shadow node retains the pre-animation position. The problem is deterministic when the component has no React re-renders: a direct tap may work, but pressing the visually translated control, moving the finger about 10 points horizontally, and releasing cancels `onPress` because hit testing uses stale layout information.

Minimal reproduction (with `KeyboardProvider` mounted at the application root):

```tsx
import React from "react";
import {
  Alert,
  Animated,
  TextInput,
  TouchableOpacity,
  View,
} from "react-native";
import { useKeyboardAnimation } from "react-native-keyboard-controller";

export function Reproduction() {
  const { height } = useKeyboardAnimation();

  return (
    <>
      <TextInput autoFocus placeholder="Focus me" />
      <Animated.View
        style={{
          transform: [{ translateY: Animated.add(height, 400) }],
        }}
      >
        <TouchableOpacity onPress={() => Alert.alert("10 dollars")}>
          <View
            style={{
              width: 20,
              height: 20,
              marginLeft: 40,
              backgroundColor: "red",
            }}
          />
        </TouchableOpacity>
      </Animated.View>
    </>
  );
}
```

The `400`-point offset places the red target in the visible area after the software keyboard opens while its final position is still driven entirely by the core React Native `Animated` node.

To reproduce on an iOS simulator using Fabric:

1. Focus the input and make sure the software keyboard is visible (`Cmd+K` if necessary).
2. Press and hold the red view, move the finger approximately 10 points left or right, then release.
3. Before this change, the alert is not shown. After this change, `onPress` runs and the alert appears.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1633 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1320 https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1199

## 📢 Changelog

### iOS

- Synchronize native `Animated` props with Fabric after keyboard animations finish.
- Restore hit testing for controls moved by `useKeyboardAnimation()` when no React re-render occurs.

## 🤔 How Has This Been Tested?

Tested on iPhone X (iOS 16.4)

## 📸 Screenshots (if appropriate):

Both columns show the same press-and-hold on the visible red target, 10-point horizontal move, and release gesture. The videos include Argent's touch indicator.

| | Before | After |
| --- | --- | --- |
| Behavior | `onPress` is cancelled; the keyboard remains visible and no alert appears. | `onPress` runs and the alert appears. |
| Screenshot | ![Before: the keyboard remains visible and no alert appears after the gesture](https://github.com/user-attachments/assets/7612351a-fa46-47a8-911a-6d0125458c75) | ![After: the alert appears after the same gesture](https://github.com/user-attachments/assets/3aab9d72-f3a2-4a42-9b12-28274553f28f) |
| Video | <video src="https://github.com/user-attachments/assets/531bbb1b-c8b7-4f56-8784-88a7b98a6f58"> | <video src="https://github.com/user-attachments/assets/e8d646c3-7291-4e30-b2aa-1933b1add7ee"> |

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
