### PR TITLE
fix: support `NestedScrollView` in `KeyboardAwareScrollView`

### DIFF
--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/EditText.kt
@@ -8,7 +8,6 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewTreeObserver.OnPreDrawListener
 import android.widget.EditText
-import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.textinput.ReactEditText
 import com.reactnativekeyboardcontroller.log.Logger
 import java.lang.reflect.Field
@@ -105,7 +104,7 @@ val EditText.parentScrollViewTarget: Int
     while (currentView != null) {
       val parentView = currentView.parent as? View
 
-      if (parentView is ReactScrollView && parentView.scrollEnabled) {
+      if (parentView != null && parentView.isEnabledReactScrollView()) {
         // If the parent is a vertical, scrollable ScrollView - return its id
         return parentView.id
       }

--- a/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ScrollView.kt
+++ b/android/src/main/java/com/reactnativekeyboardcontroller/extensions/ScrollView.kt
@@ -1,0 +1,65 @@
+package com.reactnativekeyboardcontroller.extensions
+
+import android.view.View
+import com.facebook.react.views.scroll.ReactScrollView
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+internal fun View.isEnabledReactScrollView(): Boolean =
+  when {
+    this is ReactScrollView -> scrollEnabled
+    ReactNestedScrollViewCompat.isInstance(this) ->
+      ReactNestedScrollViewCompat.isScrollEnabled(this)
+    else -> false
+  }
+
+private object ReactNestedScrollViewCompat {
+  private const val CLASS_NAME =
+    "com.facebook.react.views.scroll.ReactNestedScrollView"
+
+  private val clazz: Class<*>? by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    runCatching {
+      Class.forName(
+        CLASS_NAME,
+        false,
+        ReactScrollView::class.java.classLoader,
+      )
+    }.getOrNull()
+  }
+
+  private val scrollEnabledGetter: Method? by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    val c = clazz ?: return@lazy null
+
+    runCatching {
+      c.getMethod("getScrollEnabled")
+    }.getOrNull()
+      ?: runCatching {
+        c.getMethod("isScrollEnabled")
+      }.getOrNull()
+  }
+
+  private val scrollEnabledField: Field? by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    val c = clazz ?: return@lazy null
+
+    runCatching {
+      c.getDeclaredField("mScrollEnabled").apply {
+        isAccessible = true
+      }
+    }.getOrNull()
+  }
+
+  fun isInstance(view: View): Boolean = clazz?.isInstance(view) == true
+
+  fun isScrollEnabled(view: View): Boolean =
+    scrollEnabledGetter?.let { getter ->
+      runCatching {
+        getter.invoke(view) as Boolean
+      }.getOrNull()
+    }
+      ?: scrollEnabledField?.let { field ->
+        runCatching {
+          field.getBoolean(view)
+        }.getOrNull()
+      }
+      ?: false
+}


### PR DESCRIPTION
## 📜 Description

Added support for `NestedScrollView` for `KeyboardAwareScrollView`.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When users enable `useNestedScrollViewAndroid` feature flag, then `ReactNestedScrollView` is used:

```kt
      if (ReactNativeFeatureFlags.useNestedScrollViewAndroid()) ReactNestedScrollViewManager()
      else ReactScrollViewManager(),
```

As a result our condition returns `false` (casting of `parentView` to `ReactScrollView` is failing):

```kt
if (parentView is ReactScrollView && parentView.scrollEnabled) {
```

So we never recognize the `ReactNestedScrollView` as a `ScrollView` and because of that condition is evaluated as `true`:

```ts
        // input belongs to ScrollView
        if (layout.value?.parentScrollViewTarget !== scrollViewTarget.value) {
          return 0;
        }
```

So scrolling never works.

In this PR I created small extension called `View.isEnabledReactScrollView()` that checks both cases: `ReactScrollView` and `ReactNestedScrollView`.

This implementation had technical difficulties, because `ReactNestedScrollView` is not available in earlier RN versions (was introduced only in RN 0.85+) so I had to use reflection, because we can not use direct class references as it may be not available in all framework versions.

Closes https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1537

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added `View.isEnabledReactScrollView()` extension that checks both `ReactScrollView`/`ReactNestedScrollView` cases;
- use `isEnabledReactScrollView()` condition instead of previous check;

## 🤔 How Has This Been Tested?

Tested via CI (e2e tests).

## 📸 Screenshots (if appropriate):

<img width="796" height="302" alt="image" src="https://github.com/user-attachments/assets/604c9f6d-a268-4331-aaaf-081689df153f" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
