### PR TITLE
fix: omit deps array for reanimated hooks on native platforms

### DIFF
--- a/src/components/KeyboardAvoidingView/index.tsx
+++ b/src/components/KeyboardAvoidingView/index.tsx
@@ -3,13 +3,12 @@ import { View } from "react-native";
 import Reanimated, {
   interpolate,
   runOnUI,
-  useAnimatedStyle,
-  useDerivedValue,
   useSharedValue,
 } from "react-native-reanimated";
 
 import { KeyboardControllerNative } from "../../bindings";
 import { useWindowDimensions } from "../../hooks";
+import { useAnimatedStyle, useDerivedValue } from "../../reanimated";
 import { findNodeHandle } from "../../utils/findNodeHandle";
 import useCombinedRef from "../hooks/useCombinedRef";
 

--- a/src/components/KeyboardAwareScrollView/index.tsx
+++ b/src/components/KeyboardAwareScrollView/index.tsx
@@ -10,10 +10,7 @@ import Reanimated, {
   interpolate,
   runOnUI,
   scrollTo,
-  useAnimatedReaction,
   useAnimatedRef,
-  useAnimatedStyle,
-  useDerivedValue,
   useSharedValue,
 } from "react-native-reanimated";
 
@@ -23,6 +20,11 @@ import {
   useReanimatedFocusedInput,
   useWindowDimensions,
 } from "../../hooks";
+import {
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useDerivedValue,
+} from "../../reanimated";
 import { findNodeHandle } from "../../utils/findNodeHandle";
 import useCombinedRef from "../hooks/useCombinedRef";
 import useScrollState from "../hooks/useScrollState";

--- a/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
+++ b/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Platform } from "react-native";
 import { Easing, useSharedValue, withTiming } from "react-native-reanimated";
 
@@ -26,7 +27,7 @@ const TELEGRAM_ANDROID_TIMING_CONFIG = {
  * Hook that uses default transitions for iOS and Android > 11, and uses
  * custom interpolation on Android < 11 to achieve more smooth animation.
  *
- * @param handler - Object containing keyboard event handlers.
+ * @param unstableHandler - Object containing keyboard event handlers.
  * @param [deps] - Dependencies array for the effect.
  * @example
  * ```ts
@@ -43,9 +44,11 @@ const TELEGRAM_ANDROID_TIMING_CONFIG = {
  * ```
  */
 export const useSmoothKeyboardHandler: typeof useKeyboardHandler = (
-  handler,
+  unstableHandler,
   deps,
 ) => {
+  // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
+  const handler = useMemo(() => unstableHandler, deps ?? []);
   const target = useSharedValue(-1);
   const height = useSharedValue(0);
   const persistedHeight = useSharedValue(0);
@@ -78,7 +81,6 @@ export const useSmoothKeyboardHandler: typeof useKeyboardHandler = (
       // dispatch `onEnd`
       if (evt.height === height.value) {
         handler.onEnd?.(evt);
-        // eslint-disable-next-line react-compiler/react-compiler
         persistedHeight.value = height.value;
       }
     },

--- a/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
+++ b/src/components/KeyboardAwareScrollView/useSmoothKeyboardHandler.ts
@@ -1,12 +1,8 @@
 import { Platform } from "react-native";
-import {
-  Easing,
-  useAnimatedReaction,
-  useSharedValue,
-  withTiming,
-} from "react-native-reanimated";
+import { Easing, useSharedValue, withTiming } from "react-native-reanimated";
 
 import { useKeyboardHandler } from "../../hooks";
+import { useAnimatedReaction } from "../../reanimated";
 
 const IS_ANDROID_ELEVEN_OR_HIGHER =
   Platform.OS === "android" && Platform.Version >= 30;

--- a/src/components/KeyboardChatScrollView/index.tsx
+++ b/src/components/KeyboardChatScrollView/index.tsx
@@ -1,13 +1,9 @@
 import React, { forwardRef, useCallback, useMemo } from "react";
 import { StyleSheet } from "react-native";
-import {
-  makeMutable,
-  useAnimatedRef,
-  useAnimatedStyle,
-  useDerivedValue,
-} from "react-native-reanimated";
+import { makeMutable, useAnimatedRef } from "react-native-reanimated";
 import Reanimated from "react-native-reanimated";
 
+import { useAnimatedStyle, useDerivedValue } from "../../reanimated";
 import useCombinedRef from "../hooks/useCombinedRef";
 import ScrollViewWithBottomPadding from "../ScrollViewWithBottomPadding";
 

--- a/src/components/KeyboardChatScrollView/useEndVisible.ts
+++ b/src/components/KeyboardChatScrollView/useEndVisible.ts
@@ -1,9 +1,7 @@
 import { useMemo } from "react";
-import {
-  runOnJS,
-  useAnimatedReaction,
-  useDerivedValue,
-} from "react-native-reanimated";
+import { runOnJS } from "react-native-reanimated";
+
+import { useAnimatedReaction, useDerivedValue } from "../../reanimated";
 
 import { isScrollAtEnd } from "./useChatKeyboard/helpers";
 

--- a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
+++ b/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
@@ -1,8 +1,9 @@
 import { useCallback } from "react";
 import { Platform } from "react-native";
-import { scrollTo, useAnimatedReaction } from "react-native-reanimated";
+import { scrollTo } from "react-native-reanimated";
 
 import { IS_FABRIC } from "../../../architecture";
+import { useAnimatedReaction } from "../../../reanimated";
 import { isScrollAtEnd, shouldShiftContent } from "../useChatKeyboard/helpers";
 
 import type { KeyboardLiftBehavior } from "../useChatKeyboard/types";

--- a/src/components/KeyboardChatScrollView/useFrozenPadding/index.ts
+++ b/src/components/KeyboardChatScrollView/useFrozenPadding/index.ts
@@ -1,6 +1,7 @@
-import { useAnimatedReaction, useSharedValue } from "react-native-reanimated";
+import { useSharedValue } from "react-native-reanimated";
 
 import { useKeyboardHandler } from "../../../hooks";
+import { useAnimatedReaction } from "../../../reanimated";
 import { getEffectiveHeight } from "../useChatKeyboard/helpers";
 
 import type { SharedValue } from "react-native-reanimated";

--- a/src/components/KeyboardStickyView/index.tsx
+++ b/src/components/KeyboardStickyView/index.tsx
@@ -1,10 +1,8 @@
 import React, { forwardRef, useMemo } from "react";
-import Reanimated, {
-  interpolate,
-  useAnimatedStyle,
-} from "react-native-reanimated";
+import Reanimated, { interpolate } from "react-native-reanimated";
 
 import { useReanimatedKeyboardAnimation } from "../../hooks";
+import { useAnimatedStyle } from "../../reanimated";
 
 import type { View, ViewProps } from "react-native";
 

--- a/src/components/ScrollViewWithBottomPadding/index.tsx
+++ b/src/components/ScrollViewWithBottomPadding/index.tsx
@@ -1,14 +1,13 @@
 import React, { forwardRef, useEffect } from "react";
 import { Platform } from "react-native";
-import Reanimated, {
-  runOnJS,
+import Reanimated, { runOnJS, useSharedValue } from "react-native-reanimated";
+
+import { ClippingScrollView } from "../../bindings";
+import {
   useAnimatedProps,
   useAnimatedReaction,
   useDerivedValue,
-  useSharedValue,
-} from "react-native-reanimated";
-
-import { ClippingScrollView } from "../../bindings";
+} from "../../reanimated";
 
 import styles from "./styles";
 

--- a/src/reanimated.native.ts
+++ b/src/reanimated.native.ts
@@ -1,5 +1,9 @@
 import {
   useEvent,
+  useAnimatedProps as useReanimatedAnimatedProps,
+  useAnimatedReaction as useReanimatedAnimatedReaction,
+  useAnimatedStyle as useReanimatedAnimatedStyle,
+  useDerivedValue as useReanimatedDerivedValue,
   useHandler as useReanimatedHandler,
 } from "react-native-reanimated";
 
@@ -14,6 +18,20 @@ import type {
 type EventContext = Record<string, unknown>;
 
 // Dependencies are only needed on Web when the Babel plugin is unavailable.
+export const useAnimatedProps: typeof useReanimatedAnimatedProps = (
+  updater,
+  _dependencies,
+  adapters,
+  isAnimatedProps,
+) => useReanimatedAnimatedProps(updater, undefined, adapters, isAnimatedProps);
+export const useAnimatedReaction: typeof useReanimatedAnimatedReaction = (
+  prepare,
+  react,
+) => useReanimatedAnimatedReaction(prepare, react);
+export const useAnimatedStyle: typeof useReanimatedAnimatedStyle = (updater) =>
+  useReanimatedAnimatedStyle(updater);
+export const useDerivedValue: typeof useReanimatedDerivedValue = (updater) =>
+  useReanimatedDerivedValue(updater);
 export const useHandler: typeof useReanimatedHandler = (handlers) =>
   useReanimatedHandler(handlers);
 

--- a/src/reanimated.ts
+++ b/src/reanimated.ts
@@ -6,7 +6,13 @@ import type {
   NativeEvent,
 } from "./types";
 
-export { useHandler } from "react-native-reanimated";
+export {
+  useAnimatedProps,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useDerivedValue,
+  useHandler,
+} from "react-native-reanimated";
 
 const NOOP = () => () => {};
 


### PR DESCRIPTION
## 📜 Description

Fixed warning that deps array should only be used on web.

## 💡 Motivation and Context

Dependencies are not needed if you are using babel plugin. But deps are needed on web if you don't use babel plugin. In this PR I extend the approach added in https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1611

In future we are going to support web platform as well (we are just waiting for WebKit to support modern standards which hopefully happens this year https://github.com/WebKit/WebKit/pull/69393) so in this PR I added custom versions of all reanimated hooks that are not passing deps array to the hooks. It fixes warnings.

In future I may revisit the approach and don't require deps array in keyboard-controller hooks and remove all deps array from existing reanimated hooks.

From technical implementation - we found one regression. `useSmoothKeyboardHandler` still requires handler to be memoized. Otherwise each re-render creates a new object and `useAnimatedReaction` will be re-running every time when re-render happens. But `re-render !== keyboard move event` so we need to memoize the handler to return the old behavior.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1630

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- export own reanimated hooks versions such as `useDerivedValue`/`useAnimatedStyle`/`useAnimatedReaction` that are skipping deps array on native side;
- use own hooks version instead of reanimated;
- memoize handler in `useSmoothKeyboardHandler` because otherwise it re-runs animated reaction even when keyboard is not moving;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 17 Pro (iOS 26.2).

## 📸 Screenshots (if appropriate):

|Before|After|
|------|------|
|<video src="https://github.com/user-attachments/assets/67bf270f-0b23-418f-ab90-d94291667436">|<video src="https://github.com/user-attachments/assets/780bb7a9-ba6d-4601-b0d0-552572753f6d">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
