### PR TITLE
fix: inverted `KeyboardChatScrollView` can not be scrolled at the beginning

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/views/ClippingScrollViewDecoratorView.kt
@@ -37,11 +37,22 @@ class ClippingScrollViewDecoratorView(
       paddingScrollWorkaroundActive = shouldUsePaddingScrollWorkaround(scrollView, event)
     }
 
+    // ScrollView.inChild() ignores its direct child's translationY when it
+    // initializes a gesture. contentInsetTop is represented by translating
+    // that child, so the translated portion is visible but cannot start a
+    // scroll (the gap appears at the top once the ScrollView is inverted).
+    // Include the translated visual range only while dispatching ACTION_DOWN;
+    // subsequent events use the real bounds after ScrollView has initialized
+    // the gesture.
+    val translatedContentNeedsExpandedHitRange =
+      event.actionMasked == MotionEvent.ACTION_DOWN && appliedTopInsetPx > 0
+
     val handled =
-      if (paddingScrollWorkaroundActive) {
-        dispatchWithExpandedContentRange(scrollView, event)
-      } else {
-        super.dispatchTouchEvent(event)
+      when {
+        paddingScrollWorkaroundActive -> dispatchWithExpandedContentRange(scrollView, event)
+        translatedContentNeedsExpandedHitRange ->
+          dispatchWithTranslatedContentRange(scrollView, event)
+        else -> super.dispatchTouchEvent(event)
       }
 
     if (
@@ -123,6 +134,27 @@ class ClippingScrollViewDecoratorView(
     val originalBottom = contentView?.bottom ?: 0
     val expandedBottom =
       max(originalBottom, scrollView.height + scrollView.scrollY + MIN_SCROLL_RANGE_PX)
+
+    return dispatchWithTemporaryContentBottom(contentView, event, expandedBottom)
+  }
+
+  private fun dispatchWithTranslatedContentRange(
+    scrollView: ViewGroup,
+    event: MotionEvent,
+  ): Boolean {
+    val contentView = scrollView.getChildAt(0)
+    val originalBottom = contentView?.bottom ?: 0
+    val translatedBottom = originalBottom + appliedTopInsetPx + MIN_SCROLL_RANGE_PX
+
+    return dispatchWithTemporaryContentBottom(contentView, event, translatedBottom)
+  }
+
+  private fun dispatchWithTemporaryContentBottom(
+    contentView: View?,
+    event: MotionEvent,
+    expandedBottom: Int,
+  ): Boolean {
+    val originalBottom = contentView?.bottom ?: 0
 
     if (contentView == null || expandedBottom == originalBottom) {
       return super.dispatchTouchEvent(event)


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1553

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

-
-

### iOS

-
-

### Android

-
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
